### PR TITLE
Fix add course modal not displaying on /videos page

### DIFF
--- a/app/routes/videos._index.tsx
+++ b/app/routes/videos._index.tsx
@@ -88,6 +88,7 @@ export default function Component(props: Route.ComponentProps) {
     plans,
   } = props.loaderData;
   const [isAddVideoOpen, setIsAddVideoOpen] = useState(false);
+  const [isAddCourseModalOpen, setIsAddCourseModalOpen] = useState(false);
   const [videoToDelete, setVideoToDelete] = useState<{
     id: string;
     path: string;
@@ -110,6 +111,8 @@ export default function Component(props: Route.ComponentProps) {
         courses={courses}
         standaloneVideos={sidebarVideos}
         plans={plans}
+        isAddCourseModalOpen={isAddCourseModalOpen}
+        setIsAddCourseModalOpen={setIsAddCourseModalOpen}
         isAddStandaloneVideoModalOpen={isAddVideoOpen}
         setIsAddStandaloneVideoModalOpen={setIsAddVideoOpen}
       />


### PR DESCRIPTION
## Summary
- The `/videos` page was missing `isAddCourseModalOpen` / `setIsAddCourseModalOpen` state, so the `AddCourseModal` never rendered and clicking the sidebar "+" button next to Courses was a no-op
- Added `useState` for the modal state and wired it to `AppSidebar` props, matching the pattern in `archived-courses.tsx` and other pages

Closes #771

## Test plan
- [ ] Navigate to `/videos`, click the "+" button next to "Courses" in the sidebar — modal should appear
- [ ] Enter a course name and submit — course should be created
- [ ] Verify no regressions on other pages (home, archived courses, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)