### PR TITLE
fix(cli): emit a uniform `name` on every list

### DIFF
--- a/app/cli/cli-integration.test.ts
+++ b/app/cli/cli-integration.test.ts
@@ -415,6 +415,55 @@ describe("output contract: NDJSON / single object / empty", () => {
 });
 
 // ===========================================================================
+// Uniform `name` on list output
+// ===========================================================================
+
+describe("uniform display name on every list", () => {
+  const nameOf = (stdout: string) =>
+    (ndjson(stdout) as { id: string; name: string | null }[]).map((r) => [
+      r.id,
+      r.name,
+    ]);
+
+  it("section list carries name mirroring path", async () => {
+    const { stdout, exitCode } = await run([
+      "section",
+      "list",
+      "--course",
+      s.courseAId,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(nameOf(stdout)).toContainEqual([s.draftSectionId, "01-intro"]);
+  });
+
+  it("lesson list carries name = title", async () => {
+    const { stdout, exitCode } = await run([
+      "lesson",
+      "list",
+      "--section",
+      s.draftSectionId,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(nameOf(stdout)).toContainEqual([s.lessonId, "Welcome"]);
+  });
+
+  it("video list carries name mirroring path", async () => {
+    const { stdout, exitCode } = await run(["video", "list"]);
+    expect(exitCode).toBe(0);
+    expect(nameOf(stdout)).toContainEqual([
+      s.standaloneActiveId,
+      "standalone-active.mp4",
+    ]);
+  });
+
+  it("pitch list carries name = title (the noun the report was about)", async () => {
+    const { stdout, exitCode } = await run(["pitch", "list"]);
+    expect(exitCode).toBe(0);
+    expect(nameOf(stdout)).toContainEqual([s.pitchActiveId, "Active pitch"]);
+  });
+});
+
+// ===========================================================================
 // Error -> exit code mapping
 // ===========================================================================
 

--- a/app/cli/commands/deliverable.ts
+++ b/app/cli/commands/deliverable.ts
@@ -1,7 +1,7 @@
 import { Args, Command } from "@effect/cli";
 import { Effect } from "effect";
 import { DeliverableOperationsService } from "@/services/db-deliverable-operations.server";
-import { detail, emitGet, emitNdjson } from "@/cli/helpers";
+import { detail, emitGet, emitNdjson, withName } from "@/cli/helpers";
 
 // ---------------------------------------------------------------------------
 // Help text — domain-teaching prose (keep in sync with CONTEXT.md,
@@ -55,6 +55,8 @@ const LIST_HELP = `List the FULL set of active (non-archived) Deliverables.
 Output: NDJSON — one compact JSON object per line (nothing at all when empty).
 Each line is identity-rich so an agent can map title/date -> id in one call:
   - id          — Deliverable id (use with 'cvm deliverable get').
+  - name        — uniform display label (mirrors title); every noun's 'list'
+                  carries 'name' so you never need to guess the label field.
   - title       — the Deliverable's headline.
   - date        — the all-day date it is pinned to (YYYY-MM-DD).
   - status      — Deliverable Status: planned | done | cancelled (see below).
@@ -105,11 +107,11 @@ const shape = (row: {
   readonly deliverablesPitches: ReadonlyArray<{ pitchId: string }>;
 }) => {
   const { deliverablesCourses, deliverablesPitches, ...rest } = row;
-  return {
+  return withName({
     ...rest,
     courseIds: deliverablesCourses.map((c) => c.courseId),
     pitchIds: deliverablesPitches.map((p) => p.pitchId),
-  };
+  });
 };
 
 // ---------------------------------------------------------------------------

--- a/app/cli/commands/lesson.ts
+++ b/app/cli/commands/lesson.ts
@@ -9,6 +9,7 @@ import {
   emitObject,
   notFound,
   parseError,
+  withName,
 } from "@/cli/helpers";
 
 /**
@@ -68,8 +69,11 @@ EXAMPLES
 const LIST_HELP = `List every ACTIVE lesson in a Section (the complete set, not a UI-bounded slice).
 
 Requires --section <id>. Output is NDJSON, one compact lesson object per line,
-ordered by the lesson's 'order'. Each line is identity-rich (id, title, path,
-sectionId) plus fsStatus / authoringStatus so an agent can map a name to an id
+ordered by the lesson's 'order'. Each line is identity-rich (id, name, title,
+path, sectionId) plus fsStatus / authoringStatus so an agent can map a name to an
+id. 'name' is the uniform display label every noun's 'list' carries (for a lesson
+it is the title, falling back to path when the title is empty), so you never have
+to guess the label field. An agent can map a name to an id
 and judge real-vs-ghost / todo-vs-done in one call. Archived lessons are never
 included. Empty section => no output, exit 0.
 
@@ -124,7 +128,7 @@ const listCmd = Command.make("list", { section }, ({ section }) =>
   Effect.gen(function* () {
     const svc = yield* LessonSectionOperationsService;
     const rows = yield* svc.getLessonsBySectionId(section);
-    yield* emitNdjson(rows);
+    yield* emitNdjson(rows.map(withName));
   })
 ).pipe(Command.withDescription(detail(LIST_HELP)));
 

--- a/app/cli/commands/pitch.ts
+++ b/app/cli/commands/pitch.ts
@@ -4,7 +4,7 @@ import {
   PitchOperationsService,
   type PitchState,
 } from "@/services/db-pitch-operations.server";
-import { detail, emitGet, emitNdjson } from "@/cli/helpers";
+import { detail, emitGet, emitNdjson, withName } from "@/cli/helpers";
 
 // ---------------------------------------------------------------------------
 // Help text — domain-teaching prose (keep in sync with CONTEXT.md, "Pitches").
@@ -59,6 +59,8 @@ Output: NDJSON — one compact JSON object per line (nothing at all when empty).
 Each line is identity-rich and carries the derived Pitch State, so an agent can
 map title -> id and read state in a single call:
   - id          — pitch id (use with 'cvm pitch get').
+  - name        — uniform display label (mirrors title); every noun's 'list'
+                  carries 'name' so you never need to guess the label field.
   - title       — the pitch title (packaging headline).
   - state       — derived Pitch State: idle | scheduled | shipped (see below).
   - priority    — triage rank (integer; lower sorts first).
@@ -130,7 +132,7 @@ const listCmd = Command.make("list", { state: stateOption }, ({ state }) =>
     const rows = yield* svc.listPitches(
       stateFilter ? { state: [stateFilter] } : undefined
     );
-    yield* emitNdjson(rows);
+    yield* emitNdjson(rows.map(withName));
   })
 ).pipe(Command.withDescription(detail(LIST_HELP)));
 

