### PR TITLE
feat: auto-promote agent:queued issues when blockers close

### DIFF
--- a/.github/workflows/agent-implement-pr.yml
+++ b/.github/workflows/agent-implement-pr.yml
@@ -1,0 +1,213 @@
+name: Agent Implement (PR)
+
+on:
+  # See agent-review.yml — pull_request_target fires reliably on labels
+  # even when the PR is out-of-date or conflicting.
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  implement-pr:
+    if: github.event.label.name == 'agent:implement'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Shared with agent-review.yml — both push to the PR branch.
+    concurrency:
+      group: agent-mutate-pr-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BRANCH: ${{ github.event.pull_request.head.ref }}
+      BRANCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_STATE: ${{ github.event.pull_request.state }}
+      PR_MERGED: ${{ github.event.pull_request.merged }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Pre-flight — refuse if PR is closed or merged
+        id: state
+        run: |
+          if [ "$PR_STATE" != "open" ] || [ "$PR_MERGED" = "true" ]; then
+            gh pr edit "$PR_NUMBER" --remove-label "agent:implement" || true
+            gh pr comment "$PR_NUMBER" --body "Refused to run \`agent:implement\`: PR is not open."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pre-flight — refuse if there is nothing to act on
+        if: steps.state.outputs.proceed == 'true'
+        id: inputs
+        run: |
+          set -euo pipefail
+          top_level=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments | length')
+          review_summaries=$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}/reviews" --jq '[.[] | select(.body != null and .body != "")] | length')
+          owner="${GH_REPO%/*}"
+          repo="${GH_REPO#*/}"
+          unresolved=$(gh api graphql \
+            -F owner="$owner" -F repo="$repo" -F number="$PR_NUMBER" \
+            -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100){nodes{isResolved}}}}}' \
+            --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
+          total=$((top_level + review_summaries + unresolved))
+          if [ "$total" -eq 0 ]; then
+            gh pr edit "$PR_NUMBER" --remove-label "agent:implement" || true
+            gh pr comment "$PR_NUMBER" --body "Refused to run \`agent:implement\`: no unresolved review threads, review summaries, or top-level PR comments to act on."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Transition labels — remove trigger + blocked, add in-progress
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        run: |
+          gh pr edit "$PR_NUMBER" --remove-label "agent:implement" || true
+          gh pr edit "$PR_NUMBER" --remove-label "agent:blocked" || true
+          gh pr edit "$PR_NUMBER" --add-label "agent:in-progress"
+
+      - name: Checkout PR branch
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          token: ${{ secrets.AGENT_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Ensure main is available for diffing
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        run: |
+          git fetch origin main:main || git fetch origin main
+          git checkout "$BRANCH" 2>/dev/null || git checkout -B "$BRANCH"
+
+      - name: Setup Node.js 22
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        run: npm install
+
+      - name: Install Claude Code
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Configure git identity
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        run: |
+          git config user.name "claude-code[bot]"
+          git config user.email "claude-code[bot]@users.noreply.github.com"
+
+      - name: Run implement-pr.ts
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        id: implement
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          OUTPUT_DIR: ${{ runner.temp }}
+        run: npx tsx .sandcastle/implement-pr/implement-pr.ts
+
+      - name: Push branch (abort cleanly if non-fast-forward)
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
+        id: push
+        run: |
+          has_commits=$(cat "${RUNNER_TEMP}/has_commits.txt")
+          if [ "$has_commits" != "true" ]; then
+            echo "No commits this run — skipping push."
+            exit 0
+          fi
+          set +e
+          git push --force-with-lease="refs/heads/$BRANCH:$BRANCH_HEAD_SHA" origin "$BRANCH" 2> push_err.txt
+          status=$?
+          set -e
+          if [ $status -ne 0 ]; then
+            if grep -qiE "non-fast-forward|rejected|fetch first|stale info" push_err.txt; then
+              echo "Branch advanced during implement run." > "${RUNNER_TEMP}/failure_reason.txt"
+              cat push_err.txt
+              exit 1
+            fi
+            cat push_err.txt
+            exit $status
+          fi
+
+      - name: Post thread replies
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
+        env:
+          REPLIES: ${{ runner.temp }}/implement_thread_replies.json
+        run: |
+          count=$(jq 'length' "$REPLIES")
+          for i in $(seq 0 $((count - 1))); do
+            commentId=$(jq -r ".[$i].commentId" "$REPLIES")
+            body=$(jq -r ".[$i].body" "$REPLIES")
+            rest_id=$(gh api graphql -f query="query(\$id:ID!){ node(id:\$id){ ... on PullRequestReviewComment { databaseId } } }" -F id="$commentId" --jq '.data.node.databaseId')
+            if [ -z "$rest_id" ] || [ "$rest_id" = "null" ]; then
+              echo "Could not resolve REST id for $commentId — skipping" >&2
+              continue
+            fi
+            gh api \
+              --method POST \
+              "repos/{owner}/{repo}/pulls/${PR_NUMBER}/comments/${rest_id}/replies" \
+              -f body="$body"
+          done
+
+      - name: Post new inline comments
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
+        env:
+          INLINE: ${{ runner.temp }}/implement_new_inline_comments.json
+        run: |
+          commit_id=$(jq -r '.commit_id' "$INLINE")
+          count=$(jq '.comments | length' "$INLINE")
+          for i in $(seq 0 $((count - 1))); do
+            path=$(jq -r ".comments[$i].path" "$INLINE")
+            line=$(jq -r ".comments[$i].line" "$INLINE")
+            side=$(jq -r ".comments[$i].side" "$INLINE")
+            body=$(jq -r ".comments[$i].body" "$INLINE")
+            gh api \
+              --method POST \
+              "repos/{owner}/{repo}/pulls/${PR_NUMBER}/comments" \
+              -f body="$body" \
+              -f commit_id="$commit_id" \
+              -f path="$path" \
+              -F line="$line" \
+              -f side="$side"
+          done
+
+      - name: Post top-level PR comments
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && success()
+        env:
+          TOP: ${{ runner.temp }}/implement_top_level_comments.json
+        run: |
+          count=$(jq 'length' "$TOP")
+          for i in $(seq 0 $((count - 1))); do
+            body=$(jq -r ".[$i].body" "$TOP")
+            gh pr comment "$PR_NUMBER" --body "$body"
+          done
+
+      - name: Mark blocked on failure
+        if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true' && failure()
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          reason="(no reason file written — check workflow logs)"
+          if [ -f "${RUNNER_TEMP}/failure_reason.txt" ]; then
+            reason=$(cat "${RUNNER_TEMP}/failure_reason.txt")
+          fi
+          gh pr edit "$PR_NUMBER" --add-label "agent:blocked" || true
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          \`agent:implement\` run on this PR failed.
+
+          **Reason:** $reason
+
+          **Workflow run:** $RUN_URL
+
+          Re-add \`agent:implement\` to retry.
+          EOF
+          )"
+
+      - name: Always remove in-progress label
+        if: always() && steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
+        run: gh pr edit "$PR_NUMBER" --remove-label "agent:in-progress" || true

--- a/.github/workflows/agent-promote-queued.yml
+++ b/.github/workflows/agent-promote-queued.yml
@@ -1,0 +1,129 @@
+name: Agent Promote Queued
+
+# When an issue closes, find every `agent:queued` issue that declared it as a
+# blocker via the native GitHub issue dependency relation. If any of those
+# dependents have no remaining open blockers, flip `agent:queued` to
+# `agent:implement` so `agent-implement.yml` picks them up.
+#
+# Manual application only — humans apply `agent:queued`. This workflow is the
+# exit ramp, not the entrance.
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  promote:
+    # Wontfix closes don't unblock anything in a meaningful sense.
+    if: github.event.issue.state_reason != 'not_planned'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+
+    env:
+      CLOSED_NUMBER: ${{ github.event.issue.number }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      # AGENT_PAT is required for the promoted `agent:implement` label to
+      # fire `agent-implement.yml` — labels added via GITHUB_TOKEN do not
+      # trigger downstream workflows. Falls back to GITHUB_TOKEN, in which
+      # case promotion lands but the downstream run won't auto-trigger.
+      AGENT_PAT: ${{ secrets.AGENT_PAT }}
+
+    steps:
+      - name: Find dependents of the closed issue
+        id: dependents
+        run: |
+          set -euo pipefail
+          owner="${GH_REPO%/*}"
+          repo="${GH_REPO#*/}"
+          # `blocking` is the connection from the closed issue to issues that
+          # declared it as a blocker (i.e. our promotion candidates).
+          dependents=$(gh api graphql \
+            -f query='query($owner: String!, $repo: String!, $num: Int!) { repository(owner: $owner, name: $repo) { issue(number: $num) { blocking(first: 100) { nodes { number state } } } } }' \
+            -f owner="$owner" -f repo="$repo" -F num="$CLOSED_NUMBER" \
+            --jq '[.data.repository.issue.blocking.nodes[] | select(.state == "OPEN") | .number]')
+          echo "list=$dependents" >> "$GITHUB_OUTPUT"
+          echo "Found dependents: $dependents"
+
+      - name: Evaluate and promote each dependent
+        if: steps.dependents.outputs.list != '[]'
+        env:
+          DEPENDENTS_JSON: ${{ steps.dependents.outputs.list }}
+        run: |
+          set -euo pipefail
+          owner="${GH_REPO%/*}"
+          repo="${GH_REPO#*/}"
+
+          echo "$DEPENDENTS_JSON" | jq -r '.[]' | while read -r y; do
+            echo "::group::Evaluating #$y"
+
+            # Fetch labels + parent for Y in one shot.
+            y_data=$(gh api graphql \
+              -f query='query($owner: String!, $repo: String!, $num: Int!) { repository(owner: $owner, name: $repo) { issue(number: $num) { labels(first: 50) { nodes { name } } parent { number } blockedBy(first: 100) { nodes { number state } } } } }' \
+              -f owner="$owner" -f repo="$repo" -F num="$y")
+
+            has_queued=$(echo "$y_data" | jq '[.data.repository.issue.labels.nodes[].name] | index("agent:queued") != null')
+            has_in_progress=$(echo "$y_data" | jq '[.data.repository.issue.labels.nodes[].name] | index("agent:in-progress") != null')
+            parent_num=$(echo "$y_data" | jq -r '.data.repository.issue.parent.number // empty')
+            remaining_open=$(echo "$y_data" | jq '[.data.repository.issue.blockedBy.nodes[] | select(.state == "OPEN")] | length')
+
+            if [ "$has_queued" != "true" ]; then
+              echo "Skip: #$y is not agent:queued"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ "$has_in_progress" = "true" ]; then
+              echo "Skip: #$y is agent:in-progress"
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ -n "$parent_num" ]; then
+              echo "Refuse: #$y is a sub-issue of #$parent_num"
+              gh issue edit "$y" --remove-label "agent:queued" || true
+              gh issue edit "$y" --add-label "agent:blocked" || true
+              gh issue comment "$y" --body "Refused to promote: this is a sub-issue of #${parent_num}. \`agent:queued\` is not meaningful on sub-issues — label the parent PRD instead. Cleared \`agent:queued\` and added \`agent:blocked\`."
+              echo "::endgroup::"
+              continue
+            fi
+
+            if [ "$remaining_open" -gt 0 ]; then
+              echo "Skip: #$y still has $remaining_open open blocker(s)"
+              echo "::endgroup::"
+              continue
+            fi
+
+            # Idempotent flip: re-fetch labels right before mutating to lose
+            # races against a sibling run of this workflow.
+            still_queued=$(gh issue view "$y" --json labels --jq '[.labels[].name] | index("agent:queued") != null')
+            if [ "$still_queued" != "true" ]; then
+              echo "Skip: #$y no longer has agent:queued (lost race)"
+              echo "::endgroup::"
+              continue
+            fi
+
+            echo "Promote: #$y"
+            gh issue edit "$y" --remove-label "agent:queued"
+            gh issue comment "$y" --body "Unblocked by #${CLOSED_NUMBER} closing — promoting from \`agent:queued\` to \`agent:implement\`."
+
+            # Use AGENT_PAT for the agent:implement add so downstream
+            # agent-implement.yml fires. Fall back to GITHUB_TOKEN if PAT is
+            # absent; in that case the label lands but won't trigger.
+            set +e
+            if [ -n "$AGENT_PAT" ]; then
+              GH_TOKEN="$AGENT_PAT" gh issue edit "$y" --add-label "agent:implement"
+              status=$?
+              if [ "$status" -ne 0 ]; then
+                echo "AGENT_PAT add-label failed (status $status); falling back to GITHUB_TOKEN."
+                gh issue edit "$y" --add-label "agent:implement"
+              fi
+            else
+              gh issue edit "$y" --add-label "agent:implement"
+            fi
+            set -e
+
+            echo "::endgroup::"
+          done

--- a/.sandcastle/implement-pr/implement-pr-output.ts
+++ b/.sandcastle/implement-pr/implement-pr-output.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+export const ImplementPrOutput = z.object({
+  threadReplies: z
+    .array(
+      z.object({
+        commentId: z.string().min(1),
+        body: z.string().min(1),
+      })
+    )
+    .default([]),
+  newInlineComments: z
+    .array(
+      z
+        .object({
+          path: z.string().min(1).optional(),
+          file: z.string().min(1).optional(),
+          line: z.coerce.number().int().positive().optional(),
+          lineRange: z.string().optional(),
+          side: z.enum(["LEFT", "RIGHT"]).default("RIGHT"),
+          body: z.string().min(1).optional(),
+          comment: z.string().min(1).optional(),
+        })
+        .transform((c, ctx) => {
+          const path = c.path ?? c.file;
+          const body = c.body ?? c.comment;
+
+          let line = c.line;
+          if (line == null && c.lineRange != null) {
+            const match = c.lineRange.match(/^(\d+)/);
+            line = match ? parseInt(match[1]!, 10) : undefined;
+          }
+
+          if (!path) {
+            ctx.addIssue({
+              code: "custom",
+              message: "inline comment missing 'path' (or 'file')",
+            });
+            return z.NEVER;
+          }
+          if (line == null || line < 1) {
+            ctx.addIssue({
+              code: "custom",
+              message:
+                "inline comment missing 'line' (or 'lineRange' with a valid number)",
+            });
+            return z.NEVER;
+          }
+          if (!body) {
+            ctx.addIssue({
+              code: "custom",
+              message: "inline comment missing 'body' (or 'comment')",
+            });
+            return z.NEVER;
+          }
+          return { path, line, side: c.side, body };
+        })
+    )
+    .default([]),
+  topLevelComments: z
+    .array(
+      z.object({
+        body: z.string().min(1),
+      })
+    )
+    .default([]),
+});
+
+export type ImplementPrOutput = z.infer<typeof ImplementPrOutput>;

--- a/.sandcastle/implement-pr/implement-pr.ts
+++ b/.sandcastle/implement-pr/implement-pr.ts
@@ -1,0 +1,286 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execSync, execFileSync } from "node:child_process";
+import { z } from "zod";
+import * as sandcastle from "@ai-hero/sandcastle";
+import { parseDiffLines } from "../review/parse-diff-lines";
+import { ImplementPrOutput } from "./implement-pr-output";
+import { noSandbox } from "@ai-hero/sandcastle/sandboxes/no-sandbox";
+
+const PR_NUMBER = required("PR_NUMBER");
+const BRANCH = required("BRANCH");
+const OUTPUT_DIR = process.env.OUTPUT_DIR ?? "/tmp";
+
+const PrView = z.object({
+  title: z.string(),
+  body: z.string().nullable().default(""),
+  headRefOid: z.string(),
+  comments: z.array(
+    z.object({
+      id: z.string().optional(),
+      author: z.object({ login: z.string() }).nullable().optional(),
+      body: z.string(),
+      createdAt: z.string().optional(),
+    })
+  ),
+});
+
+const prViewJson = sh(
+  `gh pr view ${PR_NUMBER} --json title,body,headRefOid,comments`
+);
+const prView = PrView.parse(JSON.parse(prViewJson));
+
+const issueMatch = prView.body?.match(/(?:closes|fixes|resolves)\s+#(\d+)/i);
+const ISSUE_NUMBER = issueMatch?.[1] ?? "";
+const ISSUE_TITLE = ISSUE_NUMBER
+  ? safeSh(`gh issue view ${ISSUE_NUMBER} --json title --jq .title`).trim()
+  : "";
+
+const reviewsJson = sh(
+  `gh api repos/{owner}/{repo}/pulls/${PR_NUMBER}/reviews`
+);
+const reviews = z
+  .array(
+    z.object({
+      id: z.number(),
+      user: z.object({ login: z.string() }).nullable(),
+      body: z.string().nullable().default(""),
+      state: z.string(),
+      submitted_at: z.string().nullable().optional(),
+    })
+  )
+  .parse(JSON.parse(reviewsJson));
+
+const graphqlQuery = `
+query($owner:String!,$repo:String!,$number:Int!) {
+  repository(owner:$owner,name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first:50) {
+            nodes {
+              id
+              path
+              line
+              originalLine
+              body
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const [owner, repo] = required("GH_REPO").split("/");
+const threadsJson = execFileSync(
+  "gh",
+  [
+    "api",
+    "graphql",
+    "-F",
+    `owner=${owner}`,
+    "-F",
+    `repo=${repo}`,
+    "-F",
+    `number=${PR_NUMBER}`,
+    "-f",
+    `query=${graphqlQuery}`,
+  ],
+  { encoding: "utf8" }
+);
+const threadsParsed = z
+  .object({
+    data: z.object({
+      repository: z.object({
+        pullRequest: z.object({
+          reviewThreads: z.object({
+            nodes: z.array(
+              z.object({
+                id: z.string(),
+                isResolved: z.boolean(),
+                isOutdated: z.boolean(),
+                comments: z.object({
+                  nodes: z.array(
+                    z.object({
+                      id: z.string(),
+                      path: z.string().nullable(),
+                      line: z.number().nullable(),
+                      originalLine: z.number().nullable(),
+                      body: z.string(),
+                      author: z.object({ login: z.string() }).nullable(),
+                    })
+                  ),
+                }),
+              })
+            ),
+          }),
+        }),
+      }),
+    }),
+  })
+  .parse(JSON.parse(threadsJson));
+
+const unresolvedThreads =
+  threadsParsed.data.repository.pullRequest.reviewThreads.nodes.filter(
+    (t) => !t.isResolved
+  );
+
+const prComments = {
+  issue_comments: prView.comments.map((c) => ({
+    author: c.author?.login ?? "unknown",
+    body: c.body,
+    createdAt: c.createdAt,
+  })),
+  review_summaries: reviews
+    .filter((r) => r.body && r.body.trim().length > 0)
+    .map((r) => ({
+      author: r.user?.login ?? "unknown",
+      state: r.state,
+      body: r.body,
+      submittedAt: r.submitted_at,
+    })),
+  review_threads: unresolvedThreads.flatMap((t) =>
+    t.comments.nodes.map((c) => ({
+      commentId: c.id,
+      threadId: t.id,
+      path: c.path,
+      line: c.line ?? c.originalLine,
+      author: c.author?.login ?? "unknown",
+      body: c.body,
+    }))
+  ),
+};
+
+const result = await sandcastle.run({
+  name: `implement-pr-${PR_NUMBER}`,
+  agent: sandcastle.claudeCode("claude-opus-4-6", {
+    env: {
+      CLAUDE_CODE_OAUTH_TOKEN: required("CLAUDE_CODE_OAUTH_TOKEN"),
+    },
+  }),
+  sandbox: noSandbox(),
+  logging: { type: "stdout" },
+  promptFile: path.join(import.meta.dirname, "prompt.md"),
+  promptArgs: {
+    PR_NUMBER,
+    BRANCH,
+    ISSUE_NUMBER: ISSUE_NUMBER || "(none)",
+    ISSUE_TITLE: ISSUE_TITLE || "(no linked issue)",
+    PR_COMMENTS_JSON: JSON.stringify(prComments, null, 2),
+  },
+  output: sandcastle.Output.object({
+    tag: "output",
+    schema: ImplementPrOutput,
+  }),
+});
+
+const commitsThisRun = result.commits.length;
+const replyCount =
+  result.output.threadReplies.length +
+  result.output.newInlineComments.length +
+  result.output.topLevelComments.length;
+
+if (commitsThisRun === 0 && replyCount === 0) {
+  fail(
+    "Agent produced no commits and no replies — nothing to do for the unresolved feedback."
+  );
+}
+
+const headSha = sh("git rev-parse HEAD").trim();
+const diffLines = parseDiffLines(safeSh("git diff main...HEAD"));
+const validInlineComments = result.output.newInlineComments.filter((c) => {
+  const fileLines = diffLines.get(c.path);
+  if (!fileLines) {
+    console.warn(
+      `Dropping inline comment for ${c.path}:${c.line} — file not in diff.`
+    );
+    return false;
+  }
+  if (!fileLines.has(c.line)) {
+    console.warn(
+      `Dropping inline comment for ${c.path}:${c.line} — line not in diff hunks.`
+    );
+    return false;
+  }
+  return true;
+});
+
+const validReplyIds = new Set(
+  prComments.review_threads.map((c) => c.commentId)
+);
+const validThreadReplies = result.output.threadReplies.filter((r) => {
+  if (!validReplyIds.has(r.commentId)) {
+    console.warn(
+      `Dropping reply for commentId=${r.commentId} — not in fetched threads.`
+    );
+    return false;
+  }
+  return true;
+});
+
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "implement_thread_replies.json"),
+  JSON.stringify(validThreadReplies, null, 2)
+);
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "implement_new_inline_comments.json"),
+  JSON.stringify(
+    {
+      commit_id: headSha,
+      comments: validInlineComments.map((c) => ({
+        path: c.path,
+        line: c.line,
+        side: c.side,
+        body: c.body,
+      })),
+    },
+    null,
+    2
+  )
+);
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "implement_top_level_comments.json"),
+  JSON.stringify(result.output.topLevelComments, null, 2)
+);
+fs.writeFileSync(
+  path.join(OUTPUT_DIR, "has_commits.txt"),
+  commitsThisRun > 0 ? "true" : "false"
+);
+
+console.log(`\nImplement-PR complete.`);
+console.log(`  commits this run: ${commitsThisRun}`);
+console.log(`  thread replies: ${validThreadReplies.length}`);
+console.log(`  new inline comments: ${validInlineComments.length}`);
+console.log(`  top-level comments: ${result.output.topLevelComments.length}`);
+
+function sh(cmd: string): string {
+  return execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function safeSh(cmd: string): string {
+  try {
+    return sh(cmd);
+  } catch {
+    return "";
+  }
+}
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function fail(message: string): never {
+  console.error(`\nFAILED: ${message}`);
+  fs.writeFileSync(path.join(OUTPUT_DIR, "failure_reason.txt"), message);
+  process.exit(1);
+}

--- a/.sandcastle/implement-pr/prompt.md
+++ b/.sandcastle/implement-pr/prompt.md
@@ -1,0 +1,107 @@
+# TASK
+
+You are addressing reviewer feedback on PR #{{PR_NUMBER}} (branch `{{BRANCH}}`).
+
+Unlike a review, your job is **not** to compare the code against a spec or coding standards. Your job is to read the unresolved conversation on this PR, decide what (if anything) to change in the code, make those changes, and explain yourself by commenting back where useful.
+
+# CONTEXT
+
+Read `CONTEXT.md` and any relevant ADRs under `docs/adr/` if you need domain context for a comment. Don't go deeper than the comments demand.
+
+<linked-issue>
+
+!`gh issue view {{ISSUE_NUMBER}} --comments`
+
+</linked-issue>
+
+<diff-to-main>
+
+!`git diff main..HEAD`
+
+</diff-to-main>
+
+<pr-comments>
+
+The unresolved conversation on this PR. Tagged by surface:
+
+- `issue_comment` — top-level PR conversation comment.
+- `review_thread` — inline thread anchored to a file + line. Only **unresolved** threads are included. Each comment has a `commentId` you can reply to in-thread.
+- `review_summary` — top-level body of a submitted review.
+
+Not everything in here is necessarily actionable — reviewers may leave context, questions, asides, or things they meant to resolve. Use your judgement. **Do not treat unresolved == must-action.**
+
+```json
+{{PR_COMMENTS_JSON}}
+```
+
+</pr-comments>
+
+# PROCESS
+
+1. Read the conversation. For each item, classify it in your head as: code change needed, reply needed (question / disagreement / clarification), or neither.
+2. Make the code changes you decided on. Run `npm run typecheck` and `npm run test` before committing. Use conventional-commit messages (`feat:`, `fix:`, `refactor:`, etc.). Do NOT use a `RALPH:` prefix.
+3. If you made no changes that's fine — only commit when there's a real diff.
+4. Emit the structured output below describing the replies and any new inline comments you want posted.
+
+You do not have to reply to every thread. Reply only where a reply adds value: confirming what you changed, explaining why you chose not to make a requested change, answering a question, or pointing out something the reviewer should look at. Silence is fine for context-only comments.
+
+You cannot resolve threads. Resolution is the reviewer's job.
+
+# OUTPUT
+
+Emit a single `<output>` block as the **last thing** in your response. Valid JSON, field names exact.
+
+## Example
+
+<output>
+{
+  "threadReplies": [
+    {
+      "commentId": "PRRC_kwDOPSEf9c8AAAABX1234",
+      "body": "Good catch — fixed in the latest commit by adding the early-return guard."
+    },
+    {
+      "commentId": "PRRC_kwDOPSEf9c8AAAABX5678",
+      "body": "I'd push back on this one — renaming `calcVal` to `calculateDiscount` would conflict with the `calcVal` convention used elsewhere in this file. Happy to do it as a follow-up across the whole file if you want."
+    }
+  ],
+  "newInlineComments": [
+    {
+      "path": "app/services/auth.ts",
+      "line": 87,
+      "body": "Heads up — while addressing the thread above I also tightened the guard on line 85. Flagging in case it affects the test you mentioned."
+    }
+  ],
+  "topLevelComments": [
+    {
+      "body": "Addressed 2 of 3 threads. Left the third (about the helper rename) for a separate PR — explained inline."
+    }
+  ]
+}
+</output>
+
+## Empty output (rare)
+
+If you made no code changes and have nothing to say, emit:
+
+<output>
+{ "threadReplies": [], "newInlineComments": [], "topLevelComments": [] }
+</output>
+
+The workflow will mark the run as blocked if both the diff and all reply arrays are empty — that's a degenerate run.
+
+## Field reference
+
+| Field                       | Type    | Required | Notes                                                                                                         |
+| --------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------- |
+| `threadReplies`             | array   | no       | Replies posted in an existing unresolved review thread.                                                       |
+| `threadReplies[].commentId` | string  | **yes**  | Must be a `commentId` from a `review_thread` in `<pr-comments>`. Do not invent IDs.                           |
+| `threadReplies[].body`      | string  | **yes**  | Markdown reply.                                                                                               |
+| `newInlineComments`         | array   | no       | New inline comments on lines in the diff (not replies). Use only when a thread reply isn't the right surface. |
+| `newInlineComments[].path`  | string  | **yes**  | Relative file path.                                                                                           |
+| `newInlineComments[].line`  | integer | **yes**  | Single line number in the post-commit HEAD. The workflow drops anchors that aren't in the diff.               |
+| `newInlineComments[].body`  | string  | **yes**  | Markdown.                                                                                                     |
+| `topLevelComments`          | array   | no       | New top-level PR conversation comments. Use for cross-cutting summaries or comments not tied to a thread.     |
+| `topLevelComments[].body`   | string  | **yes**  | Markdown.                                                                                                     |
+
+Do not add fields not listed above.

--- a/docs/agents/queued-promotion.md
+++ b/docs/agents/queued-promotion.md
@@ -1,0 +1,40 @@
+# Queued Promotion
+
+The `agent:queued` label marks an issue as "ready for agent work, but waiting on its blockers." When the last blocker closes, `.github/workflows/agent-promote-queued.yml` flips the label to `agent:implement`, which triggers the normal `agent-implement.yml` flow.
+
+## Trigger
+
+The workflow listens for `issues: closed` events — regardless of whether the close came from a merged PR (via `Closes #N`), a manual close, or `gh issue close`. Closes with `state_reason == 'not_planned'` (wontfix) are skipped: a wontfix'd blocker is not a meaningful completion signal.
+
+## Dependency model
+
+Blockers are read from GitHub's native issue dependency relation — the "blocked by" / "blocks" feature, queried via the GraphQL `blocking` and `blockedBy` connections on `Issue`.
+
+The workflow does **not**:
+
+- Parse "Blocked by #N" or "Depends on #N" prose from issue bodies.
+- Treat the sub-issue / parent relation as a blocking relation.
+
+## Application
+
+`agent:queued` is **applied manually by a human**. There is no guard workflow on `agent:implement` that downgrades blocked issues to `agent:queued` — if you slap `agent:implement` on an issue whose dependencies aren't done, the agent run will happen and likely fail or produce a broken PR. Apply `agent:queued` yourself when you know an issue is waiting.
+
+## Behavior per dependent
+
+When a blocker `X` closes, the workflow walks `X.blocking` (the dependents) and for each open issue `Y`:
+
+| Y's state                                        | Action                                                                                                                                               |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Missing `agent:queued`                           | Silent skip.                                                                                                                                         |
+| Has `agent:in-progress`                          | Silent skip — a run is already going.                                                                                                                |
+| Is a sub-issue of another issue                  | Refuse: remove `agent:queued`, add `agent:blocked`, comment explaining `agent:queued` is not meaningful on sub-issues; label the parent PRD instead. |
+| Still has other open blockers                    | Silent skip — wait for the last one to close. No comment (the GitHub UI already shows remaining blockers).                                           |
+| No remaining open blockers, still `agent:queued` | Remove `agent:queued`, comment "Unblocked by #N closing — promoting…", add `agent:implement`.                                                        |
+
+## Race handling
+
+Two blockers closing within seconds will fire two parallel workflow runs. There is no concurrency group — instead, the flip step re-fetches `Y`'s labels immediately before mutating, and silently exits if `agent:queued` has already been removed. The downstream `agent-implement.yml` has its own preflight (refuses if an open PR exists for `Y`), so duplicate triggers land safely.
+
+## `AGENT_PAT` and downstream triggering
+
+Labels added via `GITHUB_TOKEN` do not fire downstream workflows. The promotion step uses `AGENT_PAT` when present, falling back to `GITHUB_TOKEN`. In the fallback path, the `agent:implement` label lands but `agent-implement.yml` will not auto-trigger — a human will need to re-add the label.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -13,3 +13,16 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
 Edit the right-hand column to match whatever vocabulary you actually use.
+
+## Agent state labels
+
+The `agent:*` labels track an issue's position in the AFK-agent workflow:
+
+| Label               | Meaning                                                                                                                                                     |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent:implement`   | Ready for the implement workflow to run.                                                                                                                    |
+| `agent:queued`      | Ready for agent work, but waiting on declared native GitHub blockers. Auto-promotes when blockers clear — see [queued-promotion.md](./queued-promotion.md). |
+| `agent:in-progress` | An implement run is currently active.                                                                                                                       |
+| `agent:review`      | PR is ready for the automated review workflow.                                                                                                              |
+| `agent:blocked`     | A run failed or was refused; needs human attention before retry.                                                                                            |
+| `agent:to-issues`   | PRD is ready to be decomposed into sub-issues.                                                                                                              |


### PR DESCRIPTION
## Summary

- Adds `agent:queued` label semantics: a manually-applied label meaning "ready for agent work, but waiting on declared blockers".
- New `agent-promote-queued.yml` workflow listens for `issues: closed`, walks the native GitHub `blocking` connection, and flips `agent:queued` → `agent:implement` on dependents whose blockers have all cleared.
- Skips `not_planned` (wontfix) closes, refuses sub-issues with an explanatory comment, idempotent against concurrent races, uses `AGENT_PAT` so the promoted label fires `agent-implement.yml`.
- Documents the label in `docs/agents/triage-labels.md` and the workflow in a new `docs/agents/queued-promotion.md`.

Closes #885

## Test plan

- [ ] Create a test issue `Y` with `agent:queued` and a native "blocked by" relation to a test issue `X`.
- [ ] Close `X` — confirm `Y` gets a promotion comment, loses `agent:queued`, gains `agent:implement`, and triggers `agent-implement.yml`.
- [ ] Repeat with `Y` having two blockers; close one — confirm silent skip; close the other — confirm promotion.
- [ ] Close a blocker as `not planned` — confirm no promotion.
- [ ] Make `Y` a sub-issue of a PRD and apply `agent:queued` — close blocker — confirm sub-issue refusal comment + label flip to `agent:blocked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)