### PR TITLE
Power agent-review with the `review` skill

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -61,6 +61,14 @@ jobs:
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
+      # Install Matt's `review` skill globally (~/.claude/skills), always at
+      # latest — every run exercises the current version of the skill. Global
+      # (not project) install keeps it outside the git work tree so the review
+      # agent's commit step can never sweep it into the PR branch. Scoped to the
+      # claude-code agent so the step exits 0 (other agents reject -g installs).
+      - name: Install review skill
+        run: npx --yes skills@latest add mattpocock/skills -g -s review -a claude-code -y --copy
+
       - name: Configure git identity
         run: |
           git config user.name "claude-code[bot]"

--- a/.sandcastle/review/prompt.md
+++ b/.sandcastle/review/prompt.md
@@ -36,49 +36,27 @@ The following PR comments have been fetched by the workflow. They are tagged by 
 
 # REVIEW PROCESS
 
-## 1. Read the diff carefully
+## 1. Analyse with the `review` skill
 
-For anything that looks suspicious — fragile logic, unchecked assumptions, tricky conditions, implicit type coercions, missing guards — write a test that exercises it. Try to actually break it. If you can break it, fix it.
+Use the **`review` skill** (installed globally at `~/.claude/skills/review`) to produce the review. It analyses the diff along two axes — **Standards** and **Spec** — using parallel sub-agents. Its findings are the **single source of truth** for what's wrong with this branch: act only on what it reports, not on a separate ad-hoc pass of your own.
 
-## 2. Verify the change matches the spec
+Invoke it with everything it needs, so it does **not** run its own discovery and does **not** prompt or pause:
 
-The linked issue (above, in `<linked-issue>`) is the spec. Read it carefully and check:
+- **Fixed point:** `main`. The diff to review is `git diff main...HEAD`. Do not ask for a fixed point — it is `main`.
+- **Spec:** issue #{{ISSUE_NUMBER}} — already fetched above in `<linked-issue>`. Pass this as the spec. Do **not** look for `docs/agents/issue-tracker.md` and do **not** run `/setup-matt-pocock-skills`; the spec is provided. If the linked issue is a **PRD** (it has sub-issues), pull them with `gh api repos/$GH_REPO/issues/{{ISSUE_NUMBER}}/sub_issues` and treat each closed sub-issue as a sub-requirement; code for an _open_ sub-issue is a scope violation.
+- **Standards:** `.sandcastle/CODING_STANDARDS.md` is this repo's documented standard — feed it as the standards source. The skill's built-in smell baseline applies on top, but a documented repo standard always wins.
 
-- **Coverage:** does the diff actually do what the issue asked for? Walk through the issue's stated outcomes and find each one in the code. Note any stated outcome you can't locate.
-- **Scope:** does the diff do anything the issue didn't ask for? Unrequested refactors, drive-by changes, scope creep — flag them.
-- **Interpretation:** does the implementation interpret the spec sensibly? If a requirement was ambiguous, did it pick a reasonable reading? If you'd have implemented it differently in a way that better serves the stated goal, say so.
+The skill is read-only and produces a report; it does not edit code. That report — its Standards findings and its Spec findings — is your worklist for the steps below.
 
-If the linked issue is a **PRD** (it has sub-issues), treat the PRD body as the overall intent and each sub-issue as a sub-requirement. Pull the sub-issues with `gh api repos/$GH_REPO/issues/{{ISSUE_NUMBER}}/sub_issues` and verify every closed sub-issue is reflected in the diff. Open sub-issues should _not_ be implemented in this PR — if you see code for an open sub-issue, that's a scope violation.
+## 2. Act on the skill's findings
 
-Findings here go into the `summary` and (where line-anchored) the inline comments. Don't silently "fix" missing spec coverage by adding code yourself — call it out for the human reviewer to decide whether to fold it in or open a follow-up.
+Work through the skill's findings and resolve each one on this branch:
 
