### PR TITLE
RALPH: Add move standalone video to course page (issue #614)

### DIFF
--- a/app/components/app-sidebar.tsx
+++ b/app/components/app-sidebar.tsx
@@ -20,6 +20,7 @@ import type { Plan } from "@/features/course-planner/types";
 import { cn, isLeftClick } from "@/lib/utils";
 import {
   Archive,
+  ArrowRightLeft,
   ClipboardList,
   Eye,
   FolderGit2,
@@ -220,6 +221,14 @@ export function AppSidebar({
                 </button>
               </ContextMenuTrigger>
               <ContextMenuContent>
+                <ContextMenuItem
+                  onSelect={() => {
+                    navigate(`/videos/${video.id}/move-to-course`);
+                  }}
+                >
+                  <ArrowRightLeft className="w-4 h-4" />
+                  Move to Course
+                </ContextMenuItem>
                 <ContextMenuItem
                   onSelect={() => {
                     setVideoToRename({ id: video.id, path: video.path });

--- a/app/routes/api.videos.$videoId.move-to-course.ts
+++ b/app/routes/api.videos.$videoId.move-to-course.ts
@@ -1,0 +1,162 @@
+import { Console, Effect, Schema } from "effect";
+import type { Route } from "./+types/api.videos.$videoId.move-to-course";
+import { DBFunctionsService } from "@/services/db-service.server";
+import { runtimeLive } from "@/services/layer.server";
+import { withDatabaseDump } from "@/services/dump-service";
+import { getStandaloneVideoFilePath } from "@/services/standalone-video-files";
+import { data } from "react-router";
+import { FileSystem } from "@effect/platform";
+import path from "path";
+
+const moveToCourseSchema = Schema.Struct({
+  sectionId: Schema.String.pipe(
+    Schema.minLength(1, { message: () => "Section ID is required" })
+  ),
+  lessonId: Schema.String.pipe(
+    Schema.minLength(1, { message: () => "Lesson ID is required" })
+  ),
+  newLessonPath: Schema.optional(Schema.String),
+});
+
+/**
+ * Finds an available filename in a directory by suffixing with " copy", " copy 2", etc.
+ * Returns the filename unchanged if it doesn't exist.
+ */
+const findAvailableFilename = (dir: string, filename: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const originalPath = path.join(dir, filename);
+    const originalExists = yield* fs.exists(originalPath);
+    if (!originalExists) return filename;
+
+    const ext = path.extname(filename);
+    const base = path.basename(filename, ext);
+
+    // Try "base copy.ext"
+    const copyName = `${base} copy${ext}`;
+    const copyPath = path.join(dir, copyName);
+    const copyExists = yield* fs.exists(copyPath);
+    if (!copyExists) return copyName;
+
+    // Try "base copy 2.ext", "base copy 3.ext", etc.
+    let counter = 2;
+    let found = false;
+    let resultName = copyName;
+    while (!found) {
+      const numberedName = `${base} copy ${counter}${ext}`;
+      const numberedPath = path.join(dir, numberedName);
+      const numberedExists = yield* fs.exists(numberedPath);
+      if (!numberedExists) {
+        resultName = numberedName;
+        found = true;
+      } else {
+        counter++;
+      }
+    }
+    return resultName;
+  });
+
+export const action = async (args: Route.ActionArgs) => {
+  const formData = await args.request.formData();
+  const formDataObject = Object.fromEntries(formData);
+  const videoId = args.params.videoId;
+
+  return Effect.gen(function* () {
+    const { sectionId, lessonId, newLessonPath } =
+      yield* Schema.decodeUnknown(moveToCourseSchema)(formDataObject);
+
+    const db = yield* DBFunctionsService;
+    const fs = yield* FileSystem.FileSystem;
+
+    let targetLessonId: string;
+
+    if (lessonId === "__new__") {
+      if (!newLessonPath || newLessonPath.trim() === "") {
+        return yield* Effect.die(
+          data("New lesson path is required", { status: 400 })
+        );
+      }
+
+      // Get all lessons in section to determine the next order value
+      const lessonsInSection = yield* db.getLessonsBySectionId(sectionId);
+      const maxOrder = lessonsInSection.reduce(
+        (max, l) => Math.max(max, l.order),
+        0
+      );
+
+      // Create new real lesson at end of section
+      const newLessons = yield* db.createLessons(sectionId, [
+        {
+          lessonPathWithNumber: newLessonPath.trim(),
+          lessonNumber: maxOrder + 1,
+        },
+      ]);
+
+      const newLesson = newLessons[0];
+      if (!newLesson) {
+        return yield* Effect.die(
+          data("Failed to create lesson", { status: 500 })
+        );
+      }
+      targetLessonId = newLesson.id;
+    } else {
+      targetLessonId = lessonId;
+    }
+
+    // Get lesson with hierarchy to find directory path
+    const lesson = yield* db.getLessonWithHierarchyById(targetLessonId);
+    const repo = lesson.section.repoVersion.repo;
+    const section = lesson.section;
+    const lessonDir = path.join(repo.filePath, section.path, lesson.path);
+
+    // Ensure lesson directory exists (needed for new lessons, safe for existing)
+    yield* fs.makeDirectory(lessonDir, { recursive: true });
+
+    // Get standalone video files directory
+    const standaloneDir = getStandaloneVideoFilePath(videoId);
+    const standaloneDirExists = yield* fs.exists(standaloneDir);
+
+    if (standaloneDirExists) {
+      const files = yield* fs.readDirectory(standaloneDir);
+
+      yield* Effect.forEach(
+        files,
+        (filename) =>
+          Effect.gen(function* () {
+            const sourcePath = path.join(standaloneDir, filename);
+            const stat = yield* fs.stat(sourcePath);
+
+            // Only copy files, skip directories
+            if (stat.type !== "File") return;
+
+            const targetFilename = yield* findAvailableFilename(
+              lessonDir,
+              filename
+            );
+            const targetPath = path.join(lessonDir, targetFilename);
+
+            yield* fs.copyFile(sourcePath, targetPath);
+          }),
+        { concurrency: 1 }
+      );
+    }
+
+    // Update video's lessonId in database
+    yield* db.updateVideoLesson({ videoId, lessonId: targetLessonId });
+
+    return { success: true };
+  }).pipe(
+    withDatabaseDump,
+    Effect.tapErrorCause((e) => Console.dir(e, { depth: null })),
+    Effect.catchTag("ParseError", () => {
+      return Effect.die(data("Invalid request", { status: 400 }));
+    }),
+    Effect.catchTag("NotFoundError", () => {
+      return Effect.die(data("Not found", { status: 404 }));
+    }),
+    Effect.catchAll(() => {
+      return Effect.die(data("Internal server error", { status: 500 }));
+    }),
+    runtimeLive.runPromise
+  );
+};

--- a/app/routes/videos.$videoId.move-to-course.tsx
+++ b/app/routes/videos.$videoId.move-to-course.tsx
@@ -1,0 +1,259 @@
+import { AppSidebar } from "@/components/app-sidebar";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { DBFunctionsService } from "@/services/db-service.server";
+import { runtimeLive } from "@/services/layer.server";
+import { Console, Effect } from "effect";
+import { ArrowRightLeft, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { data, redirect, useFetcher, useNavigate } from "react-router";
+import type { Route } from "./+types/videos.$videoId.move-to-course";
+
+export const meta: Route.MetaFunction = () => {
+  return [{ title: "CVM - Move Video to Course" }];
+};
+
+export const loader = async (args: Route.LoaderArgs) => {
+  const { videoId } = args.params;
+
+  return Effect.gen(function* () {
+    const db = yield* DBFunctionsService;
+
+    const video = yield* db.getVideoById(videoId);
+
+    if (video.lessonId !== null) {
+      return yield* Effect.die(redirect(`/videos/${videoId}/edit`));
+    }
+
+    const repos = yield* db.getRepos();
+    const sidebarVideos = yield* db.getStandaloneVideos();
+    const plans = yield* db.getPlans();
+
+    const reposWithSections = yield* Effect.forEach(
+      repos,
+      (repo) => db.getRepoWithSectionsById(repo.id),
+      { concurrency: "unbounded" }
+    );
+
+    // Map to a simpler structure for the UI
+    const courseData = reposWithSections.map((repo) => ({
+      id: repo.id,
+      name: repo.name,
+      sections: (repo.versions[0]?.sections ?? []).map((section) => ({
+        id: section.id,
+        path: section.path,
+        lessons: section.lessons.map((lesson) => ({
+          id: lesson.id,
+          path: lesson.path,
+          fsStatus: lesson.fsStatus,
+        })),
+      })),
+    }));
+
+    return { video, courseData, sidebarVideos, plans };
+  }).pipe(
+    Effect.tapErrorCause((e) => Console.dir(e, { depth: null })),
+    Effect.catchTag("NotFoundError", () => {
+      return Effect.die(data("Video not found", { status: 404 }));
+    }),
+    Effect.catchAll(() => {
+      return Effect.die(data("Internal server error", { status: 500 }));
+    }),
+    runtimeLive.runPromise
+  );
+};
+
+export default function Component(props: Route.ComponentProps) {
+  const { video, courseData, sidebarVideos, plans } = props.loaderData;
+  const navigate = useNavigate();
+  const fetcher = useFetcher();
+
+  const [selectedCourseId, setSelectedCourseId] = useState<string>("");
+  const [selectedSectionId, setSelectedSectionId] = useState<string>("");
+  const [selectedLessonId, setSelectedLessonId] = useState<string>("");
+  const [newLessonPath, setNewLessonPath] = useState<string>("");
+
+  const selectedCourse = courseData.find((c) => c.id === selectedCourseId);
+  const selectedSection = selectedCourse?.sections.find(
+    (s) => s.id === selectedSectionId
+  );
+
+  const isCreatingNew = selectedLessonId === "__new__";
+  const isSubmitting = fetcher.state === "submitting";
+
+  const canSubmit =
+    selectedSectionId &&
+    selectedLessonId &&
+    (!isCreatingNew || newLessonPath.trim() !== "");
+
+  useEffect(() => {
+    if (fetcher.data && (fetcher.data as { success?: boolean }).success) {
+      navigate("/videos");
+    }
+  }, [fetcher.data, navigate]);
+
+  // Reset section and lesson when course changes
+  const handleCourseChange = (courseId: string) => {
+    setSelectedCourseId(courseId);
+    setSelectedSectionId("");
+    setSelectedLessonId("");
+    setNewLessonPath("");
+  };
+
+  // Reset lesson when section changes
+  const handleSectionChange = (sectionId: string) => {
+    setSelectedSectionId(sectionId);
+    setSelectedLessonId("");
+    setNewLessonPath("");
+  };
+
+  const handleSubmit = () => {
+    const formData: Record<string, string> = {
+      sectionId: selectedSectionId,
+      lessonId: selectedLessonId,
+    };
+    if (isCreatingNew && newLessonPath.trim()) {
+      formData.newLessonPath = newLessonPath.trim();
+    }
+    fetcher.submit(formData, {
+      method: "post",
+      action: `/api/videos/${video.id}/move-to-course`,
+    });
+  };
+
+  return (
+    <div className="flex h-screen bg-background text-foreground">
+      <AppSidebar
+        repos={courseData.map((c) => ({ id: c.id, name: c.name }))}
+        standaloneVideos={sidebarVideos}
+        plans={plans}
+      />
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-2xl mx-auto p-6">
+          <div className="flex items-center gap-3 mb-8">
+            <ArrowRightLeft className="w-6 h-6" />
+            <div>
+              <h1 className="text-2xl font-bold">Move to Course</h1>
+              <p className="text-muted-foreground text-sm mt-1">
+                Moving:{" "}
+                <span className="font-medium text-foreground">
+                  {video.path}
+                </span>
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-6 border rounded-lg p-6">
+            <div className="space-y-2">
+              <Label>Course</Label>
+              <Select
+                value={selectedCourseId}
+                onValueChange={handleCourseChange}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a course..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {courseData.map((course) => (
+                    <SelectItem key={course.id} value={course.id}>
+                      {course.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Section</Label>
+              <Select
+                value={selectedSectionId}
+                onValueChange={handleSectionChange}
+                disabled={!selectedCourseId}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a section..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {(selectedCourse?.sections ?? []).map((section) => (
+                    <SelectItem key={section.id} value={section.id}>
+                      {section.path}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Lesson</Label>
+              <Select
+                value={selectedLessonId}
+                onValueChange={setSelectedLessonId}
+                disabled={!selectedSectionId}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a lesson..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {(selectedSection?.lessons ?? []).map((lesson) => (
+                    <SelectItem key={lesson.id} value={lesson.id}>
+                      {lesson.path}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value="__new__">+ Create new lesson</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {isCreatingNew && (
+              <div className="space-y-2">
+                <Label>New Lesson Path</Label>
+                <Input
+                  value={newLessonPath}
+                  onChange={(e) => setNewLessonPath(e.target.value)}
+                  placeholder="e.g. 01-my-new-lesson"
+                  autoFocus
+                />
+                <p className="text-xs text-muted-foreground">
+                  This will be the directory name for the new lesson.
+                </p>
+              </div>
+            )}
+
+            <div className="flex justify-end gap-3 pt-2">
+              <Button
+                variant="outline"
+                onClick={() => navigate(-1)}
+                disabled={isSubmitting}
+                type="button"
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleSubmit}
+                disabled={!canSubmit || isSubmitting}
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    Moving...
+                  </>
+                ) : (
+                  "Move Video"
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/videos._index.tsx
+++ b/app/routes/videos._index.tsx
@@ -18,6 +18,7 @@ import { FileSystem } from "@effect/platform";
 import { Console, Effect } from "effect";
 import {
   Archive,
+  ArrowRightLeft,
   Download,
   FileX,
   FolderOpen,
@@ -186,6 +187,14 @@ export default function Component(props: Route.ComponentProps) {
                       </Link>
                     </ContextMenuTrigger>
                     <ContextMenuContent>
+                      <ContextMenuItem
+                        onSelect={() => {
+                          navigate(`/videos/${video.id}/move-to-course`);
+                        }}
+                      >
+                        <ArrowRightLeft className="w-4 h-4" />
+                        Move to Course
+                      </ContextMenuItem>
                       <ContextMenuItem
                         onSelect={() => {
                           setVideoToRename({ id: video.id, path: video.path });


### PR DESCRIPTION
Task: Implement ability to move standalone videos into course lessons via a dedicated page (not modal) as requested by owner.

Key decisions:
- Created standalone page at /videos/:videoId/move-to-course with three sequential selects: course → section → lesson (or create new)
- New lessons created with fsStatus='real' at end of section (maxOrder+1)
- File merging: copies all files from STANDALONE_VIDEO_FILES_DIR/{videoId}/ into lesson dir, with " copy"/" copy 2" suffix on conflicts
- Context menu "Move to Course" added to both /videos page and sidebar

Files changed:
- app/routes/videos.$videoId.move-to-course.tsx (new) - page UI
- app/routes/api.videos.$videoId.move-to-course.ts (new) - POST handler
- app/routes/videos._index.tsx - added Move to Course context menu item
- app/components/app-sidebar.tsx - added Move to Course context menu item