--- a/app/cli/commands/section.ts
+++ b/app/cli/commands/section.ts
@@ -8,6 +8,7 @@ import {
   emitObject,
   parseError,
   resolveVersionId,
+  withName,
 } from "@/cli/helpers";
 
 /**
@@ -66,7 +67,7 @@ EXAMPLES
   # Walk the structure, then drill into a lesson (flags come BEFORE the id):
   cvm section tree --depth all <sectionId> | jq '.children[].id'`;
 
-const LIST_HELP = `List ALL Sections of one Course Version (the complete set, never a UI-bounded subset), as NDJSON — one compact JSON object per line, ordered by 'order' ascending. Each line carries the section's identity (id, path, order, repoVersionId), so an agent can map a section name to its id in a single call. Lessons are NOT included — list goes one level deep; use 'section get <id>' or 'lesson list --section <id>' to drill in.
+const LIST_HELP = `List ALL Sections of one Course Version (the complete set, never a UI-bounded subset), as NDJSON — one compact JSON object per line, ordered by 'order' ascending. Each line carries the section's identity (id, name, path, order, repoVersionId), so an agent can map a section name to its id in a single call. 'name' is the uniform display label every noun's 'list' carries (for a section it mirrors 'path'), so you never have to guess the label field. Lessons are NOT included — list goes one level deep; use 'section get <id>' or 'lesson list --section <id>' to drill in.
 
 You MUST scope the read to a Version:
   --course-version <id>   pin a specific Course Version (Draft or Published).
@@ -143,7 +144,7 @@ const listCmd = Command.make(
       const svc = yield* ops;
       const repoVersionId = yield* resolveScopedVersion(version, course);
       const sections = yield* svc.getSectionsByRepoVersionId(repoVersionId);
-      yield* emitNdjson(sections);
+      yield* emitNdjson(sections.map(withName));
     })
 ).pipe(Command.withDescription(detail(LIST_HELP)));
 

--- a/app/cli/commands/video.ts
+++ b/app/cli/commands/video.ts
@@ -8,6 +8,7 @@ import {
   emitObject,
   notFound,
   parseError,
+  withName,
 } from "@/cli/helpers";
 import {
   formatProseTranscript,
@@ -60,6 +61,8 @@ nothing and exits 0.
 
 Key fields:
   id         the stable video id (use with get/tree/transcript)
+  name       uniform display label every noun's 'list' carries (mirrors 'path'),
+             so you never have to guess the label field
   path       the video's name within its lesson (its display/file name)
   pitchId    set when a Pitch packages this standalone video; else null
   archived   soft-delete flag (always false here unless --archived)
@@ -205,7 +208,7 @@ const listCmd = Command.make("list", { archived }, ({ archived }) =>
     const videos = archived
       ? yield* svc.getArchivedStandaloneVideos()
       : yield* svc.getAllStandaloneVideos();
-    yield* emitNdjson(videos);
+    yield* emitNdjson(videos.map(withName));
   })
 ).pipe(Command.withDescription(detail(LIST_HELP)));
 

--- a/app/cli/helpers.test.ts
+++ b/app/cli/helpers.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { displayName, withName } from "@/cli/helpers";
+
+describe("displayName — the uniform label of any row", () => {
+  it("prefers a real `name` (course/version shape)", () => {
+    expect(displayName({ name: "Alpha", title: "ignored" })).toBe("Alpha");
+  });
+
+  it("falls back to `title` when there is no name (pitch/deliverable/lesson)", () => {
+    expect(displayName({ title: "Active pitch" })).toBe("Active pitch");
+  });
+
+  it("falls back to `path` when there is neither name nor title (section/video)", () => {
+    expect(displayName({ path: "01-intro" })).toBe("01-intro");
+  });
+
+  it("prefers title over path (lesson with a title)", () => {
+    expect(displayName({ title: "Welcome", path: "01-welcome" })).toBe(
+      "Welcome"
+    );
+  });
+
+  it("treats an empty title as absent and falls through to path (bare ghost lesson)", () => {
+    expect(displayName({ title: "", path: "01-welcome" })).toBe("01-welcome");
+  });
+
+  it("ignores non-string / empty label fields", () => {
+    expect(displayName({ name: "", title: null, path: undefined })).toBeNull();
+    expect(displayName({ name: 42 })).toBeNull();
+  });
+
+  it("returns null for a row with no label-bearing field", () => {
+    expect(displayName({ id: "x" })).toBeNull();
+    expect(displayName(undefined)).toBeNull();
+  });
+});
+
+describe("withName — prepend a normalised name onto a row", () => {
+  it("adds `name` while preserving every existing field", () => {
+    const row = { id: "p1", title: "Active pitch", priority: 2 };
+    expect(withName(row)).toEqual({
+      name: "Active pitch",
+      id: "p1",
+      title: "Active pitch",
+      priority: 2,
+    });
+  });
+
+  it("never clobbers an existing real name", () => {
+    expect(withName({ id: "c1", name: "Alpha" }).name).toBe("Alpha");
+  });
+});

--- a/app/cli/helpers.ts
+++ b/app/cli/helpers.ts
@@ -45,6 +45,37 @@ export const detail = (text: string): HelpDoc.HelpDoc => {
 };
 
 // ---------------------------------------------------------------------------
+// Uniform display name
+// ---------------------------------------------------------------------------
+
+/**
+ * The single human-readable label of ANY row, regardless of noun.
+ *
+ * The CVM schema spells its label column differently per table — `name` on
+ * courses/versions, `title` on lessons/pitches/deliverables, `path` on
+ * sections/videos — so a flat `list` row exposes whichever raw column it
+ * happens to have and an agent that asks for `.name` gets nothing. `tree`
+ * already papers over this by synthesising a `name` per level; `displayName`
+ * is that same normalisation as a reusable function so flat `list` output can
+ * carry a uniform `name` too. Precedence mirrors the tree builders: a real
+ * `name`, else a non-empty `title`, else `path` (lesson: title-then-path).
+ *
+ * Returns null only when a row genuinely has no label-bearing field.
+ */
+export const displayName = (row: unknown): string | null => {
+  const r = (row ?? {}) as Record<string, unknown>;
+  const pick = (v: unknown): string | null =>
+    typeof v === "string" && v !== "" ? v : null;
+  return pick(r.name) ?? pick(r.title) ?? pick(r.path);
+};
+
+/** Spread `row` and prepend a normalised `name` (see {@link displayName}). */
+export const withName = <T>(row: T): T & { name: string | null } => ({
+  name: displayName(row),
+  ...row,
+});
+
+// ---------------------------------------------------------------------------
 // Output emitters
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`cvm pitch list` / `deliverable list` (and `section`/`lesson`/`video` list) returned rows with **no `name` field** — an agent asking for `.name` got `null`/undefined and had to fall back to `course tree`.

Root cause is a schema-level naming inconsistency: the human-readable label column is spelled differently per table:

| Noun | Label column |
|---|---|
| course, version | `name` |
| lesson, **pitch**, **deliverable** | `title` |
| section, video | `path` |

Only `tree` papered over this, synthesising a `name` per level. Flat `list` emitted the raw column verbatim, so `name` was absent on every noun except course/version.

## Fix

Normalise at the CLI distill layer (not a DB migration). A shared `displayName`/`withName` helper encodes the **same precedence the tree builders already use** — `name` → non-empty `title` → `path` — and is applied to the `list` emitters for **section, lesson, video, pitch, deliverable**. Each list now carries a populated `name` alongside its existing raw fields (`title`/`path` unchanged), so consumers get one predictable label key across every noun.

`get` output is intentionally left as-is for now; this targets the reported `list` symptom.

## Verified

- `npm run typecheck` clean.
- New unit tests for `displayName`/`withName` (precedence, empty-title fallthrough, null cases) + integration assertions that `name` is populated on section/lesson/video/pitch lists. All 42 tests pass.
- Smoke-tested against the live DB — every noun now emits a real `name` (e.g. lesson `name` = title, section `name` = path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)