-## 3. Stress-test edge cases
+- For any **correctness/robustness** finding, write a test that exercises it and try to actually break it. If you can break it, fix it. Cover the edge cases the skill flagged (empty/zero/negative inputs, missing optional fields, null/undefined, off-by-one, races, regressions in adjacent code).
+- For any **quality/standards** finding, improve the code: reduce nesting, eliminate redundancy, improve names, consolidate related logic, drop comments that restate obvious code, avoid nested ternaries (prefer if/else or switch), choose clarity over brevity. Apply `.sandcastle/CODING_STANDARDS.md`.
+- For any **spec** finding (missing coverage, scope creep, misinterpretation), do **not** silently "fix" missing spec coverage by adding code yourself — call it out in the `summary` and (where line-anchored) the inline comments for the human reviewer to decide.
 
-- Empty arrays, empty strings, zero, negative numbers
-- Missing optional fields, null values, undefined properties
-- Rapid repeated calls, race conditions, state that changes mid-operation
-- Off-by-one errors in loops or slice/substring operations
-- Regressions in adjacent functionality
-
-Write tests for anything that isn't already covered.
-
-## 4. Improve code quality
-
-- Reduce nesting and unnecessary complexity
-- Eliminate redundant code and abstractions
-- Improve names
-- Consolidate related logic
-- Remove comments that describe obvious code
-- Avoid nested ternaries — prefer if/else chains or switch
-- Choose clarity over brevity
-
-## 5. Preserve functionality
-
-Never change what the code does — only how it does it. All original features, outputs, and behaviors must remain intact.
-
-## 6. Apply project standards
-
-Follow `.sandcastle/CODING_STANDARDS.md`.
+**Preserve functionality.** When improving code, never change what it does — only how it does it. All original features, outputs, and behaviours must remain intact.
 
 # RESPONDING TO HUMAN COMMENTS
 


### PR DESCRIPTION
## What

Makes the `agent:review` workflow's review reasoning come from Matt's **`review` skill** (two-axis Standards + Spec) instead of the hand-written `REVIEW PROCESS` steps in the review prompt. Motivation: exercise the `review` skill robustly against real PRs.

The workflow's **shape is unchanged** — same `RALPH: Review -` squashed commit + force-with-lease push, same inline-comment/reply posting, same `ReviewOutput` schema. Only *where the review thinking comes from* changes.

## Changes

- **`.github/workflows/agent-review.yml`** — new step installs the `review` skill globally each run, always at latest:
  ```
  npx --yes skills@latest add mattpocock/skills -g -s review -a claude-code -y --copy
  ```
  - **Always-latest** → every run tests the current skill.
  - **Global** (`~/.claude/skills`, outside the git work tree) → the review agent's commit step can't sweep the skill into the PR branch.
  - **Scoped to `claude-code`** → step exits 0 (other agents reject `-g` installs and would fail the step).

- **`.sandcastle/review/prompt.md`** — `REVIEW PROCESS` rewritten:
  - **Step 1** runs the `review` skill, fed everything so it skips its own discovery and never pauses: fixed-point=`main`, spec=linked issue (already fetched), standards=`.sandcastle/CODING_STANDARDS.md`, and an explicit instruction *not* to look for `docs/agents/issue-tracker.md` or run `/setup-matt-pocock-skills`.
  - **Step 2** acts **only** on the skill's findings (the skill is the single source of "what's wrong") — write breaking tests + fix, improve quality, flag spec gaps for the human. The agent does not run a separate ad-hoc analysis pass.

## Verified before opening

- `npx skills add mattpocock/skills -g -s review -a claude-code -y --copy` installs to `~/.claude/skills/review/` and **exits 0** (tested in a throwaway `HOME`).
- `review` skill is present on `mattpocock/skills` **`origin/main`** (the branch `npx skills add` pulls).
- Sandcastle runs Claude Code with `dangerouslySkipPermissions` and captures sub-agent transcripts, so the skill's two parallel sub-agents spawn in CI.
- `review.ts` loads `.sandcastle/review/prompt.md` (not the legacy top-level `review-prompt.md`); all `{{…}}` placeholders it injects are preserved.
- Workflow YAML validates; typecheck/lint-staged passed on commit.

## Notes / trade-offs

- The skill's two-axis structure **collapses into the flat `summary`** (existing schema) — it's not surfaced separately on the PR. Inspect the skill's raw output via sandcastle's captured sub-agent transcripts.
- No new CI artifact and no per-repo skill config (`docs/agents/issue-tracker.md`) added — the workflow already fetches the issue and feeds it to the skill, so the skill's own spec-discovery is bypassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)