### PR TITLE
chore: install code-review skill in agent-review workflow

### DIFF
--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -61,13 +61,13 @@ jobs:
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
-      # Install Matt's `review` skill globally (~/.claude/skills), always at
+      # Install Matt's `code-review` skill globally (~/.claude/skills), always at
       # latest — every run exercises the current version of the skill. Global
       # (not project) install keeps it outside the git work tree so the review
       # agent's commit step can never sweep it into the PR branch. Scoped to the
       # claude-code agent so the step exits 0 (other agents reject -g installs).
-      - name: Install review skill
-        run: npx --yes skills@latest add mattpocock/skills -g -s review -a claude-code -y --copy
+      - name: Install code-review skill
+        run: npx --yes skills@latest add mattpocock/skills -g -s code-review -a claude-code -y --copy
 
       - name: Configure git identity
         run: |

--- a/.sandcastle/review/prompt.md
+++ b/.sandcastle/review/prompt.md
@@ -36,9 +36,9 @@ The following PR comments have been fetched by the workflow. They are tagged by 
 
 # REVIEW PROCESS
 
-## 1. Analyse with the `review` skill
+## 1. Analyse with the `code-review` skill
 
-Use the **`review` skill** (installed globally at `~/.claude/skills/review`) to produce the review. It analyses the diff along two axes — **Standards** and **Spec** — using parallel sub-agents. Its findings are the **single source of truth** for what's wrong with this branch: act only on what it reports, not on a separate ad-hoc pass of your own.
+Use the **`code-review` skill** (installed globally at `~/.claude/skills/code-review`) to produce the review. It analyses the diff along two axes — **Standards** and **Spec** — using parallel sub-agents. Its findings are the **single source of truth** for what's wrong with this branch: act only on what it reports, not on a separate ad-hoc pass of your own.
 
 Invoke it with everything it needs, so it does **not** run its own discovery and does **not** prompt or pause:
 


### PR DESCRIPTION
## What

The `review` skill graduated to the public skillset as `code-review`. Update the `agent-review` workflow so it installs the renamed skill.

## Changes

- **`.github/workflows/agent-review.yml`** — install step now runs `skills@latest add mattpocock/skills -g -s code-review …` (step name + comment updated to match).
- **`.sandcastle/review/prompt.md`** — point the review prompt at the new skill name/path (`code-review` at `~/.claude/skills/code-review`) so the invocation actually resolves after the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)