### PR TITLE
fix(cvm): order `course list` deterministically by createdAt

### DIFF
--- a/app/services/db-course-operations-list-ordering.test.ts
+++ b/app/services/db-course-operations-list-ordering.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "@effect/vitest";
+import { beforeAll, beforeEach } from "vitest";
+import { Effect, Layer } from "effect";
+import { CourseOperationsService } from "@/services/db-course-operations.server";
+import { DrizzleService } from "@/services/drizzle-service.server";
+import {
+  createTestDb,
+  truncateAllTables,
+  type TestDb,
+} from "@/test-utils/pglite";
+import * as schema from "@/db/schema";
+
+let testDb: TestDb;
+let testLayer: Layer.Layer<CourseOperationsService>;
+
+beforeAll(async () => {
+  const result = await createTestDb();
+  testDb = result.testDb;
+
+  const drizzleLayer = Layer.succeed(DrizzleService, testDb as any);
+  testLayer = Layer.mergeAll(CourseOperationsService.Default).pipe(
+    Layer.provide(drizzleLayer)
+  );
+});
+
+beforeEach(async () => {
+  await truncateAllTables(testDb);
+});
+
+// Insert directly so createdAt is explicit — createCourse defaults it to now,
+// which is too coarse to assert an ordering on.
+const insertCourse = (opts: {
+  name: string;
+  slug: string;
+  filePath: string;
+  createdAt: Date;
+  archived?: boolean;
+}) =>
+  testDb
+    .insert(schema.courses)
+    .values({
+      name: opts.name,
+      slug: opts.slug,
+      filePath: opts.filePath,
+      createdAt: opts.createdAt,
+      archived: opts.archived ?? false,
+    })
+    .returning()
+    .then(([row]) => row!);
+
+describe("course list ordering", () => {
+  it.effect("getCourses orders active courses by createdAt, newest first", () =>
+    Effect.gen(function* () {
+      const middle = yield* Effect.promise(() =>
+        insertCourse({
+          name: "Middle",
+          slug: "middle",
+          filePath: "/tmp/middle",
+          createdAt: new Date("2020-01-01T00:00:00Z"),
+        })
+      );
+      const newest = yield* Effect.promise(() =>
+        insertCourse({
+          name: "Newest",
+          slug: "newest",
+          filePath: "/tmp/newest",
+          createdAt: new Date("2030-01-01T00:00:00Z"),
+        })
+      );
+      const oldest = yield* Effect.promise(() =>
+        insertCourse({
+          name: "Oldest",
+          slug: "oldest",
+          filePath: "/tmp/oldest",
+          createdAt: new Date("2010-01-01T00:00:00Z"),
+        })
+      );
+
+      const courseOps = yield* CourseOperationsService;
+      const courses = yield* courseOps.getCourses();
+
+      expect(courses.map((c) => c.id)).toEqual([
+        newest.id,
+        middle.id,
+        oldest.id,
+      ]);
+    }).pipe(Effect.provide(testLayer))
+  );
+
+  it.effect(
+    "getArchivedCourses orders archived courses by createdAt, newest first",
+    () =>
+      Effect.gen(function* () {
+        const older = yield* Effect.promise(() =>
+          insertCourse({
+            name: "Older archived",
+            slug: "older-archived",
+            filePath: "/tmp/older-archived",
+            createdAt: new Date("2010-01-01T00:00:00Z"),
+            archived: true,
+          })
+        );
+        const newer = yield* Effect.promise(() =>
+          insertCourse({
+            name: "Newer archived",
+            slug: "newer-archived",
+            filePath: "/tmp/newer-archived",
+            createdAt: new Date("2030-01-01T00:00:00Z"),
+            archived: true,
+          })
+        );
+
+        const courseOps = yield* CourseOperationsService;
+        const archived = yield* courseOps.getArchivedCourses();
+
+        expect(archived.map((c) => c.id)).toEqual([newer.id, older.id]);
+      }).pipe(Effect.provide(testLayer))
+  );
+});

--- a/app/services/db-course-operations.server.ts
+++ b/app/services/db-course-operations.server.ts
@@ -396,6 +396,7 @@ export const createCourseOperations = (db: Database) => {
     const result = yield* makeDbCall(() =>
       db.query.courses.findMany({
         where: eq(courses.archived, false),
+        orderBy: desc(courses.createdAt),
       })
     );
     return result;
@@ -418,6 +419,7 @@ export const createCourseOperations = (db: Database) => {
     const result = yield* makeDbCall(() =>
       db.query.courses.findMany({
         where: eq(courses.archived, true),
+        orderBy: desc(courses.createdAt),
       })
     );
     return result;


### PR DESCRIPTION
## Problem

`cvm course list` did not always order its output correctly. Both `getCourses` (active) and `getArchivedCourses` in `db-course-operations.server.ts` issued a `findMany` with only a `where` clause and **no `orderBy`**, so rows came back in Postgres heap order — non-deterministic and occasionally mis-ordered.

Every other noun's `list` command already orders deterministically in the DB with a key appropriate to its column type (sections/lessons numeric `asc(order)`, clips/segments byte-wise `varchar COLLATE "C"`, version/pitch/deliverable by explicit keys). `course` was the sole exception.

## Fix

Add `orderBy: desc(courses.createdAt)` to both list methods — the same convention already used by the sibling `getTopActiveCourses` in this file and by `version list`. Newest first, deterministic.

## Verification

- `cvm course list` / `cvm course list --archived` now return a stable, newest-first sequence.
- `npm run typecheck` passes.
- Audited the ordering of all other `list` commands (course, version, section, lesson, video, clip, segment, pitch, deliverable) — `course` was the only one missing an `orderBy`; the rest are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)