### PR TITLE
ci(architecture-review): skip run when 10+ open backlog issues

### DIFF
--- a/.github/workflows/architecture-review.yml
+++ b/.github/workflows/architecture-review.yml
@@ -7,7 +7,37 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-backlog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: read
+    outputs:
+      proceed: ${{ steps.count.outputs.proceed }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Count open architecture-review issues
+        id: count
+        env:
+          LABEL: source:architecture-review
+        run: |
+          set -euo pipefail
+          # Only care whether the backlog is below 10, so a limit of 10 is enough
+          # to detect the threshold; the true count may be higher.
+          open=$(gh issue list --state open --label "$LABEL" --limit 10 --json number --jq 'length')
+          echo "Found $open open '$LABEL' issue(s) (counted up to 10)."
+          if [ "$open" -lt 10 ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "Backlog has 10+ open '$LABEL' issues — skipping this run." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   architecture-review:
+    needs: check-backlog
+    if: needs.check-backlog.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:


### PR DESCRIPTION
## What

The Architecture Review workflow opens a new PRD issue (labelled `source:architecture-review`) on each scheduled run. This adds a gate so it only runs when **fewer than 10** such issues are currently open, preventing the backlog from growing unbounded while older proposals go unaddressed.

## How

- New `check-backlog` job (needs only `issues: read`) counts open issues with the `source:architecture-review` label via `gh issue list`, capped at a limit of 10 since we only need to know whether the threshold is reached.
- It exports `proceed=true`/`false`.
- The existing `architecture-review` job now `needs: check-backlog` and runs only `if: needs.check-backlog.outputs.proceed == 'true'`.
- When skipped, a note is written to the job summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)