### PR TITLE
Fix lesson creation crash when adding video to new FS lesson (#759)

### DIFF
--- a/app/components/add-video-modal.tsx
+++ b/app/components/add-video-modal.tsx
@@ -39,8 +39,10 @@ export function AddVideoModal(props: {
     navigate,
   ]);
 
-  // Don't render if no lessonId (standalone videos use different flow)
-  if (!props.lessonId) return null;
+  if (!props.open) return null;
+
+  const isPending = !props.lessonId;
+  const isSubmitting = addVideoFetcher.state !== "idle";
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
@@ -50,10 +52,16 @@ export function AddVideoModal(props: {
         </DialogHeader>
         <addVideoFetcher.Form
           method="post"
-          action={`/api/lessons/${props.lessonId}/add-video`}
+          action={
+            props.lessonId
+              ? `/api/lessons/${props.lessonId}/add-video`
+              : undefined
+          }
+          onSubmit={(e) => {
+            if (isPending) e.preventDefault();
+          }}
           className="space-y-4 py-4"
         >
-          <input type="hidden" name="lessonId" value={props.lessonId} />
           <div className="space-y-2">
             <Label htmlFor="video-path">Video Name</Label>
             <Input
@@ -74,9 +82,14 @@ export function AddVideoModal(props: {
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={addVideoFetcher.state !== "idle"}>
-              {addVideoFetcher.state !== "idle" ? (
+            <Button type="submit" disabled={isPending || isSubmitting}>
+              {isSubmitting ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
+              ) : isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Saving Lesson…
+                </>
               ) : (
                 "Add Video"
               )}

--- a/app/features/course-view/sortable-lesson-item.tsx
+++ b/app/features/course-view/sortable-lesson-item.tsx
@@ -402,7 +402,7 @@ export function SortableLessonItem({
                       onSelect={() =>
                         dispatch({
                           type: "set-add-video-to-lesson-id",
-                          lessonId: lesson.id,
+                          lessonId: getLessonDndId(lesson),
                         })
                       }
                     >
@@ -509,16 +509,19 @@ export function SortableLessonItem({
           </ContextMenuContent>
         </ContextMenu>
         <AddVideoModal
-          lessonId={lesson.id}
+          lessonId={
+            (lesson as unknown as { databaseId: string | null }).databaseId ??
+            undefined
+          }
           videoCount={lesson.videos.length}
           hasExplainerFolder={
             lessonFsMaps.hasExplainerFolderMap[lesson.id] ?? false
           }
-          open={addVideoToLessonId === lesson.id}
+          open={addVideoToLessonId === getLessonDndId(lesson)}
           onOpenChange={(open) => {
             dispatch({
               type: "set-add-video-to-lesson-id",
-              lessonId: open ? lesson.id : null,
+              lessonId: open ? getLessonDndId(lesson) : null,
             });
           }}
         />

--- a/app/hooks/use-course-editor.test.ts
+++ b/app/hooks/use-course-editor.test.ts
@@ -232,6 +232,42 @@ describe("editorSectionsToLoaderSections", () => {
     const result = editorSectionsToLoaderSections([]);
     expect(result).toEqual([]);
   });
+
+  it("should expose databaseId on lesson for add-video guard (null before reconciliation)", () => {
+    const section = createEditorSection({
+      lessons: [
+        createEditorLesson({
+          frontendId: fid("optimistic-uuid"),
+          databaseId: null as unknown as DatabaseId,
+        }),
+      ],
+    });
+
+    const result = editorSectionsToLoaderSections([section]);
+    const lesson = result[0]!.lessons[0]! as unknown as {
+      databaseId: string | null;
+    };
+
+    expect(lesson.databaseId).toBeNull();
+  });
+
+  it("should expose databaseId on lesson after reconciliation", () => {
+    const section = createEditorSection({
+      lessons: [
+        createEditorLesson({
+          frontendId: fid("optimistic-uuid"),
+          databaseId: did("db-real-id"),
+        }),
+      ],
+    });
+
+    const result = editorSectionsToLoaderSections([section]);
+    const lesson = result[0]!.lessons[0]! as unknown as {
+      databaseId: string | null;
+    };
+
+    expect(lesson.databaseId).toBe("db-real-id");
+  });
 });
 
 describe("useCourseEditor integration (reducer + queue)", () => {

--- a/app/hooks/use-course-editor.ts
+++ b/app/hooks/use-course-editor.ts
@@ -79,6 +79,7 @@ export function editorSectionsToLoaderSections(
         lessons: s.lessons.map((l) => ({
           id: (l.databaseId ?? l.frontendId) as string,
           frontendId: l.frontendId as string,
+          databaseId: (l.databaseId as string) ?? null,
           path: l.path,
           title: l.title,
           fsStatus: l.fsStatus,


### PR DESCRIPTION
## Summary
- Fixed crash when adding a video to a newly created filesystem lesson
- Root cause: `lesson.id` transitions from `frontendId` to `databaseId` after the `lesson-created` reconciliation, breaking the AddVideoModal's open-state comparison and causing the API call to use an unrecognized frontendId (404 → error boundary crash)
- Uses stable `frontendId` (via `getLessonDndId`) for modal state tracking, and exposes `databaseId` on the lesson object so the modal receives the correct DB id for the API call
- Added pending guard: submit button shows "Saving Lesson…" and is disabled until the lesson is persisted

## Test plan
- [x] TypeScript typecheck passes
- [x] All 1170 tests pass (87 test files)
- [x] 2 new tests verify `databaseId` exposure on lesson objects
- [ ] Manual: create a real lesson (with "Create on filesystem" checked), then right-click → Add Video — modal should stay open and submit successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)