### PR TITLE
feat(cvm): write verbs for lesson/video/pitch + segment add --pitch

### DIFF
--- a/app/cli/cli-lesson-video-writes.test.ts
+++ b/app/cli/cli-lesson-video-writes.test.ts
@@ -1,0 +1,433 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  createTestDb,
+  truncateAllTables,
+  type TestDb,
+} from "@/test-utils/pglite";
+import {
+  buildWriteLayer,
+  makeRun,
+  ndjson,
+  one,
+  seedWrite,
+  type RunResult,
+  type WriteSeed,
+} from "./cli-write-test-harness";
+
+// ===========================================================================
+// cvm WRITE verbs — lesson create + video create/move/update
+// (Split from cli-integration.test.ts to stay under the per-file token budget.)
+// ===========================================================================
+
+let testDb: TestDb;
+let run: (argv: ReadonlyArray<string>) => Promise<RunResult>;
+
+beforeAll(async () => {
+  const result = await createTestDb();
+  testDb = result.testDb;
+  run = makeRun(buildWriteLayer(testDb));
+});
+
+let s: WriteSeed;
+beforeEach(async () => {
+  await truncateAllTables(testDb);
+  s = await seedWrite(testDb);
+});
+
+describe("lesson create (ghost)", () => {
+  interface Lesson {
+    id: string;
+    sectionId: string;
+    title: string;
+    path: string;
+    order: number;
+    fsStatus: string;
+    authoringStatus: string | null;
+    archived: boolean;
+  }
+
+  it("creates a ghost lesson appended to the section, echoing the row", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "lesson",
+      "create",
+      "--section",
+      s.draftSectionId,
+      "--title",
+      "Intro to Effect",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toMatch(/^\{\n/); // single pretty object, not NDJSON
+    const lesson = one<Lesson>(stdout);
+    expect(lesson.sectionId).toBe(s.draftSectionId);
+    expect(lesson.title).toBe("Intro to Effect");
+    expect(lesson.path).toBe("intro-to-effect"); // slugified
+    expect(lesson.fsStatus).toBe("ghost");
+    expect(lesson.authoringStatus).toBeNull(); // ghosts have no authoring status
+    expect(lesson.archived).toBe(false);
+    expect(lesson.order).toBeGreaterThan(1); // appended after the seed lesson
+    const list = ndjson(
+      (await run(["lesson", "list", "--section", s.draftSectionId])).stdout
+    ) as Lesson[];
+    expect(list.map((l) => l.id)).toContain(lesson.id);
+  });
+
+  it("--before places the new lesson before the anchor", async () => {
+    const before = one<Lesson>(
+      (
+        await run([
+          "lesson",
+          "create",
+          "--section",
+          s.draftSectionId,
+          "--title",
+          "Goes First",
+          "--before",
+          s.lessonId,
+        ])
+      ).stdout
+    );
+    const list = ndjson(
+      (await run(["lesson", "list", "--section", s.draftSectionId])).stdout
+    ) as Lesson[];
+    const ids = list.map((l) => l.id);
+    expect(ids.indexOf(before.id)).toBeLessThan(ids.indexOf(s.lessonId));
+  });
+
+  it("--after places the new lesson after the anchor", async () => {
+    const after = one<Lesson>(
+      (
+        await run([
+          "lesson",
+          "create",
+          "--section",
+          s.draftSectionId,
+          "--title",
+          "Goes After",
+          "--after",
+          s.lessonId,
+        ])
+      ).stdout
+    );
+    const list = ndjson(
+      (await run(["lesson", "list", "--section", s.draftSectionId])).stdout
+    ) as Lesson[];
+    const ids = list.map((l) => l.id);
+    expect(ids.indexOf(after.id)).toBeGreaterThan(ids.indexOf(s.lessonId));
+  });
+
+  it("both --before and --after => invalid input, exit 3", async () => {
+    const { exitCode, stdout, stderr } = await run([
+      "lesson",
+      "create",
+      "--section",
+      s.draftSectionId,
+      "--title",
+      "X",
+      "--before",
+      s.lessonId,
+      "--after",
+      s.lessonId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+    expect((JSON.parse(stderr.trim()) as { _tag: string })._tag).toBe(
+      "ParseError"
+    );
+  });
+
+  it("unknown section => NotFoundError(section), exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "lesson",
+      "create",
+      "--section",
+      "sec_missing",
+      "--title",
+      "X",
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "section"
+    );
+  });
+
+  it("unknown anchor => NotFoundError(lesson), exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "lesson",
+      "create",
+      "--section",
+      s.draftSectionId,
+      "--title",
+      "X",
+      "--before",
+      "les_missing",
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "lesson"
+    );
+  });
+
+  it("a slug that collides with an existing lesson => invalid input, exit 3", async () => {
+    await run([
+      "lesson",
+      "create",
+      "--section",
+      s.draftSectionId,
+      "--title",
+      "Duplicate",
+    ]);
+    const { exitCode, stdout } = await run([
+      "lesson",
+      "create",
+      "--section",
+      s.draftSectionId,
+      "--title",
+      "Duplicate",
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+});
+
+describe("video create / move / update", () => {
+  interface Video {
+    id: string;
+    path: string;
+    lessonId: string | null;
+    pitchId: string | null;
+    archived: boolean;
+  }
+  const vobj = (stdout: string): Video => one<Video>(stdout);
+
+  it("create --name (standalone) has no lesson or pitch parent", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "video",
+      "create",
+      "--name",
+      "New Standalone",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    const v = vobj(stdout);
+    expect(v.path).toBe("New Standalone");
+    expect(v.lessonId).toBeNull();
+    expect(v.pitchId).toBeNull();
+    expect(v.archived).toBe(false);
+  });
+
+  it("create --lesson attaches to the lesson", async () => {
+    const v = vobj(
+      (
+        await run([
+          "video",
+          "create",
+          "--name",
+          "02-part",
+          "--lesson",
+          s.lessonId,
+        ])
+      ).stdout
+    );
+    expect(v.lessonId).toBe(s.lessonId);
+    expect(v.pitchId).toBeNull();
+  });
+
+  it("create --pitch attaches to the pitch, name required and honored", async () => {
+    const v = vobj(
+      (
+        await run([
+          "video",
+          "create",
+          "--name",
+          "My Pitch Cut",
+          "--pitch",
+          s.pitchActiveId,
+        ])
+      ).stdout
+    );
+    expect(v.pitchId).toBe(s.pitchActiveId);
+    expect(v.lessonId).toBeNull();
+    expect(v.path).toBe("My Pitch Cut");
+  });
+
+  it("create with missing --name => invalid input, exit 3", async () => {
+    const { exitCode } = await run(["video", "create"]);
+    expect(exitCode).toBe(3);
+  });
+
+  it("create with both --lesson and --pitch => invalid input, exit 3", async () => {
+    const { exitCode, stdout } = await run([
+      "video",
+      "create",
+      "--name",
+      "X",
+      "--lesson",
+      s.lessonId,
+      "--pitch",
+      s.pitchActiveId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("create --lesson with unknown lesson => NotFoundError(lesson), exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "video",
+      "create",
+      "--name",
+      "X",
+      "--lesson",
+      "les_missing",
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "lesson"
+    );
+  });
+
+  it("create --pitch with unknown pitch => NotFoundError(pitch), exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "video",
+      "create",
+      "--name",
+      "X",
+      "--pitch",
+      "pit_missing",
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "pitch"
+    );
+  });
+
+  it("create --lesson with a name already taken in the lesson => invalid input, exit 3", async () => {
+    // s.lessonVideoId already has path "intro.mp4" in the lesson.
+    const { exitCode, stdout } = await run([
+      "video",
+      "create",
+      "--name",
+      "intro.mp4",
+      "--lesson",
+      s.lessonId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("move re-homes a standalone video into a lesson", async () => {
+    const moved = vobj(
+      (
+        await run([
+          "video",
+          "move",
+          "--lesson",
+          s.lessonId,
+          s.standaloneActiveId,
+        ])
+      ).stdout
+    );
+    expect(moved.id).toBe(s.standaloneActiveId);
+    expect(moved.lessonId).toBe(s.lessonId);
+    expect(moved.pitchId).toBeNull();
+  });
+
+  it("move to a pitch clears any lesson parent (single-parent invariant)", async () => {
+    const moved = vobj(
+      (
+        await run([
+          "video",
+          "move",
+          "--pitch",
+          s.pitchActiveId,
+          s.lessonVideoId,
+        ])
+      ).stdout
+    );
+    expect(moved.id).toBe(s.lessonVideoId);
+    expect(moved.pitchId).toBe(s.pitchActiveId);
+    expect(moved.lessonId).toBeNull(); // lesson association cleared
+  });
+
+  it("move with neither --lesson nor --pitch => invalid input, exit 3", async () => {
+    const { exitCode } = await run(["video", "move", s.standaloneActiveId]);
+    expect(exitCode).toBe(3);
+  });
+
+  it("move with both --lesson and --pitch => invalid input, exit 3", async () => {
+    const { exitCode } = await run([
+      "video",
+      "move",
+      "--lesson",
+      s.lessonId,
+      "--pitch",
+      s.pitchActiveId,
+      s.standaloneActiveId,
+    ]);
+    expect(exitCode).toBe(3);
+  });
+
+  it("move an unknown video => NotFoundError(video), exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "video",
+      "move",
+      "--lesson",
+      s.lessonId,
+      "vid_missing",
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "video"
+    );
+  });
+
+  it("move into a lesson where the name is taken => invalid input, exit 3", async () => {
+    // Rename the standalone video to collide with the existing lesson video,
+    // then try to move it into that lesson.
+    await run(["video", "update", "--name", "intro.mp4", s.standaloneActiveId]);
+    const { exitCode, stdout } = await run([
+      "video",
+      "move",
+      "--lesson",
+      s.lessonId,
+      s.standaloneActiveId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("update --name renames the video, echoing the row", async () => {
+    const updated = vobj(
+      (
+        await run([
+          "video",
+          "update",
+          "--name",
+          "renamed.mp4",
+          s.standaloneActiveId,
+        ])
+      ).stdout
+    );
+    expect(updated.id).toBe(s.standaloneActiveId);
+    expect(updated.path).toBe("renamed.mp4");
+  });
+
+  it("update with no --name => invalid input, exit 3", async () => {
+    const { exitCode } = await run(["video", "update", s.standaloneActiveId]);
+    expect(exitCode).toBe(3);
+  });
+
+  it("update an unknown video => NotFoundError(video), exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "video",
+      "update",
+      "--name",
+      "x",
+      "vid_missing",
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "video"
+    );
+  });
+});

--- a/app/cli/cli-lesson-video-writes.test.ts
+++ b/app/cli/cli-lesson-video-writes.test.ts
@@ -256,6 +256,12 @@ describe("video create / move / update", () => {
     expect(exitCode).toBe(3);
   });
 
+  it("create with an empty --name => invalid input, exit 3", async () => {
+    const { exitCode, stdout } = await run(["video", "create", "--name", "  "]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
   it("create with both --lesson and --pitch => invalid input, exit 3", async () => {
     const { exitCode, stdout } = await run([
       "video",
@@ -415,6 +421,18 @@ describe("video create / move / update", () => {
   it("update with no --name => invalid input, exit 3", async () => {
     const { exitCode } = await run(["video", "update", s.standaloneActiveId]);
     expect(exitCode).toBe(3);
+  });
+
+  it("update with an empty --name => invalid input, exit 3", async () => {
+    const { exitCode, stdout } = await run([
+      "video",
+      "update",
+      "--name",
+      "  ",
+      s.standaloneActiveId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
   });
 
   it("update an unknown video => NotFoundError(video), exit 2", async () => {

--- a/app/cli/cli-pitch-segment-writes.test.ts
+++ b/app/cli/cli-pitch-segment-writes.test.ts
@@ -108,6 +108,17 @@ describe("pitch create / update", () => {
     expect(exitCode).toBe(3);
   });
 
+  it("create with an empty --title => invalid input, exit 3", async () => {
+    const { exitCode, stdout } = await run([
+      "pitch",
+      "create",
+      "--title",
+      "  ",
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
   it("update --title renames (patches only what is passed)", async () => {
     const updated = pobj(
       (await run(["pitch", "update", "--title", "Renamed", s.pitchActiveId]))
@@ -140,6 +151,18 @@ describe("pitch create / update", () => {
     const { exitCode, stdout } = await run([
       "pitch",
       "update",
+      s.pitchActiveId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("update with an empty --title => invalid input, exit 3", async () => {
+    const { exitCode, stdout } = await run([
+      "pitch",
+      "update",
+      "--title",
+      "  ",
       s.pitchActiveId,
     ]);
     expect(exitCode).toBe(3);

--- a/app/cli/cli-pitch-segment-writes.test.ts
+++ b/app/cli/cli-pitch-segment-writes.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  createTestDb,
+  truncateAllTables,
+  type TestDb,
+} from "@/test-utils/pglite";
+import {
+  buildWriteLayer,
+  makeRun,
+  ndjson,
+  one,
+  seedWrite,
+  type RunResult,
+  type WriteSeed,
+} from "./cli-write-test-harness";
+
+// ===========================================================================
+// cvm WRITE verbs — pitch create/update + segment add --pitch
+// (Split from cli-integration.test.ts to stay under the per-file token budget.)
+// ===========================================================================
+
+let testDb: TestDb;
+let run: (argv: ReadonlyArray<string>) => Promise<RunResult>;
+
+beforeAll(async () => {
+  const result = await createTestDb();
+  testDb = result.testDb;
+  run = makeRun(buildWriteLayer(testDb));
+});
+
+let s: WriteSeed;
+beforeEach(async () => {
+  await truncateAllTables(testDb);
+  s = await seedWrite(testDb);
+});
+
+describe("pitch create / update", () => {
+  interface Pitch {
+    id: string;
+    title: string;
+    description: string;
+    contentPlan: string;
+    youtubeTitle: string;
+    youtubeThumbnailDescription: string;
+    newsletterTitle: string;
+    tweet: string;
+    priority: number;
+    effort: number;
+    archived: boolean;
+  }
+  const pobj = (stdout: string): Pitch => one<Pitch>(stdout);
+
+  it("create --title makes a titled pitch that appears in list", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "pitch",
+      "create",
+      "--title",
+      "Effect for React devs",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    const p = pobj(stdout);
+    expect(p.title).toBe("Effect for React devs");
+    expect(p.archived).toBe(false);
+    const list = ndjson((await run(["pitch", "list"])).stdout) as Pitch[];
+    expect(list.map((x) => x.id)).toContain(p.id);
+  });
+
+  it("create accepts the full copy + ranking field set", async () => {
+    const p = pobj(
+      (
+        await run([
+          "pitch",
+          "create",
+          "--title",
+          "Zod v4",
+          "--description",
+          "d",
+          "--content-plan",
+          "cp",
+          "--youtube-title",
+          "yt",
+          "--youtube-thumbnail",
+          "thumb",
+          "--newsletter-title",
+          "nl",
+          "--tweet",
+          "big news",
+          "--priority",
+          "1",
+          "--effort",
+          "3",
+        ])
+      ).stdout
+    );
+    expect(p.description).toBe("d");
+    expect(p.contentPlan).toBe("cp");
+    expect(p.youtubeTitle).toBe("yt");
+    expect(p.youtubeThumbnailDescription).toBe("thumb");
+    expect(p.newsletterTitle).toBe("nl");
+    expect(p.tweet).toBe("big news");
+    expect(p.priority).toBe(1);
+    expect(p.effort).toBe(3);
+  });
+
+  it("create with missing --title => invalid input, exit 3", async () => {
+    const { exitCode } = await run(["pitch", "create"]);
+    expect(exitCode).toBe(3);
+  });
+
+  it("update --title renames (patches only what is passed)", async () => {
+    const updated = pobj(
+      (await run(["pitch", "update", "--title", "Renamed", s.pitchActiveId]))
+        .stdout
+    );
+    expect(updated.id).toBe(s.pitchActiveId);
+    expect(updated.title).toBe("Renamed");
+  });
+
+  it("update patches priority and effort, leaving title untouched", async () => {
+    const updated = pobj(
+      (
+        await run([
+          "pitch",
+          "update",
+          "--priority",
+          "5",
+          "--effort",
+          "1",
+          s.pitchActiveId,
+        ])
+      ).stdout
+    );
+    expect(updated.priority).toBe(5);
+    expect(updated.effort).toBe(1);
+    expect(updated.title).toBe("Active pitch"); // untouched
+  });
+
+  it("update with no fields => invalid input, exit 3", async () => {
+    const { exitCode, stdout } = await run([
+      "pitch",
+      "update",
+      s.pitchActiveId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("update an unknown pitch => NotFoundError(pitch), exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "pitch",
+      "update",
+      "--title",
+      "x",
+      "pit_missing",
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "pitch"
+    );
+  });
+
+  it("update an archived pitch => NotFoundError(pitch), exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "pitch",
+      "update",
+      "--title",
+      "x",
+      s.pitchArchivedId,
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "pitch"
+    );
+  });
+});
+
+describe("segment add --pitch (resolve-or-create the pitch's video)", () => {
+  interface Seg {
+    id: string;
+    videoId: string;
+    kind: string;
+    title: string;
+  }
+  const sobj = (stdout: string): Seg => one<Seg>(stdout);
+
+  it("with 0 videos, auto-creates the pitch's video and adds the segment", async () => {
+    const seg = sobj(
+      (
+        await run([
+          "segment",
+          "add",
+          "--pitch",
+          s.pitchActiveId,
+          "--kind",
+          "quest",
+          "--title",
+          "Try it",
+        ])
+      ).stdout
+    );
+    expect(seg.kind).toBe("quest");
+    expect(seg.title).toBe("Try it");
+    // The pitch now has exactly one video, carrying that segment.
+    const pitch = one<{
+      videos: Array<{ id: string; segments: Array<{ id: string }> }>;
+    }>((await run(["pitch", "get", s.pitchActiveId])).stdout);
+    expect(pitch.videos).toHaveLength(1);
+    expect(pitch.videos[0]!.id).toBe(seg.videoId);
+    expect(pitch.videos[0]!.segments.map((x) => x.id)).toContain(seg.id);
+  });
+
+  it("with exactly 1 video, adds to that video (no new video)", async () => {
+    const v = one<{ id: string }>(
+      (
+        await run([
+          "video",
+          "create",
+          "--name",
+          "Cut",
+          "--pitch",
+          s.pitchActiveId,
+        ])
+      ).stdout
+    );
+    const seg = sobj(
+      (await run(["segment", "add", "--pitch", s.pitchActiveId])).stdout
+    );
+    expect(seg.videoId).toBe(v.id);
+    const pitch = one<{ videos: unknown[] }>(
+      (await run(["pitch", "get", s.pitchActiveId])).stdout
+    );
+    expect(pitch.videos).toHaveLength(1); // still one video
+  });
+
+  it("with >1 videos, is ambiguous => invalid input, exit 3", async () => {
+    await run(["video", "create", "--name", "A", "--pitch", s.pitchActiveId]);
+    await run(["video", "create", "--name", "B", "--pitch", s.pitchActiveId]);
+    const { exitCode, stdout } = await run([
+      "segment",
+      "add",
+      "--pitch",
+      s.pitchActiveId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("both --video and --pitch => invalid input, exit 3", async () => {
+    const { exitCode } = await run([
+      "segment",
+      "add",
+      "--video",
+      s.standaloneActiveId,
+      "--pitch",
+      s.pitchActiveId,
+    ]);
+    expect(exitCode).toBe(3);
+  });
+
+  it("neither --video nor --pitch => invalid input, exit 3", async () => {
+    const { exitCode } = await run(["segment", "add"]);
+    expect(exitCode).toBe(3);
+  });
+
+  it("unknown pitch => NotFoundError(pitch), exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "segment",
+      "add",
+      "--pitch",
+      "pit_missing",
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "pitch"
+    );
+  });
+
+  it("archived pitch => NotFoundError(pitch), exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "segment",
+      "add",
+      "--pitch",
+      s.pitchArchivedId,
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "pitch"
+    );
+  });
+});

--- a/app/cli/cli-write-test-harness.ts
+++ b/app/cli/cli-write-test-harness.ts
@@ -1,0 +1,137 @@
+import { Effect, Layer } from "effect";
+import { DrizzleService } from "@/services/drizzle-service.server";
+import { CourseOperationsService } from "@/services/db-course-operations.server";
+import { VersionOperationsService } from "@/services/db-version-operations.server";
+import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
+import { VideoOperationsService } from "@/services/db-video-operations.server";
+import { ClipOperationsService } from "@/services/db-clip-operations.server";
+import { SegmentOperationsService } from "@/services/db-segment-operations.server";
+import { PitchOperationsService } from "@/services/db-pitch-operations.server";
+import { DeliverableOperationsService } from "@/services/db-deliverable-operations.server";
+import { SearchOperationsService } from "@/services/db-search-operations.server";
+import type { TestDb } from "@/test-utils/pglite";
+import * as schema from "@/db/schema";
+import { buildProgram } from "@/cli/main";
+import { makeTestCliOutput } from "@/cli/output";
+
+/**
+ * Shared harness for the `cvm` WRITE-verb integration tests. Mirrors the layer
+ * + run() plumbing of cli-integration.test.ts, but lives in its own module so
+ * the write-verb suites can be split across small test files (the main
+ * integration test file is already at the repo's per-file token budget). Same
+ * contract: run the REAL buildProgram over PGlite with a captured CliOutput,
+ * asserting { stdout, stderr, exitCode } — no subprocess.
+ */
+export interface RunResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+export const buildWriteLayer = (db: TestDb) =>
+  Layer.mergeAll(
+    CourseOperationsService.Default,
+    VersionOperationsService.Default,
+    LessonSectionOperationsService.Default,
+    VideoOperationsService.Default,
+    ClipOperationsService.Default,
+    SegmentOperationsService.Default,
+    PitchOperationsService.Default,
+    DeliverableOperationsService.Default,
+    SearchOperationsService.Default
+  ).pipe(Layer.provideMerge(Layer.succeed(DrizzleService, db as never)));
+
+/** A run() bound to a specific captured-output layer. */
+export const makeRun =
+  (layer: ReturnType<typeof buildWriteLayer>) =>
+  async (argv: ReadonlyArray<string>): Promise<RunResult> => {
+    const out = makeTestCliOutput();
+    const exitCode = await Effect.runPromise(
+      buildProgram(argv).pipe(Effect.provide(out.layer), Effect.provide(layer))
+    );
+    return { stdout: out.stdout(), stderr: out.stderr(), exitCode };
+  };
+
+/** Parse NDJSON stdout into an array of objects (one per non-empty line). */
+export const ndjson = (stdout: string): unknown[] =>
+  stdout
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line));
+
+/** Parse a write verb's single pretty-printed JSON object. */
+export const one = <T = Record<string, unknown>>(stdout: string): T =>
+  JSON.parse(stdout) as T;
+
+export interface WriteSeed {
+  draftSectionId: string;
+  lessonId: string;
+  lessonVideoId: string;
+  standaloneActiveId: string;
+  pitchActiveId: string;
+  pitchArchivedId: string;
+}
+
+/**
+ * Minimal fixture for the write-verb suites: one course → draft version →
+ * section → lesson → lesson-bound video, plus a standalone video and an active
+ * + archived pitch. Enough to exercise every create/move/update/link path.
+ */
+export const seedWrite = async (db: TestDb): Promise<WriteSeed> => {
+  const [course] = await db
+    .insert(schema.courses)
+    .values({ name: "Alpha", slug: "alpha", filePath: "/tmp/alpha" })
+    .returning();
+  const [draftVersion] = await db
+    .insert(schema.courseVersions)
+    .values({
+      repoId: course!.id,
+      name: "",
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+    })
+    .returning();
+  const [draftSection] = await db
+    .insert(schema.sections)
+    .values({ repoVersionId: draftVersion!.id, path: "01-intro", order: 1 })
+    .returning();
+  const [lesson] = await db
+    .insert(schema.lessons)
+    .values({
+      sectionId: draftSection!.id,
+      path: "01-welcome",
+      title: "Welcome",
+      order: 1,
+      fsStatus: "real",
+      authoringStatus: "done",
+    })
+    .returning();
+  const [lessonVideo] = await db
+    .insert(schema.videos)
+    .values({
+      lessonId: lesson!.id,
+      path: "intro.mp4",
+      originalFootagePath: "footage.mp4",
+    })
+    .returning();
+  const [standaloneActive] = await db
+    .insert(schema.videos)
+    .values({ path: "standalone-active.mp4", originalFootagePath: "f.mp4" })
+    .returning();
+  const [pitchActive] = await db
+    .insert(schema.pitches)
+    .values({ title: "Active pitch" })
+    .returning();
+  const [pitchArchived] = await db
+    .insert(schema.pitches)
+    .values({ title: "Archived pitch", archived: true })
+    .returning();
+
+  return {
+    draftSectionId: draftSection!.id,
+    lessonId: lesson!.id,
+    lessonVideoId: lessonVideo!.id,
+    standaloneActiveId: standaloneActive!.id,
+    pitchActiveId: pitchActive!.id,
+    pitchArchivedId: pitchArchived!.id,
+  };
+};

--- a/app/cli/commands/lesson.ts
+++ b/app/cli/commands/lesson.ts
@@ -1,8 +1,9 @@
 import { Args, Command, Options } from "@effect/cli";
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
 import { lessonSearchCmd } from "./search";
 import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
 import { VideoOperationsService } from "@/services/db-video-operations.server";
+import { toSlug } from "@/services/lesson-path-service";
 import {
   detail,
   emitGet,
@@ -58,6 +59,8 @@ VERBS
   get <id...>           One or more lessons with their Section/Version/Repo
                         hierarchy. Variadic: many ids => NDJSON.
   tree <id> [--depth N] Skeleton tree lesson -> videos -> clips.
+  create --section <id> --title <t> [--before|--after <lessonId>]
+                        Create a GHOST lesson in a Section (WRITE).
   search <id> <query>   Substring search down this lesson's subtree
                         (--type lesson|video|segment).
 
@@ -120,6 +123,29 @@ Examples:
   cvm lesson tree les_abc
   cvm lesson tree --depth all les_abc
   cvm lesson tree --depth all les_abc | jq '.children[].children[].id'   # clip ids`;
+
+const CREATE_HELP = `Create a GHOST lesson inside a Section. Requires --section <id> and --title <t>.
+
+A ghost lesson is planned in the DB only (fsStatus="ghost") — it is NOT written
+to disk. It can still hold Videos, Segments and Clips; materializing it to a
+real on-disk lesson is a separate concern handled elsewhere (not by cvm). The
+lesson's 'path' (slug) is derived from the title.
+
+Flags:
+  --section <id>       (required) the Section to create the lesson in.
+  --title <text>       (required) the lesson title (also slugified into 'path').
+  --before <lessonId>  place immediately before that lesson (of --section).
+  --after  <lessonId>  place immediately after that lesson.
+                       (omit both to append to the end of the section.)
+
+--before/--after are mutually exclusive; an anchor that is not a lesson of
+--section is a not-found (exit 2). A title whose slug collides with an existing
+lesson in the section is invalid input (exit 3). Echoes the created lesson row
+as one pretty JSON object.
+
+Examples:
+  cvm lesson create --section sec_123 --title "Intro to Effect"
+  cvm lesson create --section sec_123 --title "Setup" --before les_abc`;
 
 // ---------------------------------------------------------------------------
 // list --section <id>
@@ -241,10 +267,105 @@ const treeCmd = Command.make("tree", { id: treeId, depth }, ({ id, depth }) =>
 ).pipe(Command.withDescription(detail(TREE_HELP)));
 
 // ---------------------------------------------------------------------------
+// create --section <id> --title <t> [--before|--after <lessonId>]
+// ---------------------------------------------------------------------------
+
+const createSection = Options.text("section").pipe(
+  Options.withDescription("The Section id to create the lesson in (required).")
+);
+const createTitle = Options.text("title").pipe(
+  Options.withDescription("The lesson title (also slugified into its path).")
+);
+const beforeOption = Options.text("before").pipe(
+  Options.withDescription(
+    "Place immediately before this lesson id (mutually exclusive with --after)."
+  ),
+  Options.optional
+);
+const afterOption = Options.text("after").pipe(
+  Options.withDescription(
+    "Place immediately after this lesson id (mutually exclusive with --before)."
+  ),
+  Options.optional
+);
+
+const createCmd = Command.make(
+  "create",
+  {
+    section: createSection,
+    title: createTitle,
+    before: beforeOption,
+    after: afterOption,
+  },
+  ({ section, title, before, after }) =>
+    Effect.gen(function* () {
+      const b = Option.getOrUndefined(before);
+      const a = Option.getOrUndefined(after);
+      if (b !== undefined && a !== undefined) {
+        return yield* parseError(
+          "pass at most one of --before / --after",
+          "lesson"
+        );
+      }
+
+      const svc = yield* LessonSectionOperationsService;
+
+      // Section must exist (clean exit 2 instead of an FK violation, exit 4).
+      yield* svc
+        .getSectionWithHierarchyById(section)
+        .pipe(
+          Effect.catchTag("NotFoundError", () => notFound("section", section))
+        );
+
+      const siblings = yield* svc.getLessonsBySectionId(section);
+      const maxOrder =
+        siblings.length > 0 ? Math.max(...siblings.map((l) => l.order)) : 0;
+      let insertOrder = maxOrder + 1;
+
+      // Resolve the --before/--after anchor into an insertion order, shifting
+      // the siblings at/after the insertion point up by one to make room
+      // (mirrors CourseWriteService.addGhostLesson).
+      const anchorId = b ?? a;
+      if (anchorId !== undefined) {
+        const adjIdx = siblings.findIndex((l) => l.id === anchorId);
+        if (adjIdx === -1) {
+          return yield* notFound("lesson", anchorId);
+        }
+        const idx = a !== undefined ? adjIdx + 1 : adjIdx;
+        yield* svc.batchUpdateLessonOrders(
+          siblings.slice(idx).map((l) => ({ id: l.id, order: l.order + 1 }))
+        );
+        insertOrder = siblings[idx] ? siblings[idx]!.order : maxOrder + 1;
+      }
+
+      const [lesson] = yield* svc
+        .createGhostLesson(section, {
+          title,
+          path: toSlug(title) || "untitled",
+          order: insertOrder,
+        })
+        .pipe(
+          // A slug collision with an existing lesson is invalid input (exit 3).
+          Effect.catchTag("LessonPathTakenError", (e) =>
+            parseError(e.message, "lesson")
+          )
+        );
+
+      yield* emitObject(lesson);
+    })
+).pipe(Command.withDescription(detail(CREATE_HELP)));
+
+// ---------------------------------------------------------------------------
 // lesson (parent)
 // ---------------------------------------------------------------------------
 
 export const lessonCommand = Command.make("lesson").pipe(
   Command.withDescription(detail(LESSON_HELP)),
-  Command.withSubcommands([listCmd, getCmd, treeCmd, lessonSearchCmd])
+  Command.withSubcommands([
+    listCmd,
+    getCmd,
+    treeCmd,
+    createCmd,
+    lessonSearchCmd,
+  ])
 );

--- a/app/cli/commands/lesson.ts
+++ b/app/cli/commands/lesson.ts
@@ -11,6 +11,7 @@ import {
   emitObject,
   notFound,
   parseError,
+  rejectBothFlags,
   withName,
 } from "@/cli/helpers";
 
@@ -301,12 +302,12 @@ const createCmd = Command.make(
     Effect.gen(function* () {
       const b = Option.getOrUndefined(before);
       const a = Option.getOrUndefined(after);
-      if (b !== undefined && a !== undefined) {
-        return yield* parseError(
-          "pass at most one of --before / --after",
-          "lesson"
-        );
-      }
+      yield* rejectBothFlags({
+        a: b,
+        b: a,
+        flags: ["--before", "--after"],
+        entity: "lesson",
+      });
 
       const svc = yield* LessonSectionOperationsService;
 

--- a/app/cli/commands/pitch.ts
+++ b/app/cli/commands/pitch.ts
@@ -4,7 +4,15 @@ import {
   PitchOperationsService,
   type PitchState,
 } from "@/services/db-pitch-operations.server";
-import { detail, emitGet, emitNdjson, withName } from "@/cli/helpers";
+import {
+  detail,
+  emitGet,
+  emitNdjson,
+  emitObject,
+  notFound,
+  parseError,
+  withName,
+} from "@/cli/helpers";
 
 // ---------------------------------------------------------------------------
 // Help text — domain-teaching prose (keep in sync with CONTEXT.md, "Pitches").
@@ -44,6 +52,9 @@ VERBS
   list   — every active pitch (optionally filtered by --state). Identity-rich.
   get    — one or more pitches by id, deep (linked Standalone Videos + their
            Clips and planning Segments).
+  create — create a Pitch (WRITE). --title required; other copy/ranking fields
+           optional. (A pitch needs a title to appear in list/get.)
+  update — patch a Pitch's copy/ranking fields (WRITE). Rename = --title.
 
 EXAMPLES
   cvm pitch list
@@ -110,6 +121,42 @@ EXAMPLES
   cvm pitch get <id-a> <id-b> > pitches.ndjson
   cvm pitch list --state idle | jq -r .id | xargs cvm pitch get`;
 
+const CREATE_HELP = `Create a Pitch. Requires --title <t>; a pitch needs a non-empty title to appear
+in 'pitch list' / 'pitch get', so the title is mandatory.
+
+All other copy and ranking fields are optional and default to their column
+defaults ("" for copy; priority 2; effort 2). Echoes the created pitch row.
+
+Flags:
+  --title <t>              (required) the pitch title / packaging headline.
+  --description <t>        free-text description.
+  --content-plan <t>       the content plan.
+  --youtube-title <t>      YouTube title copy.
+  --youtube-thumbnail <t>  YouTube thumbnail concept (youtubeThumbnailDescription).
+  --newsletter-title <t>   newsletter title copy.
+  --tweet <t>              tweet copy.
+  --priority <n>           triage rank (integer; lower sorts first).
+  --effort <1|2|3>         planning effort estimate (1 low, 2 medium, 3 high).
+
+Examples:
+  cvm pitch create --title "Effect for React devs"
+  cvm pitch create --title "Zod v4" --priority 1 --effort 2 --tweet "big news"`;
+
+const UPDATE_HELP = `Patch a Pitch's copy/ranking fields by id. At least one field flag is required
+(an update with no fields is invalid input, exit 3). Only the flags you pass
+change; the rest are left untouched. Renaming is just --title.
+
+Flags (all optional; same meanings as 'pitch create'):
+  --title, --description, --content-plan, --youtube-title, --youtube-thumbnail,
+  --newsletter-title, --tweet, --priority <n>, --effort <1|2|3>.
+
+An unknown or archived (deleted) pitch id is a not-found (exit 2). Flags must
+come BEFORE the <id>. Echoes the updated pitch row.
+
+Examples:
+  cvm pitch update --title "New title" pit_123
+  cvm pitch update --priority 1 --effort 1 pit_123`;
+
 // ---------------------------------------------------------------------------
 // Verbs
 // ---------------------------------------------------------------------------
@@ -157,10 +204,156 @@ const getCmd = Command.make("get", { ids }, ({ ids }) =>
 ).pipe(Command.withDescription(detail(GET_HELP)));
 
 // ---------------------------------------------------------------------------
+// Write verbs: create / update
+// ---------------------------------------------------------------------------
+
+const optText = (name: string, description: string) =>
+  Options.text(name).pipe(
+    Options.withDescription(description),
+    Options.optional
+  );
+
+const descriptionOption = optText("description", "Free-text description.");
+const contentPlanOption = optText("content-plan", "The content plan.");
+const youtubeTitleOption = optText("youtube-title", "YouTube title copy.");
+const youtubeThumbnailOption = optText(
+  "youtube-thumbnail",
+  "YouTube thumbnail concept (youtubeThumbnailDescription)."
+);
+const newsletterTitleOption = optText(
+  "newsletter-title",
+  "Newsletter title copy."
+);
+const tweetOption = optText("tweet", "Tweet copy.");
+const priorityOption = Options.integer("priority").pipe(
+  Options.withDescription("Triage rank (integer; lower sorts first)."),
+  Options.optional
+);
+const effortOption = Options.choice("effort", ["1", "2", "3"]).pipe(
+  Options.withDescription(
+    "Planning effort estimate (1 low, 2 medium, 3 high)."
+  ),
+  Options.optional
+);
+
+const copyOptions = {
+  description: descriptionOption,
+  contentPlan: contentPlanOption,
+  youtubeTitle: youtubeTitleOption,
+  youtubeThumbnailDescription: youtubeThumbnailOption,
+  newsletterTitle: newsletterTitleOption,
+  tweet: tweetOption,
+  priority: priorityOption,
+  effort: effortOption,
+};
+
+interface PitchFieldOpts {
+  readonly description: Option.Option<string>;
+  readonly contentPlan: Option.Option<string>;
+  readonly youtubeTitle: Option.Option<string>;
+  readonly youtubeThumbnailDescription: Option.Option<string>;
+  readonly newsletterTitle: Option.Option<string>;
+  readonly tweet: Option.Option<string>;
+  readonly priority: Option.Option<number>;
+  readonly effort: Option.Option<string>;
+}
+
+/** Collect the provided copy/ranking flags into a partial update object. */
+const collectPitchFields = (opts: PitchFieldOpts) => {
+  const fields: {
+    description?: string;
+    contentPlan?: string;
+    youtubeTitle?: string;
+    youtubeThumbnailDescription?: string;
+    newsletterTitle?: string;
+    tweet?: string;
+    priority?: number;
+    effort?: number;
+  } = {};
+  const set = <K extends keyof typeof fields>(
+    key: K,
+    value: (typeof fields)[K] | undefined
+  ) => {
+    if (value !== undefined) fields[key] = value;
+  };
+  set("description", Option.getOrUndefined(opts.description));
+  set("contentPlan", Option.getOrUndefined(opts.contentPlan));
+  set("youtubeTitle", Option.getOrUndefined(opts.youtubeTitle));
+  set(
+    "youtubeThumbnailDescription",
+    Option.getOrUndefined(opts.youtubeThumbnailDescription)
+  );
+  set("newsletterTitle", Option.getOrUndefined(opts.newsletterTitle));
+  set("tweet", Option.getOrUndefined(opts.tweet));
+  set("priority", Option.getOrUndefined(opts.priority));
+  const effort = Option.getOrUndefined(opts.effort);
+  set("effort", effort === undefined ? undefined : Number.parseInt(effort, 10));
+  return fields;
+};
+
+const createTitleOption = Options.text("title").pipe(
+  Options.withDescription("The pitch title / packaging headline (required).")
+);
+
+const createCmd = Command.make(
+  "create",
+  { title: createTitleOption, ...copyOptions },
+  ({ title, ...rest }) =>
+    Effect.gen(function* () {
+      const svc = yield* PitchOperationsService;
+      const created = yield* svc.createPitch();
+      const updated = yield* svc.updatePitch(created.id, {
+        title,
+        ...collectPitchFields(rest),
+      });
+      yield* emitObject(updated);
+    })
+).pipe(Command.withDescription(detail(CREATE_HELP)));
+
+const updateTitleOption = Options.text("title").pipe(
+  Options.withDescription("New pitch title (rename)."),
+  Options.optional
+);
+const idArg = Args.text({ name: "id" });
+
+const updateCmd = Command.make(
+  "update",
+  { id: idArg, title: updateTitleOption, ...copyOptions },
+  ({ id, title, ...rest }) =>
+    Effect.gen(function* () {
+      const t = Option.getOrUndefined(title);
+      const fields = { ...collectPitchFields(rest) } as {
+        title?: string;
+        [k: string]: string | number | undefined;
+      };
+      if (t !== undefined) fields.title = t;
+
+      if (Object.keys(fields).length === 0) {
+        return yield* parseError(
+          "update needs at least one field flag (e.g. --title)",
+          "pitch"
+        );
+      }
+
+      const svc = yield* PitchOperationsService;
+      // Existence + active guard (archived == deleted == not addressable).
+      const existing = yield* svc
+        .getPitch(id)
+        .pipe(Effect.catchTag("NotFoundError", () => notFound("pitch", id)));
+      if (existing.archived) {
+        return yield* notFound("pitch", id);
+      }
+
+      const updated = yield* svc.updatePitch(id, fields);
+      yield* emitObject(updated);
+    })
+).pipe(Command.withDescription(detail(UPDATE_HELP)));
+
+// ---------------------------------------------------------------------------
 // Noun
 // ---------------------------------------------------------------------------
 
 export const pitchCommand = Command.make("pitch").pipe(
   Command.withDescription(detail(PITCH_HELP)),
-  Command.withSubcommands([listCmd, getCmd])
+  Command.withSubcommands([listCmd, getCmd, createCmd, updateCmd])
 );

--- a/app/cli/commands/pitch.ts
+++ b/app/cli/commands/pitch.ts
@@ -3,6 +3,7 @@ import { Effect, Option } from "effect";
 import {
   PitchOperationsService,
   type PitchState,
+  type PitchFields,
 } from "@/services/db-pitch-operations.server";
 import {
   detail,
@@ -258,37 +259,25 @@ interface PitchFieldOpts {
   readonly effort: Option.Option<string>;
 }
 
-/** Collect the provided copy/ranking flags into a partial update object. */
-const collectPitchFields = (opts: PitchFieldOpts) => {
-  const fields: {
-    description?: string;
-    contentPlan?: string;
-    youtubeTitle?: string;
-    youtubeThumbnailDescription?: string;
-    newsletterTitle?: string;
-    tweet?: string;
-    priority?: number;
-    effort?: number;
-  } = {};
-  const set = <K extends keyof typeof fields>(
-    key: K,
-    value: (typeof fields)[K] | undefined
-  ) => {
-    if (value !== undefined) fields[key] = value;
-  };
-  set("description", Option.getOrUndefined(opts.description));
-  set("contentPlan", Option.getOrUndefined(opts.contentPlan));
-  set("youtubeTitle", Option.getOrUndefined(opts.youtubeTitle));
-  set(
-    "youtubeThumbnailDescription",
-    Option.getOrUndefined(opts.youtubeThumbnailDescription)
-  );
-  set("newsletterTitle", Option.getOrUndefined(opts.newsletterTitle));
-  set("tweet", Option.getOrUndefined(opts.tweet));
-  set("priority", Option.getOrUndefined(opts.priority));
+/**
+ * Collect the copy/ranking flags into a partial `PitchFields`. Values may be
+ * undefined (flag not passed); the service drops those before writing, so this
+ * does NOT pre-filter — undefined keys count as "leave untouched".
+ */
+const collectPitchFields = (opts: PitchFieldOpts): PitchFields => {
   const effort = Option.getOrUndefined(opts.effort);
-  set("effort", effort === undefined ? undefined : Number.parseInt(effort, 10));
-  return fields;
+  return {
+    description: Option.getOrUndefined(opts.description),
+    contentPlan: Option.getOrUndefined(opts.contentPlan),
+    youtubeTitle: Option.getOrUndefined(opts.youtubeTitle),
+    youtubeThumbnailDescription: Option.getOrUndefined(
+      opts.youtubeThumbnailDescription
+    ),
+    newsletterTitle: Option.getOrUndefined(opts.newsletterTitle),
+    tweet: Option.getOrUndefined(opts.tweet),
+    priority: Option.getOrUndefined(opts.priority),
+    effort: effort === undefined ? undefined : Number.parseInt(effort, 10),
+  };
 };
 
 const createTitleOption = Options.text("title").pipe(
@@ -300,13 +289,17 @@ const createCmd = Command.make(
   { title: createTitleOption, ...copyOptions },
   ({ title, ...rest }) =>
     Effect.gen(function* () {
+      // A pitch needs a non-empty title to appear in list/get, so reject blank.
+      if (title.trim() === "") {
+        return yield* parseError("--title must not be empty", "pitch");
+      }
       const svc = yield* PitchOperationsService;
-      const created = yield* svc.createPitch();
-      const updated = yield* svc.updatePitch(created.id, {
+      // One atomic insert carrying the title (never a titleless row + patch).
+      const created = yield* svc.createPitch({
         title,
         ...collectPitchFields(rest),
       });
-      yield* emitObject(updated);
+      yield* emitObject(created);
     })
 ).pipe(Command.withDescription(detail(CREATE_HELP)));
 
@@ -322,13 +315,13 @@ const updateCmd = Command.make(
   ({ id, title, ...rest }) =>
     Effect.gen(function* () {
       const t = Option.getOrUndefined(title);
-      const fields = { ...collectPitchFields(rest) } as {
-        title?: string;
-        [k: string]: string | number | undefined;
-      };
-      if (t !== undefined) fields.title = t;
+      if (t !== undefined && t.trim() === "") {
+        return yield* parseError("--title must not be empty", "pitch");
+      }
+      // May carry undefined values (flags not passed); the service prunes them.
+      const fields: PitchFields = { title: t, ...collectPitchFields(rest) };
 
-      if (Object.keys(fields).length === 0) {
+      if (!Object.values(fields).some((v) => v !== undefined)) {
         return yield* parseError(
           "update needs at least one field flag (e.g. --title)",
           "pitch"

--- a/app/cli/commands/segment.help.ts
+++ b/app/cli/commands/segment.help.ts
@@ -14,9 +14,10 @@ Deliberately distinct from a Chapter/Clip: a Segment is the INTENDED structure
 ("what I planned to shoot") and need not map to any recorded Chapter or Clip
 ("what I shot"). Segments are an in-app authoring aid and are NEVER published.
 
-segment is the FIRST write-capable noun in cvm: it has add/update/delete/move
-in addition to list (every other noun is read-only). Writes are immediate — no
-confirmation, no dry-run. archived == deleted (a deleted Segment is gone).
+segment is one of cvm's write-capable nouns: it has add/update/delete/move in
+addition to list (lesson, video and pitch also carry write verbs now — see
+'cvm --help'). Writes are immediate — no confirmation, no dry-run. archived ==
+deleted (a deleted Segment is gone).
 
 Segment kinds (the film-time job, from the Mise en Place glossary):
   definition   Explain a concept, term, or idea

--- a/app/cli/commands/segment.help.ts
+++ b/app/cli/commands/segment.help.ts
@@ -1,0 +1,148 @@
+/**
+ * Long-form --help text for the `cvm segment` verbs, split out of segment.ts
+ * to keep that command module under the repo's per-file token budget. These
+ * are domain-teaching prose strings consumed only by Command.withDescription.
+ */
+export const HELP = `Segment — the film-time planning units of a single Video.
+
+A Segment is one unit of a Video's PLAN: an ordered, pre-recording sketch of
+"what this video does for the viewer", authored before the video is recorded.
+Segments belong to a Video (not the Lesson/Pitch); each Video carries its own
+plan and a Segment can be moved between Videos (its parent videoId is mutable).
+
+Deliberately distinct from a Chapter/Clip: a Segment is the INTENDED structure
+("what I planned to shoot") and need not map to any recorded Chapter or Clip
+("what I shot"). Segments are an in-app authoring aid and are NEVER published.
+
+segment is the FIRST write-capable noun in cvm: it has add/update/delete/move
+in addition to list (every other noun is read-only). Writes are immediate — no
+confirmation, no dry-run. archived == deleted (a deleted Segment is gone).
+
+Segment kinds (the film-time job, from the Mise en Place glossary):
+  definition   Explain a concept, term, or idea
+  walkthrough  Step through existing code or a process
+  playthrough  Build something live, start to finish
+  quest        Set the viewer a challenge to attempt
+  reaction     React to or review code or content
+
+Positioning (add & move): pick a place with an anchor, not an index —
+  --before <id>  before that segment | --after <id>  after it | (neither) end.
+--before/--after are mutually exclusive; the CLI computes the fractional order.
+
+Output fields: id, videoId, kind, title, description (never published), order
+(fractional sort key), archived, createdAt.
+
+Verbs (flags come BEFORE the positional <id> — a flag after it exits 3):
+  list   --video <id>              A Video's full ordered plan (active only)
+  add    --video|--pitch <id> [flags]  Create a Segment in a Video's plan
+                                   (--pitch targets a pitch's video)
+  update [flags] <id>              Patch title/description/kind
+  move   --video <id> [flags] <id> Reorder, or move to another Video
+  delete <id>                      Archive (delete) a Segment
+
+Every write echoes the affected row as one pretty JSON object.
+
+Examples:
+  cvm segment list --video vid_123
+  cvm segment add --video vid_123 --kind quest --title "Try it"
+  cvm segment update --title "Setup" --kind walkthrough seg_456
+  cvm segment move --video vid_123 --after seg_789 seg_456
+  cvm segment delete seg_456`;
+
+export const LIST_HELP = `List a Video's full, ordered Segment plan as NDJSON (one compact JSON object
+per line; empty plan prints nothing). Requires --video <videoId>.
+
+The list is the COMPLETE active plan, already sorted by 'order' ascending (plan
+order). Archived (deleted) Segments are always excluded — there is no flag to
+include them.
+
+Each line carries: id, videoId, kind (definition|walkthrough|playthrough|quest|
+reaction), title, description (in-app planning note; never published), order
+(fractional sort key), archived (always false), createdAt.
+
+Find a video id with 'cvm video list' or 'cvm video tree <id>'.
+
+Examples:
+  cvm segment list --video vid_123
+  cvm segment list --video vid_123 | jq -r '.title'
+  cvm segment list --video vid_123 | jq -r 'select(.kind=="walkthrough") | .id'`;
+
+export const ADD_HELP = `Create a Segment in a Video's plan. Requires EXACTLY ONE of --video / --pitch
+to name the target video (passing both, or neither, is invalid input, exit 3).
+
+Flags:
+  --video <id>        the Video to add the Segment to.
+  --pitch <id>        target a PITCH's video instead: resolves the pitch's single
+                      active video and adds the Segment there. If the pitch has
+                      NO video yet, one is AUTO-CREATED (named after the pitch)
+                      and the Segment is added to it — so 'add --pitch' can have
+                      the side effect of creating a video. If the pitch has more
+                      than one video it is ambiguous: invalid input (exit 3);
+                      target the video directly with --video. An unknown or
+                      archived pitch id is a not-found (exit 2).
+  --kind <kind>       one of definition|walkthrough|playthrough|quest|reaction.
+                      Defaults to 'definition'.
+  --title <text>      short label (default "").
+  --description <text> free-text planning note (default ""; never published).
+  --before <id>       place immediately before that segment.
+  --after <id>        place immediately after that segment.
+                      (omit both --before/--after to append to the end.)
+
+Echoes the created Segment row (including its new id and computed order) as one
+pretty JSON object. --before/--after are mutually exclusive; an anchor that is
+not a segment of the target video is a not-found (exit 2).
+
+Examples:
+  cvm segment add --video vid_123
+  cvm segment add --video vid_123 --kind quest --title "Try it" --description "..."
+  cvm segment add --video vid_123 --before seg_456
+  cvm segment add --pitch pit_123 --kind quest --title "Try it"`;
+
+export const UPDATE_HELP = `Patch a single Segment's content by id. At least one of --title / --description
+/ --kind is required (an update with no fields is an invalid-input error, exit 3).
+
+update ONLY changes content — it never repositions the Segment or moves it
+between Videos (use 'move' for that). Only the flags you pass change; the rest
+are left untouched.
+
+Flags:
+  --title <text>       new short label.
+  --description <text> new planning note (never published).
+  --kind <kind>        definition|walkthrough|playthrough|quest|reaction.
+
+Echoes the updated Segment row. An unknown or already-deleted id is a not-found
+(exit 2). Flags must come BEFORE the <id> (a flag after it exits 3).
+
+Examples:
+  cvm segment update --title "Setup" seg_456
+  cvm segment update --kind walkthrough --description "Step through it" seg_456`;
+
+export const MOVE_HELP = `Reposition a Segment within its plan, or move it into another Video. Requires
+--video <targetVideoId> (pass the Segment's CURRENT video to reorder in place,
+or a DIFFERENT video to drag it across).
+
+Placement uses the same anchors as 'add':
+  --before <id>  place immediately before that segment (of --video).
+  --after  <id>  place immediately after it.
+  (neither)      append to the end of --video's plan.
+
+--before/--after are mutually exclusive and must name a segment of --video;
+otherwise it is a not-found (exit 2). Echoes the moved Segment row with its new
+videoId and computed order. Flags must come BEFORE the <id> (a flag after it
+exits 3).
+
+Examples:
+  cvm segment move --video vid_123 --after seg_789 seg_456   # reorder in place
+  cvm segment move --video vid_123 --before seg_789 seg_456
+  cvm segment move --video vid_999 seg_456                   # to another video, end`;
+
+export const DELETE_HELP = `Delete (archive) a single Segment by id. For Segments, archived == deleted: the
+Segment is removed from its plan and can never be listed or addressed again
+(there is no restore verb).
+
+Immediate — there is no confirmation prompt (this is an agent-facing tool).
+Echoes the now-archived row ({ ..., archived: true }). An unknown or
+already-deleted id is a not-found (exit 2).
+
+Example:
+  cvm segment delete seg_456`;

--- a/app/cli/commands/segment.ts
+++ b/app/cli/commands/segment.ts
@@ -1,11 +1,26 @@
 import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
 import { SegmentOperationsService } from "@/services/db-segment-operations.server";
+import { PitchOperationsService } from "@/services/db-pitch-operations.server";
 import {
   SEGMENT_KINDS,
   DEFAULT_SEGMENT_KIND,
 } from "@/features/segments/segment-kinds";
-import { detail, emitNdjson, emitObject, notFound, parseError } from "@/cli/helpers";
+import {
+  detail,
+  emitNdjson,
+  emitObject,
+  notFound,
+  parseError,
+} from "@/cli/helpers";
+import {
+  HELP,
+  LIST_HELP,
+  ADD_HELP,
+  UPDATE_HELP,
+  MOVE_HELP,
+  DELETE_HELP,
+} from "./segment.help";
 
 /**
  * `segment` — the film-time planning units of a single Video.
@@ -109,138 +124,6 @@ import { detail, emitNdjson, emitObject, notFound, parseError } from "@/cli/help
  *   # Delete (archive) a segment:
  *   cvm segment delete seg_456
  */
-const HELP = `Segment — the film-time planning units of a single Video.
-
-A Segment is one unit of a Video's PLAN: an ordered, pre-recording sketch of
-"what this video does for the viewer", authored before the video is recorded.
-Segments belong to a Video (not the Lesson/Pitch); each Video carries its own
-plan and a Segment can be moved between Videos (its parent videoId is mutable).
-
-Deliberately distinct from a Chapter/Clip: a Segment is the INTENDED structure
-("what I planned to shoot") and need not map to any recorded Chapter or Clip
-("what I shot"). Segments are an in-app authoring aid and are NEVER published.
-
-segment is the FIRST write-capable noun in cvm: it has add/update/delete/move
-in addition to list (every other noun is read-only). Writes are immediate — no
-confirmation, no dry-run. archived == deleted (a deleted Segment is gone).
-
-Segment kinds (the film-time job, from the Mise en Place glossary):
-  definition   Explain a concept, term, or idea
-  walkthrough  Step through existing code or a process
-  playthrough  Build something live, start to finish
-  quest        Set the viewer a challenge to attempt
-  reaction     React to or review code or content
-
-Positioning (add & move): pick a place with an anchor, not an index —
-  --before <id>  before that segment | --after <id>  after it | (neither) end.
---before/--after are mutually exclusive; the CLI computes the fractional order.
-
-Output fields: id, videoId, kind, title, description (never published), order
-(fractional sort key), archived, createdAt.
-
-Verbs (flags come BEFORE the positional <id> — a flag after it exits 3):
-  list   --video <id>              A Video's full ordered plan (active only)
-  add    --video <id> [flags]      Create a Segment in a Video's plan
-  update [flags] <id>              Patch title/description/kind
-  move   --video <id> [flags] <id> Reorder, or move to another Video
-  delete <id>                      Archive (delete) a Segment
-
-Every write echoes the affected row as one pretty JSON object.
-
-Examples:
-  cvm segment list --video vid_123
-  cvm segment add --video vid_123 --kind quest --title "Try it"
-  cvm segment update --title "Setup" --kind walkthrough seg_456
-  cvm segment move --video vid_123 --after seg_789 seg_456
-  cvm segment delete seg_456`;
-
-const LIST_HELP = `List a Video's full, ordered Segment plan as NDJSON (one compact JSON object
-per line; empty plan prints nothing). Requires --video <videoId>.
-
-The list is the COMPLETE active plan, already sorted by 'order' ascending (plan
-order). Archived (deleted) Segments are always excluded — there is no flag to
-include them.
-
-Each line carries: id, videoId, kind (definition|walkthrough|playthrough|quest|
-reaction), title, description (in-app planning note; never published), order
-(fractional sort key), archived (always false), createdAt.
-
-Find a video id with 'cvm video list' or 'cvm video tree <id>'.
-
-Examples:
-  cvm segment list --video vid_123
-  cvm segment list --video vid_123 | jq -r '.title'
-  cvm segment list --video vid_123 | jq -r 'select(.kind=="walkthrough") | .id'`;
-
-const ADD_HELP = `Create a Segment in a Video's plan. Requires --video <videoId>.
-
-Flags:
-  --video <id>        (required) the Video to add the Segment to.
-  --kind <kind>       one of definition|walkthrough|playthrough|quest|reaction.
-                      Defaults to 'definition'.
-  --title <text>      short label (default "").
-  --description <text> free-text planning note (default ""; never published).
-  --before <id>       place immediately before that segment.
-  --after <id>        place immediately after that segment.
-                      (omit both --before/--after to append to the end.)
-
-Echoes the created Segment row (including its new id and computed order) as one
-pretty JSON object. --before/--after are mutually exclusive; an anchor that is
-not a segment of --video is a not-found (exit 2).
-
-Examples:
-  cvm segment add --video vid_123
-  cvm segment add --video vid_123 --kind quest --title "Try it" --description "..."
-  cvm segment add --video vid_123 --before seg_456`;
-
-const UPDATE_HELP = `Patch a single Segment's content by id. At least one of --title / --description
-/ --kind is required (an update with no fields is an invalid-input error, exit 3).
-
-update ONLY changes content — it never repositions the Segment or moves it
-between Videos (use 'move' for that). Only the flags you pass change; the rest
-are left untouched.
-
-Flags:
-  --title <text>       new short label.
-  --description <text> new planning note (never published).
-  --kind <kind>        definition|walkthrough|playthrough|quest|reaction.
-
-Echoes the updated Segment row. An unknown or already-deleted id is a not-found
-(exit 2). Flags must come BEFORE the <id> (a flag after it exits 3).
-
-Examples:
-  cvm segment update --title "Setup" seg_456
-  cvm segment update --kind walkthrough --description "Step through it" seg_456`;
-
-const MOVE_HELP = `Reposition a Segment within its plan, or move it into another Video. Requires
---video <targetVideoId> (pass the Segment's CURRENT video to reorder in place,
-or a DIFFERENT video to drag it across).
-
-Placement uses the same anchors as 'add':
-  --before <id>  place immediately before that segment (of --video).
-  --after  <id>  place immediately after it.
-  (neither)      append to the end of --video's plan.
-
---before/--after are mutually exclusive and must name a segment of --video;
-otherwise it is a not-found (exit 2). Echoes the moved Segment row with its new
-videoId and computed order. Flags must come BEFORE the <id> (a flag after it
-exits 3).
-
-Examples:
-  cvm segment move --video vid_123 --after seg_789 seg_456   # reorder in place
-  cvm segment move --video vid_123 --before seg_789 seg_456
-  cvm segment move --video vid_999 seg_456                   # to another video, end`;
-
-const DELETE_HELP = `Delete (archive) a single Segment by id. For Segments, archived == deleted: the
-Segment is removed from its plan and can never be listed or addressed again
-(there is no restore verb).
-
-Immediate — there is no confirmation prompt (this is an agent-facing tool).
-Echoes the now-archived row ({ ..., archived: true }). An unknown or
-already-deleted id is a not-found (exit 2).
-
-Example:
-  cvm segment delete seg_456`;
 
 // ---------------------------------------------------------------------------
 // Options / Args
@@ -254,6 +137,22 @@ const videoListOption = Options.text("video").pipe(
 
 const videoTargetOption = Options.text("video").pipe(
   Options.withDescription("The target Video id for the Segment (required).")
+);
+
+const videoAddOption = Options.text("video").pipe(
+  Options.withDescription(
+    "The target Video id (mutually exclusive with --pitch)."
+  ),
+  Options.optional
+);
+
+const pitchAddOption = Options.text("pitch").pipe(
+  Options.withDescription(
+    "Target a Pitch's video instead of --video: resolves the pitch's single " +
+      "video (auto-creating one if the pitch has none; error if it has more " +
+      "than one). Mutually exclusive with --video."
+  ),
+  Options.optional
 );
 
 const kindOption = Options.choice("kind", [...SEGMENT_KINDS]).pipe(
@@ -351,6 +250,68 @@ const resolveBeforeSegmentId = (params: {
   });
 
 /**
+ * Resolve the target Video for a `segment add`, from EXACTLY ONE of --video /
+ * --pitch:
+ *   - neither / both  -> invalid input (exit 3).
+ *   - --video <id>    -> that id verbatim (existing behavior).
+ *   - --pitch <id>    -> the pitch's single active video, following the
+ *                        resolve-or-create policy:
+ *                          0 videos -> auto-create one (createVideoFromPitch,
+ *                                      named after the pitch) and use it.
+ *                          1 video  -> use it.
+ *                         >1 videos -> invalid input (exit 3): the pitch is
+ *                                      ambiguous; target the video with --video.
+ *     An unknown or archived (deleted) pitch id is a not-found (exit 2).
+ */
+const resolveTargetVideoId = (params: {
+  readonly video: Option.Option<string>;
+  readonly pitch: Option.Option<string>;
+}) =>
+  Effect.gen(function* () {
+    const video = Option.getOrUndefined(params.video);
+    const pitch = Option.getOrUndefined(params.pitch);
+
+    if (video !== undefined && pitch !== undefined) {
+      return yield* parseError(
+        "pass at most one of --video / --pitch",
+        "segment"
+      );
+    }
+    if (video === undefined && pitch === undefined) {
+      return yield* parseError(
+        "segment add needs one of --video / --pitch",
+        "segment"
+      );
+    }
+    if (video !== undefined) {
+      return video;
+    }
+
+    const pitchSvc = yield* PitchOperationsService;
+    const row = yield* pitchSvc
+      .getPitchWithVideos(pitch!)
+      .pipe(Effect.catchTag("NotFoundError", () => notFound("pitch", pitch!)));
+    // Archived pitches are deleted-equivalent (never addressable).
+    if (row.archived) {
+      return yield* notFound("pitch", pitch!);
+    }
+
+    const videos = row.videos;
+    if (videos.length > 1) {
+      return yield* parseError(
+        `pitch ${pitch} has ${videos.length} videos — target one directly with --video <id>`,
+        "segment"
+      );
+    }
+    if (videos.length === 1) {
+      return videos[0]!.id;
+    }
+    // No video yet: create the pitch's backing video (named after the pitch).
+    const created = yield* pitchSvc.createVideoFromPitch(pitch!);
+    return created.id;
+  });
+
+/**
  * Fetch a Segment by id, treating a missing OR archived row as not-found
  * (archived == deleted == unaddressable). Returns the active row. Fails with
  * the CLI NotFoundError (exit 2) otherwise.
@@ -382,23 +343,25 @@ const listCmd = Command.make("list", { video: videoListOption }, ({ video }) =>
 const addCmd = Command.make(
   "add",
   {
-    video: videoTargetOption,
+    video: videoAddOption,
+    pitch: pitchAddOption,
     kind: kindOption,
     title: titleOption,
     description: descriptionOption,
     before: beforeOption,
     after: afterOption,
   },
-  ({ video, kind, title, description, before, after }) =>
+  ({ video, pitch, kind, title, description, before, after }) =>
     Effect.gen(function* () {
+      const videoId = yield* resolveTargetVideoId({ video, pitch });
       const beforeSegmentId = yield* resolveBeforeSegmentId({
-        videoId: video,
+        videoId,
         before,
         after,
       });
       const svc = yield* SegmentOperationsService;
       const segment = yield* svc.createSegment(
-        video,
+        videoId,
         Option.getOrUndefined(kind) ?? DEFAULT_SEGMENT_KIND,
         beforeSegmentId,
         Option.getOrUndefined(title) ?? "",

--- a/app/cli/commands/segment.ts
+++ b/app/cli/commands/segment.ts
@@ -12,6 +12,7 @@ import {
   emitObject,
   notFound,
   parseError,
+  rejectBothFlags,
 } from "@/cli/helpers";
 import {
   HELP,
@@ -51,12 +52,13 @@ import {
  * Segments are PURELY an in-app authoring aid — neither the Segment plan nor a
  * Segment's free-text `description` is ever published (Publish skips them).
  *
- * WRITE SURFACE. `segment` is the FIRST write-capable noun in cvm: it exposes
+ * WRITE SURFACE. `segment` is one of cvm's write-capable nouns: it exposes
  * `add` / `update` / `delete` / `move` alongside `list`, because authoring a
  * Video's Segment plan is exactly the kind of low-stakes, never-published
- * planning work an agent should help draft. (Every OTHER noun stays read-only —
- * see `cvm --help`.) Writes hit the database immediately; there is no
- * confirmation prompt (this is an agent-facing tool) and no dry-run.
+ * planning work an agent should help draft. (`lesson`, `video` and `pitch` also
+ * carry write verbs now — see `cvm --help`.) Writes hit the database
+ * immediately; there is no confirmation prompt (this is an agent-facing tool)
+ * and no dry-run.
  *
  * Addressing: Segments have no stable public address. `list` requires
  * `--video <videoId>`; the write verbs address a single Segment by its `id`
@@ -220,12 +222,12 @@ const resolveBeforeSegmentId = (params: {
     const before = Option.getOrUndefined(params.before);
     const after = Option.getOrUndefined(params.after);
 
-    if (before !== undefined && after !== undefined) {
-      return yield* parseError(
-        "pass at most one of --before / --after",
-        "segment"
-      );
-    }
+    yield* rejectBothFlags({
+      a: before,
+      b: after,
+      flags: ["--before", "--after"],
+      entity: "segment",
+    });
     if (before === undefined && after === undefined) {
       return null;
     }
@@ -271,12 +273,12 @@ const resolveTargetVideoId = (params: {
     const video = Option.getOrUndefined(params.video);
     const pitch = Option.getOrUndefined(params.pitch);
 
-    if (video !== undefined && pitch !== undefined) {
-      return yield* parseError(
-        "pass at most one of --video / --pitch",
-        "segment"
-      );
-    }
+    yield* rejectBothFlags({
+      a: video,
+      b: pitch,
+      flags: ["--video", "--pitch"],
+      entity: "segment",
+    });
     if (video === undefined && pitch === undefined) {
       return yield* parseError(
         "segment add needs one of --video / --pitch",

--- a/app/cli/commands/video.ts
+++ b/app/cli/commands/video.ts
@@ -1,6 +1,8 @@
 import { Args, Command, Options } from "@effect/cli";
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
 import { VideoOperationsService } from "@/services/db-video-operations.server";
+import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
+import { PitchOperationsService } from "@/services/db-pitch-operations.server";
 import {
   detail,
   emitGet,
@@ -45,6 +47,9 @@ Verbs:
   get <id...>          a Video plus its Clips and Chapters (variadic; NDJSON when >1 id)
   tree <id>            skeleton: video -> clips/chapters (id/kind/name/children)
   transcript <id>      the ordered text projection (Clips + Chapters as prose)
+  create --name <n>    create a Video (--lesson <id> | --pitch <id> | neither=standalone) (WRITE)
+  move <id>            re-home a Video to a lesson/pitch (--lesson | --pitch) (WRITE)
+  update --name <n> <id>  rename a Video (its 'name'/path) (WRITE)
 
 Worked example (find a video, then read it):
   cvm video list | jq -r '.id'                     # map name -> id
@@ -269,10 +274,224 @@ const transcriptCmd = Command.make(
 ).pipe(Command.withDescription(detail(TRANSCRIPT_HELP)));
 
 // ---------------------------------------------------------------------------
+// Write verbs: create / move / update
+// ---------------------------------------------------------------------------
+
+const CREATE_HELP = `Create a Video. Requires --name <n> (the video's name / path).
+
+Choose the parent with a flag (they are mutually exclusive):
+  --lesson <id>   create the video inside that Lesson.
+  --pitch <id>    create the video packaged by that Pitch (a Standalone video).
+  (neither)       create a free Standalone video (no lesson, no pitch).
+
+--name is ALWAYS required, including under --pitch. Passing both --lesson and
+--pitch is invalid input (exit 3). An unknown --lesson / --pitch id is a
+not-found (exit 2). A --name that collides with an existing video in the same
+lesson is invalid input (exit 3). Echoes the created video row.
+
+Examples:
+  cvm video create --name "Intro"
+  cvm video create --name "01-setup" --lesson les_abc
+  cvm video create --name "My Pitch Cut" --pitch pit_123`;
+
+const MOVE_HELP = `Re-home an existing Video to a Lesson or a Pitch. Requires EXACTLY ONE of
+--lesson <id> / --pitch <id> (passing both, or neither, is invalid input,
+exit 3).
+
+"move" enforces the single-parent invariant: moving to a lesson clears any pitch
+association, and moving to a pitch clears any lesson association — a Video always
+ends up with exactly one parent. An unknown video / lesson / pitch id is a
+not-found (exit 2). Moving into a lesson where the video's name is already taken
+is invalid input (exit 3). Flags must come BEFORE the <id>. Echoes the moved row.
+
+Examples:
+  cvm video move --lesson les_abc vid_123
+  cvm video move --pitch pit_123 vid_123`;
+
+const UPDATE_HELP = `Rename a Video by id — set its 'name' (the 'path' column). Requires --name <n>
+(an update with no --name is invalid input, exit 3).
+
+For lesson-bound videos the new name must be unique within the lesson (a
+collision is invalid input, exit 3). An unknown id is a not-found (exit 2).
+Flags must come BEFORE the <id>. Echoes the updated video row.
+
+Examples:
+  cvm video update --name "02-refactor" vid_123`;
+
+const nameOption = Options.text("name").pipe(
+  Options.withDescription("The Video's name (its 'path').")
+);
+const lessonOption = Options.text("lesson").pipe(
+  Options.withDescription(
+    "Parent Lesson id (mutually exclusive with --pitch)."
+  ),
+  Options.optional
+);
+const pitchOption = Options.text("pitch").pipe(
+  Options.withDescription(
+    "Parent Pitch id (mutually exclusive with --lesson)."
+  ),
+  Options.optional
+);
+
+/** Ensure a Lesson id exists (clean exit 2), else NotFound. */
+const requireLesson = (lessonId: string) =>
+  Effect.flatMap(LessonSectionOperationsService, (svc) =>
+    svc
+      .getLessonById(lessonId)
+      .pipe(
+        Effect.catchTag("NotFoundError", () => notFound("lesson", lessonId))
+      )
+  );
+
+/** Ensure a Pitch id exists (clean exit 2), else NotFound. */
+const requirePitch = (pitchId: string) =>
+  Effect.flatMap(PitchOperationsService, (svc) =>
+    svc
+      .getPitch(pitchId)
+      .pipe(Effect.catchTag("NotFoundError", () => notFound("pitch", pitchId)))
+  );
+
+const createCmd = Command.make(
+  "create",
+  { name: nameOption, lesson: lessonOption, pitch: pitchOption },
+  ({ name, lesson, pitch }) =>
+    Effect.gen(function* () {
+      const lessonId = Option.getOrUndefined(lesson);
+      const pitchId = Option.getOrUndefined(pitch);
+      if (lessonId !== undefined && pitchId !== undefined) {
+        return yield* parseError(
+          "pass at most one of --lesson / --pitch",
+          "video"
+        );
+      }
+
+      const svc = yield* VideoOperationsService;
+
+      if (lessonId !== undefined) {
+        yield* requireLesson(lessonId);
+        const created = yield* svc
+          .createVideo(lessonId, { path: name, originalFootagePath: "" })
+          .pipe(
+            Effect.catchTag("VideoPathTakenError", (e) =>
+              parseError(e.message, "video")
+            )
+          );
+        return yield* emitObject(created);
+      }
+
+      if (pitchId !== undefined) {
+        yield* requirePitch(pitchId);
+        const created = yield* svc.createStandaloneVideo({ path: name });
+        const linked = yield* svc.linkVideoToPitch({
+          videoId: created.id,
+          pitchId,
+        });
+        return yield* emitObject(linked);
+      }
+
+      const created = yield* svc.createStandaloneVideo({ path: name });
+      yield* emitObject(created);
+    })
+).pipe(Command.withDescription(detail(CREATE_HELP)));
+
+const moveId = Args.text({ name: "id" });
+
+const moveCmd = Command.make(
+  "move",
+  { id: moveId, lesson: lessonOption, pitch: pitchOption },
+  ({ id, lesson, pitch }) =>
+    Effect.gen(function* () {
+      const lessonId = Option.getOrUndefined(lesson);
+      const pitchId = Option.getOrUndefined(pitch);
+      if (lessonId !== undefined && pitchId !== undefined) {
+        return yield* parseError(
+          "pass exactly one of --lesson / --pitch",
+          "video"
+        );
+      }
+      if (lessonId === undefined && pitchId === undefined) {
+        return yield* parseError(
+          "move needs one of --lesson / --pitch",
+          "video"
+        );
+      }
+
+      const svc = yield* VideoOperationsService;
+      // The video being moved must exist (clean exit 2).
+      yield* svc
+        .getVideoRowById(id)
+        .pipe(Effect.catchTag("NotFoundError", () => notFound("video", id)));
+
+      if (lessonId !== undefined) {
+        yield* requireLesson(lessonId);
+        const moved = yield* svc
+          .moveVideoToLesson({ videoId: id, lessonId })
+          .pipe(
+            Effect.catchTag("VideoPathTakenError", (e) =>
+              parseError(e.message, "video")
+            )
+          );
+        return yield* emitObject(moved);
+      }
+
+      yield* requirePitch(pitchId!);
+      const moved = yield* svc.linkVideoToPitch({
+        videoId: id,
+        pitchId: pitchId!,
+      });
+      yield* emitObject(moved);
+    })
+).pipe(Command.withDescription(detail(MOVE_HELP)));
+
+const updateId = Args.text({ name: "id" });
+const updateNameOption = Options.text("name").pipe(
+  Options.withDescription("The Video's new name (its 'path')."),
+  Options.optional
+);
+
+const updateCmd = Command.make(
+  "update",
+  { id: updateId, name: updateNameOption },
+  ({ id, name }) =>
+    Effect.gen(function* () {
+      const newName = Option.getOrUndefined(name);
+      if (newName === undefined) {
+        return yield* parseError("update needs --name", "video");
+      }
+
+      const svc = yield* VideoOperationsService;
+      // Existence guard first (clean exit 2).
+      yield* svc
+        .getVideoRowById(id)
+        .pipe(Effect.catchTag("NotFoundError", () => notFound("video", id)));
+
+      yield* svc
+        .updateVideoPath({ videoId: id, path: newName })
+        .pipe(
+          Effect.catchTag("VideoPathTakenError", (e) =>
+            parseError(e.message, "video")
+          )
+        );
+
+      const updated = yield* svc.getVideoRowById(id);
+      yield* emitObject(updated);
+    })
+).pipe(Command.withDescription(detail(UPDATE_HELP)));
+
+// ---------------------------------------------------------------------------
 // Noun command
 // ---------------------------------------------------------------------------
 
 export const videoCommand = Command.make("video").pipe(
   Command.withDescription(detail(VIDEO_HELP)),
-  Command.withSubcommands([listCmd, getCmd, treeCmd, transcriptCmd])
+  Command.withSubcommands([
+    listCmd,
+    getCmd,
+    treeCmd,
+    transcriptCmd,
+    createCmd,
+    moveCmd,
+    updateCmd,
+  ])
 );

--- a/app/cli/commands/video.ts
+++ b/app/cli/commands/video.ts
@@ -10,6 +10,7 @@ import {
   emitObject,
   notFound,
   parseError,
+  rejectBothFlags,
   withName,
 } from "@/cli/helpers";
 import {
@@ -357,14 +358,17 @@ const createCmd = Command.make(
   { name: nameOption, lesson: lessonOption, pitch: pitchOption },
   ({ name, lesson, pitch }) =>
     Effect.gen(function* () {
+      if (name.trim() === "") {
+        return yield* parseError("--name must not be empty", "video");
+      }
       const lessonId = Option.getOrUndefined(lesson);
       const pitchId = Option.getOrUndefined(pitch);
-      if (lessonId !== undefined && pitchId !== undefined) {
-        return yield* parseError(
-          "pass at most one of --lesson / --pitch",
-          "video"
-        );
-      }
+      yield* rejectBothFlags({
+        a: lessonId,
+        b: pitchId,
+        flags: ["--lesson", "--pitch"],
+        entity: "video",
+      });
 
       const svc = yield* VideoOperationsService;
 
@@ -404,12 +408,12 @@ const moveCmd = Command.make(
     Effect.gen(function* () {
       const lessonId = Option.getOrUndefined(lesson);
       const pitchId = Option.getOrUndefined(pitch);
-      if (lessonId !== undefined && pitchId !== undefined) {
-        return yield* parseError(
-          "pass exactly one of --lesson / --pitch",
-          "video"
-        );
-      }
+      yield* rejectBothFlags({
+        a: lessonId,
+        b: pitchId,
+        flags: ["--lesson", "--pitch"],
+        entity: "video",
+      });
       if (lessonId === undefined && pitchId === undefined) {
         return yield* parseError(
           "move needs one of --lesson / --pitch",
@@ -456,8 +460,8 @@ const updateCmd = Command.make(
   ({ id, name }) =>
     Effect.gen(function* () {
       const newName = Option.getOrUndefined(name);
-      if (newName === undefined) {
-        return yield* parseError("update needs --name", "video");
+      if (newName === undefined || newName.trim() === "") {
+        return yield* parseError("update needs a non-empty --name", "video");
       }
 
       const svc = yield* VideoOperationsService;

--- a/app/cli/helpers.ts
+++ b/app/cli/helpers.ts
@@ -3,7 +3,13 @@ import { Effect, Option } from "effect";
 import { VersionOperationsService } from "@/services/db-version-operations.server";
 import type { UnknownDBServiceError } from "@/services/db-service-errors";
 import { CliOutput } from "./output";
-import { NotFoundError, notFound, notFoundMany } from "./errors";
+import {
+  NotFoundError,
+  notFound,
+  notFoundMany,
+  parseError,
+  type ParseError,
+} from "./errors";
 
 /**
  * Shared verb helpers for every noun command. Command handlers should route ALL
@@ -74,6 +80,31 @@ export const withName = <T>(row: T): T & { name: string | null } => ({
   name: displayName(row),
   ...row,
 });
+
+// ---------------------------------------------------------------------------
+// Mutually-exclusive flag guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Fail with an invalid-input error (exit 3) when two mutually-exclusive flags
+ * are BOTH provided. Only the "both" shape is shared across the write verbs;
+ * each caller keeps its own "neither" handling (append / standalone / require
+ * exactly one all differ), so that stays at the call site.
+ */
+export const rejectBothFlags = (params: {
+  readonly a: unknown;
+  readonly b: unknown;
+  readonly flags: readonly [string, string];
+  readonly entity: string;
+}): Effect.Effect<void, ParseError> =>
+  params.a !== undefined && params.b !== undefined
+    ? Effect.fail(
+        parseError(
+          `pass at most one of ${params.flags[0]} / ${params.flags[1]}`,
+          params.entity
+        )
+      )
+    : Effect.void;
 
 // ---------------------------------------------------------------------------
 // Output emitters

--- a/app/cli/index.ts
+++ b/app/cli/index.ts
@@ -18,10 +18,10 @@ import { searchCommand } from "./commands/search";
  */
 const ROOT_HELP = `cvm — agent-facing access to this Course Video Manager project's domain data.
 
-Read-mostly: every noun is READ-ONLY except 'segment', which is the first
-write-capable noun (segment add/update/move/delete author a Video's Segment
-plan). More nouns may gain writes over time; each verb's own --help is
-authoritative about whether it reads or writes.
+Read-mostly: most verbs are READS. A growing set of nouns has WRITE verbs —
+'segment' (add/update/move/delete), 'lesson' (create), 'video' (create/move/
+update) and 'pitch' (create/update). Every other verb is read-only, and each
+verb's own --help is authoritative about whether it reads or writes.
 
 DOMAIN MODEL
   A Course is the primary entity. Its structure is snapshotted into Course
@@ -54,11 +54,18 @@ OUTPUT CONTRACT
   Errors => a JSON object on STDERR carrying the Effect error _tag. STDOUT is
   always pure data. Exit codes: 0 ok, 2 not-found, 3 invalid-input, 4 db/internal.
 
-WRITES ('segment' only)
-  'segment add/update/move/delete' author a Video's Segment plan. Writes hit the
-  database immediately — no confirmation prompt, no dry-run. Each write echoes
-  the affected row (delete echoes the archived row). Flags come BEFORE the
-  positional <id> (a flag after it exits 3). See 'cvm segment --help'.
+WRITES
+  Write verbs hit the database immediately — no confirmation prompt, no dry-run —
+  and each echoes the affected row as one pretty JSON object. Flags come BEFORE
+  any positional <id> (a flag after it exits 3). The write surface:
+    segment add/update/move/delete   author a Video's Segment plan
+                                     (add --pitch <id> targets a pitch's video)
+    lesson  create                   create a GHOST lesson in a Section
+    video   create/move/update       create a Video, re-home it to a lesson/
+                                     pitch, or rename it (--name)
+    pitch   create/update            create a Pitch (--title required) or patch
+                                     its copy/ranking fields
+  See each noun's --help for the authoritative contract.
 
 NOUNS
   course version section lesson video clip segment pitch deliverable

--- a/app/services/db-pitch-operations.server.ts
+++ b/app/services/db-pitch-operations.server.ts
@@ -12,6 +12,30 @@ import { Effect } from "effect";
 
 export type PitchState = "idle" | "scheduled" | "shipped";
 
+/** The mutable copy/ranking fields of a Pitch (all optional; partial writes). */
+export interface PitchFields {
+  title?: string;
+  description?: string;
+  contentPlan?: string;
+  youtubeTitle?: string;
+  youtubeThumbnailDescription?: string;
+  newsletterTitle?: string;
+  tweet?: string;
+  priority?: number;
+  effort?: number;
+}
+
+/** Drop undefined keys so a partial patch only touches the fields provided. */
+const prunePitchFields = (
+  fields: PitchFields
+): Record<string, string | number> => {
+  const set: Record<string, string | number> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) set[key] = value;
+  }
+  return set;
+};
+
 export function derivePitchState(deliverableStatuses: string[]): PitchState {
   if (deliverableStatuses.length === 0) return "idle";
   const allTerminal = deliverableStatuses.every(
@@ -46,9 +70,13 @@ export const createPitchOperations = (db: Database) => {
     return and(...conditions);
   };
 
-  const createPitch = Effect.fn("createPitch")(function* () {
+  const createPitch = Effect.fn("createPitch")(function* (
+    fields: PitchFields = {}
+  ) {
+    // Insert the provided fields in ONE write (atomic): a titled pitch is born
+    // with its title, never as a titleless row patched afterwards.
     const results = yield* makeDbCall(() =>
-      db.insert(pitches).values({}).returning()
+      db.insert(pitches).values(prunePitchFields(fields)).returning()
     );
 
     const pitch = results[0];
@@ -257,22 +285,9 @@ export const createPitchOperations = (db: Database) => {
    */
   const updatePitch = Effect.fn("updatePitch")(function* (
     id: string,
-    fields: {
-      title?: string;
-      description?: string;
-      contentPlan?: string;
-      youtubeTitle?: string;
-      youtubeThumbnailDescription?: string;
-      newsletterTitle?: string;
-      tweet?: string;
-      priority?: number;
-      effort?: number;
-    }
+    fields: PitchFields
   ) {
-    const set: Record<string, string | number> = {};
-    for (const [key, value] of Object.entries(fields)) {
-      if (value !== undefined) set[key] = value;
-    }
+    const set = prunePitchFields(fields);
 
     const results = yield* makeDbCall(() =>
       db

--- a/app/services/db-pitch-operations.server.ts
+++ b/app/services/db-pitch-operations.server.ts
@@ -246,6 +246,54 @@ export const createPitchOperations = (db: Database) => {
     return pitch;
   });
 
+  /**
+   * Patch a Pitch's copy/ranking fields in one write. Only the keys present in
+   * `fields` are updated (undefined keys are dropped), so this is a partial
+   * update — the caller passes exactly the fields it wants to change. Bumps
+   * updatedAt and returns the updated row; NotFoundError when the id is absent.
+   *
+   * Unlike updatePitchField (single, stringly-typed field), this is the typed
+   * multi-field updater used by the CLI's `pitch create` / `pitch update`.
+   */
+  const updatePitch = Effect.fn("updatePitch")(function* (
+    id: string,
+    fields: {
+      title?: string;
+      description?: string;
+      contentPlan?: string;
+      youtubeTitle?: string;
+      youtubeThumbnailDescription?: string;
+      newsletterTitle?: string;
+      tweet?: string;
+      priority?: number;
+      effort?: number;
+    }
+  ) {
+    const set: Record<string, string | number> = {};
+    for (const [key, value] of Object.entries(fields)) {
+      if (value !== undefined) set[key] = value;
+    }
+
+    const results = yield* makeDbCall(() =>
+      db
+        .update(pitches)
+        .set({ ...set, updatedAt: new Date() })
+        .where(eq(pitches.id, id))
+        .returning()
+    );
+
+    const pitch = results[0];
+
+    if (!pitch) {
+      return yield* new NotFoundError({
+        type: "updatePitch",
+        params: { id },
+      });
+    }
+
+    return pitch;
+  });
+
   const createVideoFromPitch = Effect.fn("createVideoFromPitch")(function* (
     pitchId: string
   ) {
@@ -300,6 +348,7 @@ export const createPitchOperations = (db: Database) => {
     getPitch,
     getPitchWithVideos,
     updatePitchField,
+    updatePitch,
     createVideoFromPitch,
     deletePitch,
   };

--- a/app/services/db-video-operations.server.ts
+++ b/app/services/db-video-operations.server.ts
@@ -13,6 +13,7 @@ import {
 import { and, asc, desc, eq, isNull, ne } from "drizzle-orm";
 import { Effect } from "effect";
 import { copyVideoImpl } from "@/services/db-video-operations.copy.server";
+import { createVideoWriteOps } from "@/services/db-video-operations.write.server";
 
 const makeDbCall = <T>(fn: () => Promise<T>) => {
   return Effect.tryPromise({
@@ -721,6 +722,7 @@ export const createVideoOperations = (
     updateVideoPath,
     copyVideo,
     updateVideoLesson,
+    ...createVideoWriteOps(db),
     updateVideoArchiveStatus,
     getNextVideoId,
     getPreviousVideoId,

--- a/app/services/db-video-operations.write.server.ts
+++ b/app/services/db-video-operations.write.server.ts
@@ -1,0 +1,136 @@
+import { type Database } from "@/services/drizzle-service.server";
+import { videos } from "@/db/schema";
+import {
+  NotFoundError,
+  UnknownDBServiceError,
+  VideoPathTakenError,
+} from "@/services/db-service-errors";
+import { and, eq, ne } from "drizzle-orm";
+import { Effect } from "effect";
+
+const makeDbCall = <T>(fn: () => Promise<T>) =>
+  Effect.tryPromise({
+    try: fn,
+    catch: (e) => new UnknownDBServiceError({ cause: e }),
+  });
+
+/**
+ * The Video WRITE verbs added for the `cvm` CLI, split out of
+ * db-video-operations.server.ts to keep that file under the repo's per-file
+ * token budget (see db-video-operations.copy.server.ts for the same pattern).
+ * These are spread into VideoOperationsService's returned object, so callers
+ * see them as ordinary service methods.
+ */
+export const createVideoWriteOps = (db: Database) => {
+  /**
+   * Fetch a single Video row (no relations) by id, failing NotFoundError when
+   * absent. Used by the CLI write verbs to echo the affected row.
+   */
+  const getVideoRowById = Effect.fn("getVideoRowById")(function* (id: string) {
+    const video = yield* makeDbCall(() =>
+      db.query.videos.findFirst({ where: eq(videos.id, id) })
+    );
+
+    if (!video) {
+      return yield* new NotFoundError({
+        type: "getVideoRowById",
+        params: { id },
+      });
+    }
+
+    return video;
+  });
+
+  /**
+   * Link a Video to a Pitch, enforcing the single-parent invariant: setting a
+   * pitch parent also clears any lesson parent (a Pitch packages Standalone
+   * videos, so a pitch-bound video is never lesson-bound). Returns the updated
+   * row; NotFoundError when the video id is absent.
+   */
+  const linkVideoToPitch = Effect.fn("linkVideoToPitch")(function* (opts: {
+    videoId: string;
+    pitchId: string;
+  }) {
+    const [updated] = yield* makeDbCall(() =>
+      db
+        .update(videos)
+        .set({ pitchId: opts.pitchId, lessonId: null, updatedAt: new Date() })
+        .where(eq(videos.id, opts.videoId))
+        .returning()
+    );
+
+    if (!updated) {
+      return yield* new NotFoundError({
+        type: "linkVideoToPitch",
+        params: { videoId: opts.videoId },
+      });
+    }
+
+    return updated;
+  });
+
+  /**
+   * Move a Video into a Lesson, enforcing the single-parent invariant: setting a
+   * lesson parent also clears any pitch parent. Re-checks the (lessonId, path)
+   * uniqueness guard (VideoPathTakenError) before mutating — unlike
+   * updateVideoLesson, which does not. Returns the updated row; NotFoundError
+   * when the video id is absent.
+   */
+  const moveVideoToLesson = Effect.fn("moveVideoToLesson")(function* (opts: {
+    videoId: string;
+    lessonId: string;
+  }) {
+    const current = yield* makeDbCall(() =>
+      db.query.videos.findFirst({
+        where: eq(videos.id, opts.videoId),
+        columns: { path: true },
+      })
+    );
+
+    if (!current) {
+      return yield* new NotFoundError({
+        type: "moveVideoToLesson",
+        params: { videoId: opts.videoId },
+      });
+    }
+
+    // (lessonId, path) must be free among the target lesson's active videos.
+    const clash = yield* makeDbCall(() =>
+      db.query.videos.findFirst({
+        where: and(
+          eq(videos.lessonId, opts.lessonId),
+          eq(videos.path, current.path),
+          eq(videos.archived, false),
+          ne(videos.id, opts.videoId)
+        ),
+        columns: { id: true },
+      })
+    );
+
+    if (clash) {
+      return yield* new VideoPathTakenError({
+        path: current.path,
+        message: `Video name "${current.path}" is already taken in this lesson`,
+      });
+    }
+
+    const [updated] = yield* makeDbCall(() =>
+      db
+        .update(videos)
+        .set({ lessonId: opts.lessonId, pitchId: null, updatedAt: new Date() })
+        .where(eq(videos.id, opts.videoId))
+        .returning()
+    );
+
+    if (!updated) {
+      return yield* new NotFoundError({
+        type: "moveVideoToLesson",
+        params: { videoId: opts.videoId },
+      });
+    }
+
+    return updated;
+  });
+
+  return { getVideoRowById, linkVideoToPitch, moveVideoToLesson };
+};


### PR DESCRIPTION
## What

Extends the agent-facing `cvm` CLI beyond segment writes with a set of low-stakes, immediate write verbs (no confirmation, no dry-run — matching the existing `segment` precedent). Each write echoes the affected row as one pretty JSON object; flags come before any positional `<id>`.

### New verbs
- **`lesson create --section <id> --title <t> [--before|--after <lessonId>]`** — creates a **ghost** lesson (DB-only, no disk/repo side effects), computing `order` + slug and shifting siblings for anchored inserts. Appends when no anchor is given.
- **`video create --name <n> [--lesson <id> | --pitch <id>]`** — `--name` always required; parents mutually exclusive; neither = standalone.
- **`video move <id> [--lesson <id> | --pitch <id>]`** — re-homes an existing video to exactly one parent, **clearing the previous association** (single-parent invariant).
- **`video update --name <n> <id>`** — rename (writes the `path` column).
- **`pitch create --title <t> [--description --content-plan --youtube-title --youtube-thumbnail --newsletter-title --tweet --priority N --effort 1|2|3]`** — `--title` required (a pitch needs a title to appear in list/get).
- **`pitch update <id> [same flags]`** — patch any subset (rename = `--title`); ≥1 flag required.
- **`segment add --pitch <id>`** — alternative to `--video` (mutually exclusive); resolves the pitch's video: auto-creates one on 0, uses the one on 1, errors on >1.

### Service layer
- `VideoOperationsService`: `getVideoRowById`, `linkVideoToPitch` (sets pitch, clears lesson), `moveVideoToLesson` (name-collision guard + clears pitch) — split into `db-video-operations.write.server.ts`.
- `PitchOperationsService`: typed `createPitch(fields)` (atomic insert) and `updatePitch(id, partial)`, sharing one `prunePitchFields` undefined-filter.

## Behavior notes
- Name-collision domain errors map to **exit 3**; unknown parents/anchors are pre-validated for clean **exit 2**.
- `segment add --pitch` on a pitch with no video will **create** its backing video as a side effect (documented in `--help`).
- Domain convention (a video has exactly one of lesson/pitch) is enforced by the CLI's create/move paths, though the DB itself does not constrain it.

## Structure
Per the repo's 5500-token-per-file pre-commit gate: segment help text extracted to `segment.help.ts`, video write methods to `db-video-operations.write.server.ts`, and new tests into two files over a shared `cli-write-test-harness.ts` (the existing `cli-integration.test.ts` was already over the gate, so new tests were kept out of it).

## Review follow-ups (`f69ee9b2`)
Addressed a two-axis (standards + spec) self-review:
- **Non-empty title/name** — blank `--title` (pitch create/update) and blank `--name` (video create/update) now return exit 3. An empty title otherwise wrote a pitch invisible to `list`/`get`.
- **Atomic pitch create** — `pitch create` is a single insert carrying the title (`createPitch(fields)`), not a titleless insert + follow-up update, so no titleless row can survive a mid-sequence failure.
- **De-duplication** — extracted `rejectBothFlags` for the 5 identical mutually-exclusive-flag guards; `createPitch`/`updatePitch` share one `prunePitchFields`.
- **Help sync** — fixed the stale `segment` `--help`/JSDoc that still claimed segment was the *only* write-capable noun (it now points at lesson/video/pitch, matching the root help).

## Tests
48 new integration tests run the real `buildProgram` over PGlite and assert `{stdout, stderr, exitCode}`. All 129 CLI tests pass; `tsgo` typecheck clean; pre-commit hooks (lint-staged, typecheck, token check) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
