### PR TITLE
fix(ci): use AGENT_PAT for checkout so workflow files can be pushed

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -65,6 +65,11 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          # Use AGENT_PAT so pushes can include changes to files under
+          # .github/workflows/ (GITHUB_TOKEN lacks the `workflows` scope).
+          # Falls back to GITHUB_TOKEN if AGENT_PAT is unset; in that case
+          # workflow-file changes will be rejected on push.
+          token: ${{ secrets.AGENT_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Compute branch name
         if: steps.preflight.outputs.refused != 'true'


### PR DESCRIPTION
## Summary
- `agent:implement` run for #817 failed at push with `refusing to allow a GitHub App to create or update workflow .github/workflows/agent-implement.yml without workflows permission` ([failed run](https://github.com/mattpocock/course-video-manager/actions/runs/26214153334/job/77132130421)).
- `GITHUB_TOKEN` lacks the `workflows` scope, so any implement run that touches `.github/workflows/**` is rejected.
- Switch the `actions/checkout` step to use `AGENT_PAT` (already used downstream for triggering the review workflow) so the credentials persisted for `git push` can push workflow file changes. Falls back to `GITHUB_TOKEN` if the secret is unset.

## Test plan
- [ ] Re-add `agent:implement` to #817 and confirm the run completes and pushes successfully.