### PR TITLE
Auto-select text in section modal on create/edit

### DIFF
--- a/app/components/create-section-modal.tsx
+++ b/app/components/create-section-modal.tsx
@@ -8,7 +8,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { capitalizeTitle } from "@/utils/capitalize-title";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export function CreateSectionModal(props: {
   repoVersionId: string;
@@ -18,7 +18,17 @@ export function CreateSectionModal(props: {
   onCreateSection: (title: string) => void;
 }) {
   const [title, setTitle] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
   const isValid = title.trim().length > 0;
+
+  useEffect(() => {
+    if (props.open) {
+      setTimeout(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }, 100);
+    }
+  }, [props.open]);
 
   return (
     <Dialog
@@ -46,12 +56,12 @@ export function CreateSectionModal(props: {
           <div className="space-y-2">
             <Label htmlFor="section-title">Title</Label>
             <Input
+              ref={inputRef}
               id="section-title"
               name="title"
               placeholder="e.g. Advanced Patterns"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              autoFocus
             />
           </div>
           <div className="flex justify-end space-x-2">

--- a/app/components/edit-ghost-section-modal.tsx
+++ b/app/components/edit-ghost-section-modal.tsx
@@ -8,7 +8,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { capitalizeTitle } from "@/utils/capitalize-title";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export function EditGhostSectionModal(props: {
   sectionId: string;
@@ -18,10 +18,20 @@ export function EditGhostSectionModal(props: {
   onRename: (title: string) => void;
 }) {
   const [title, setTitle] = useState(props.currentTitle);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setTitle(props.currentTitle);
   }, [props.currentTitle]);
+
+  useEffect(() => {
+    if (props.open) {
+      setTimeout(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }, 100);
+    }
+  }, [props.open]);
 
   const isValid = title.trim().length > 0;
 
@@ -49,12 +59,12 @@ export function EditGhostSectionModal(props: {
           <div className="space-y-2">
             <Label htmlFor="ghost-section-title">Title</Label>
             <Input
+              ref={inputRef}
               id="ghost-section-title"
               name="title"
               placeholder="e.g. Before We Start"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              autoFocus
             />
           </div>
           <div className="flex justify-end space-x-2">

--- a/app/components/edit-section-modal.tsx
+++ b/app/components/edit-section-modal.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { parseSectionPath } from "@/services/section-path-service";
 import { toSlug } from "@/services/lesson-path-service";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
@@ -27,11 +27,21 @@ export function EditSectionModal(props: {
   const currentSlug = parsed?.slug ?? props.currentPath;
 
   const [input, setInput] = useState(currentSlug);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     const p = parseSectionPath(props.currentPath);
     setInput(p?.slug ?? props.currentPath);
   }, [props.currentPath]);
+
+  useEffect(() => {
+    if (props.open) {
+      setTimeout(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }, 100);
+    }
+  }, [props.open]);
 
   const slug = toSlug(input);
   const isValid = slug.length > 0 && SLUG_PATTERN.test(slug);
@@ -66,11 +76,11 @@ export function EditSectionModal(props: {
                 </span>
               )}
               <Input
+                ref={inputRef}
                 id="section-slug"
                 placeholder="e.g. before-we-start"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
-                autoFocus
                 className="flex-1"
               />
             </div>


### PR DESCRIPTION
## Summary
- When any section modal opens (create, edit, or edit ghost), the input text is now auto-focused and auto-selected
- Users can immediately type to replace the existing value without needing to manually select it
- Follows the existing `ref + setTimeout + select()` pattern from `lesson-file-paste-modal.tsx`

Closes #769

## Files changed
- `app/components/create-section-modal.tsx`
- `app/components/edit-section-modal.tsx`
- `app/components/edit-ghost-section-modal.tsx`

## Test plan
- [ ] Open the "Create Section" modal — input should be focused
- [ ] Open the "Rename Section" modal (real section) — slug text should be fully selected
- [ ] Open the "Rename Ghost Section" modal — title text should be fully selected
- [ ] Start typing immediately after modal opens — selected text should be replaced
- [ ] Click away from input and click back — verify normal focus behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)