### PR TITLE
feat(cvm): lesson update (rename) + move (reorder / re-home)

### DIFF
--- a/app/cli/cli-integration.test.ts
+++ b/app/cli/cli-integration.test.ts
@@ -10,6 +10,7 @@ import { SegmentOperationsService } from "@/services/db-segment-operations.serve
 import { PitchOperationsService } from "@/services/db-pitch-operations.server";
 import { DeliverableOperationsService } from "@/services/db-deliverable-operations.server";
 import { SearchOperationsService } from "@/services/db-search-operations.server";
+import { CourseWriteService } from "@/services/course-write-service";
 import {
   createTestDb,
   truncateAllTables,
@@ -42,6 +43,7 @@ let cliTestLayer: Layer.Layer<
   | PitchOperationsService
   | DeliverableOperationsService
   | SearchOperationsService
+  | CourseWriteService
 >;
 
 // Mirror app/cli/layer.ts `cliLayer`, which uses `provideMerge` so the runtime
@@ -58,7 +60,8 @@ const buildLayerFor = (db: TestDb) =>
     SegmentOperationsService.Default,
     PitchOperationsService.Default,
     DeliverableOperationsService.Default,
-    SearchOperationsService.Default
+    SearchOperationsService.Default,
+    CourseWriteService.Default
   ).pipe(Layer.provideMerge(Layer.succeed(DrizzleService, db as any)));
 
 interface RunResult {

--- a/app/cli/cli-lesson-move-update.test.ts
+++ b/app/cli/cli-lesson-move-update.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import {
+  createTestDb,
+  truncateAllTables,
+  type TestDb,
+} from "@/test-utils/pglite";
+import * as schema from "@/db/schema";
+import {
+  buildWriteLayer,
+  makeRun,
+  ndjson,
+  one,
+  type RunResult,
+} from "./cli-write-test-harness";
+
+// ===========================================================================
+// cvm WRITE verbs — lesson update (rename) + move (reorder / re-home)
+//
+// All fixtures use a GHOST course (no filePath) with GHOST lessons, so the move
+// planner emits zero filesystem ops and the disk-sync validation short-circuits
+// (repoPath === null). That exercises the full CLI → CourseWriteService wiring,
+// the planner, and the Draft guard as a pure DB path over PGlite. The on-disk
+// renumber / git-mv cascade for REAL lessons is covered by the service's own
+// suites (lesson-move-planner, course-repo-write-*).
+//
+// CLI convention: options come BEFORE the positional <id> (a flag after the id
+// is rejected), so every invocation below is `move --flag val <id>`.
+// ===========================================================================
+
+let testDb: TestDb;
+let run: (argv: ReadonlyArray<string>) => Promise<RunResult>;
+
+beforeAll(async () => {
+  const result = await createTestDb();
+  testDb = result.testDb;
+  run = makeRun(buildWriteLayer(testDb));
+});
+
+interface Lesson {
+  id: string;
+  sectionId: string;
+  title: string;
+  path: string;
+  order: number;
+  fsStatus: string;
+  archived: boolean;
+}
+
+interface MoveSeed {
+  repoId: string;
+  draftVersionId: string;
+  sectionAId: string;
+  sectionBId: string;
+  /** Section A ghost lessons, in seeded order. */
+  a1: string;
+  a2: string;
+  a3: string;
+  /** Section B ghost lesson. */
+  b1: string;
+  /** A lesson living in an OLDER (published/frozen) version. */
+  publishedLessonId: string;
+}
+
+/** Add a ghost lesson to a section and return its id. */
+const addGhost = async (
+  db: TestDb,
+  sectionId: string,
+  path: string,
+  title: string,
+  order: number
+): Promise<string> => {
+  const [row] = await db
+    .insert(schema.lessons)
+    .values({ sectionId, path, title, order, fsStatus: "ghost" })
+    .returning();
+  return row!.id;
+};
+
+/**
+ * A ghost course (filePath null) with two sections of ghost lessons, plus an
+ * older frozen version carrying one lesson (for the Draft-guard tests). The
+ * draft is the NEWER version by createdAt.
+ */
+const seedMove = async (db: TestDb): Promise<MoveSeed> => {
+  const [course] = await db
+    .insert(schema.courses)
+    .values({ name: "Beta", slug: "beta" }) // no filePath => ghost course
+    .returning();
+
+  const [oldVersion] = await db
+    .insert(schema.courseVersions)
+    .values({
+      repoId: course!.id,
+      name: "v1",
+      createdAt: new Date("2024-01-01T00:00:00Z"),
+    })
+    .returning();
+  const [draftVersion] = await db
+    .insert(schema.courseVersions)
+    .values({
+      repoId: course!.id,
+      name: "",
+      createdAt: new Date("2024-06-01T00:00:00Z"),
+    })
+    .returning();
+
+  const [sectionA] = await db
+    .insert(schema.sections)
+    .values({ repoVersionId: draftVersion!.id, path: "01-alpha", order: 1 })
+    .returning();
+  const [sectionB] = await db
+    .insert(schema.sections)
+    .values({ repoVersionId: draftVersion!.id, path: "02-beta", order: 2 })
+    .returning();
+
+  const a1 = await addGhost(db, sectionA!.id, "a-one", "A One", 1);
+  const a2 = await addGhost(db, sectionA!.id, "a-two", "A Two", 2);
+  const a3 = await addGhost(db, sectionA!.id, "a-three", "A Three", 3);
+  const b1 = await addGhost(db, sectionB!.id, "b-one", "B One", 1);
+
+  const [oldSection] = await db
+    .insert(schema.sections)
+    .values({ repoVersionId: oldVersion!.id, path: "01-old", order: 1 })
+    .returning();
+  const publishedLessonId = await addGhost(
+    db,
+    oldSection!.id,
+    "old-one",
+    "Old One",
+    1
+  );
+
+  return {
+    repoId: course!.id,
+    draftVersionId: draftVersion!.id,
+    sectionAId: sectionA!.id,
+    sectionBId: sectionB!.id,
+    a1,
+    a2,
+    a3,
+    b1,
+    publishedLessonId,
+  };
+};
+
+/** Ordered lesson ids in a section (as `lesson list`, which sorts by order). */
+const orderOf = async (sectionId: string): Promise<string[]> =>
+  (
+    ndjson(
+      (await run(["lesson", "list", "--section", sectionId])).stdout
+    ) as Lesson[]
+  ).map((l) => l.id);
+
+let s: MoveSeed;
+beforeEach(async () => {
+  await truncateAllTables(testDb);
+  s = await seedMove(testDb);
+});
+
+// ---------------------------------------------------------------------------
+// update (rename)
+// ---------------------------------------------------------------------------
+
+describe("lesson update --title", () => {
+  it("renames the title, leaves the slug/path untouched, echoes the lesson", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "lesson",
+      "update",
+      "--title",
+      "A Much Better Title",
+      s.a1,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toMatch(/^\{\n/); // single pretty object
+    const lesson = one<Lesson>(stdout);
+    expect(lesson.title).toBe("A Much Better Title");
+    expect(lesson.path).toBe("a-one"); // slug is deliberately NOT re-derived
+  });
+
+  it("rejects an empty title as invalid input (exit 3)", async () => {
+    const { exitCode, stderr } = await run([
+      "lesson",
+      "update",
+      "--title",
+      "   ",
+      s.a1,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stderr).toContain("ParseError");
+  });
+
+  it("reports a missing lesson as not-found (exit 2)", async () => {
+    const { exitCode } = await run([
+      "lesson",
+      "update",
+      "--title",
+      "X",
+      "les_missing",
+    ]);
+    expect(exitCode).toBe(2);
+  });
+
+  it("refuses to edit a lesson in a published version (exit 3)", async () => {
+    const { exitCode, stderr } = await run([
+      "lesson",
+      "update",
+      "--title",
+      "Nope",
+      s.publishedLessonId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stderr).toContain("ParseError");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// move — same-section reorder
+// ---------------------------------------------------------------------------
+
+describe("lesson move (same-section reorder)", () => {
+  it("--before puts the lesson immediately before the anchor", async () => {
+    const { exitCode } = await run([
+      "lesson",
+      "move",
+      "--before",
+      s.a1,
+      s.a3,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(await orderOf(s.sectionAId)).toEqual([s.a3, s.a1, s.a2]);
+  });
+
+  it("--after puts the lesson immediately after the anchor", async () => {
+    const { exitCode } = await run(["lesson", "move", "--after", s.a3, s.a1]);
+    expect(exitCode).toBe(0);
+    expect(await orderOf(s.sectionAId)).toEqual([s.a2, s.a3, s.a1]);
+  });
+
+  it("no anchor appends to the end of the section", async () => {
+    const { exitCode } = await run(["lesson", "move", s.a1]);
+    expect(exitCode).toBe(0);
+    expect(await orderOf(s.sectionAId)).toEqual([s.a2, s.a3, s.a1]);
+  });
+
+  it("rejects moving a lesson relative to itself (exit 3)", async () => {
+    const { exitCode } = await run([
+      "lesson",
+      "move",
+      "--before",
+      s.a1,
+      s.a1,
+    ]);
+    expect(exitCode).toBe(3);
+  });
+
+  it("rejects both --before and --after (exit 3)", async () => {
+    const { exitCode } = await run([
+      "lesson",
+      "move",
+      "--before",
+      s.a2,
+      "--after",
+      s.a3,
+      s.a1,
+    ]);
+    expect(exitCode).toBe(3);
+  });
+
+  it("reports an anchor that is not a sibling as not-found (exit 2)", async () => {
+    const { exitCode } = await run([
+      "lesson",
+      "move",
+      "--before",
+      s.b1, // in section B, not a sibling of a1
+      s.a1,
+    ]);
+    expect(exitCode).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// move — cross-section re-home
+// ---------------------------------------------------------------------------
+
+describe("lesson move (cross-section)", () => {
+  it("--section appends the lesson to the destination and removes it from the source", async () => {
+    const { stdout, exitCode } = await run([
+      "lesson",
+      "move",
+      "--section",
+      s.sectionBId,
+      s.a1,
+    ]);
+    expect(exitCode).toBe(0);
+    const moved = one<{ section: { id: string } }>(stdout);
+    expect(moved.section.id).toBe(s.sectionBId);
+    expect(await orderOf(s.sectionAId)).toEqual([s.a2, s.a3]);
+    expect(await orderOf(s.sectionBId)).toEqual([s.b1, s.a1]);
+  });
+
+  it("--section with --before positions the lesson at the anchor", async () => {
+    const { exitCode } = await run([
+      "lesson",
+      "move",
+      "--section",
+      s.sectionBId,
+      "--before",
+      s.b1,
+      s.a1,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(await orderOf(s.sectionBId)).toEqual([s.a1, s.b1]);
+  });
+
+  it("--section with --after positions the lesson after the anchor", async () => {
+    const { exitCode } = await run([
+      "lesson",
+      "move",
+      "--section",
+      s.sectionBId,
+      "--after",
+      s.b1,
+      s.a1,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(await orderOf(s.sectionBId)).toEqual([s.b1, s.a1]);
+  });
+
+  it("reports a missing destination section as not-found (exit 2)", async () => {
+    const { exitCode } = await run([
+      "lesson",
+      "move",
+      "--section",
+      "sec_missing",
+      s.a1,
+    ]);
+    expect(exitCode).toBe(2);
+  });
+
+  it("refuses to move a lesson in a published version (exit 3)", async () => {
+    const { exitCode, stderr } = await run([
+      "lesson",
+      "move",
+      s.publishedLessonId, // lives in the older, frozen version
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stderr).toContain("ParseError");
+  });
+});

--- a/app/cli/cli-lesson-move-update.test.ts
+++ b/app/cli/cli-lesson-move-update.test.ts
@@ -51,6 +51,10 @@ interface MoveSeed {
   draftVersionId: string;
   sectionAId: string;
   sectionBId: string;
+  /** An archived (deleted) section in the Draft version. */
+  archivedSectionId: string;
+  /** A section in the OLDER (frozen) version. */
+  oldSectionId: string;
   /** Section A ghost lessons, in seeded order. */
   a1: string;
   a2: string;
@@ -118,6 +122,16 @@ const seedMove = async (db: TestDb): Promise<MoveSeed> => {
   const a3 = await addGhost(db, sectionA!.id, "a-three", "A Three", 3);
   const b1 = await addGhost(db, sectionB!.id, "b-one", "B One", 1);
 
+  const [archivedSection] = await db
+    .insert(schema.sections)
+    .values({
+      repoVersionId: draftVersion!.id,
+      path: "03-gone",
+      order: 3,
+      archivedAt: new Date("2024-05-01T00:00:00Z"),
+    })
+    .returning();
+
   const [oldSection] = await db
     .insert(schema.sections)
     .values({ repoVersionId: oldVersion!.id, path: "01-old", order: 1 })
@@ -135,6 +149,8 @@ const seedMove = async (db: TestDb): Promise<MoveSeed> => {
     draftVersionId: draftVersion!.id,
     sectionAId: sectionA!.id,
     sectionBId: sectionB!.id,
+    archivedSectionId: archivedSection!.id,
+    oldSectionId: oldSection!.id,
     a1,
     a2,
     a3,
@@ -336,6 +352,31 @@ describe("lesson move (cross-section)", () => {
       s.a1,
     ]);
     expect(exitCode).toBe(2);
+  });
+
+  it("reports an archived destination section as not-found (exit 2)", async () => {
+    const { exitCode } = await run([
+      "lesson",
+      "move",
+      "--section",
+      s.archivedSectionId,
+      s.a1,
+    ]);
+    expect(exitCode).toBe(2);
+    // and the lesson must NOT have moved.
+    expect(await orderOf(s.sectionAId)).toEqual([s.a1, s.a2, s.a3]);
+  });
+
+  it("reports a destination section in another version as not-found (exit 2)", async () => {
+    const { exitCode } = await run([
+      "lesson",
+      "move",
+      "--section",
+      s.oldSectionId, // exists, but in the frozen older version
+      s.a1,
+    ]);
+    expect(exitCode).toBe(2);
+    expect(await orderOf(s.sectionAId)).toEqual([s.a1, s.a2, s.a3]);
   });
 
   it("refuses to move a lesson in a published version (exit 3)", async () => {

--- a/app/cli/cli-write-test-harness.ts
+++ b/app/cli/cli-write-test-harness.ts
@@ -9,6 +9,7 @@ import { SegmentOperationsService } from "@/services/db-segment-operations.serve
 import { PitchOperationsService } from "@/services/db-pitch-operations.server";
 import { DeliverableOperationsService } from "@/services/db-deliverable-operations.server";
 import { SearchOperationsService } from "@/services/db-search-operations.server";
+import { CourseWriteService } from "@/services/course-write-service";
 import type { TestDb } from "@/test-utils/pglite";
 import * as schema from "@/db/schema";
 import { buildProgram } from "@/cli/main";
@@ -38,7 +39,8 @@ export const buildWriteLayer = (db: TestDb) =>
     SegmentOperationsService.Default,
     PitchOperationsService.Default,
     DeliverableOperationsService.Default,
-    SearchOperationsService.Default
+    SearchOperationsService.Default,
+    CourseWriteService.Default
   ).pipe(Layer.provideMerge(Layer.succeed(DrizzleService, db as never)));
 
 /** A run() bound to a specific captured-output layer. */

--- a/app/cli/commands/lesson.ts
+++ b/app/cli/commands/lesson.ts
@@ -543,8 +543,12 @@ const moveCmd = Command.make(
       const currentSectionId = lesson.sectionId;
       const targetSectionId = Option.getOrUndefined(section) ?? currentSectionId;
 
-      // A cross-section destination must exist AND belong to the same version —
-      // a lesson can only move among its own version's sections.
+      // A cross-section destination must exist, be active, AND belong to the
+      // same version — a lesson can only move among its own version's sections.
+      // getSectionWithHierarchyById is unfiltered, but the move planner builds
+      // its model from the archived-filtered section set, so an archived target
+      // would otherwise slip past here and silently plan a no-op (false
+      // success). Reject it as not-found, like every other unaddressable id.
       if (targetSectionId !== currentSectionId) {
         const target = yield* svc
           .getSectionWithHierarchyById(targetSectionId)
@@ -553,7 +557,10 @@ const moveCmd = Command.make(
               notFound("section", targetSectionId)
             )
           );
-        if (target.repoVersionId !== lesson.section.repoVersionId) {
+        if (
+          target.archivedAt !== null ||
+          target.repoVersionId !== lesson.section.repoVersionId
+        ) {
           return yield* notFound("section", targetSectionId);
         }
       }

--- a/app/cli/commands/lesson.ts
+++ b/app/cli/commands/lesson.ts
@@ -2,7 +2,9 @@ import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
 import { lessonSearchCmd } from "./search";
 import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
+import { VersionOperationsService } from "@/services/db-version-operations.server";
 import { VideoOperationsService } from "@/services/db-video-operations.server";
+import { CourseWriteService } from "@/services/course-write-service";
 import { toSlug } from "@/services/lesson-path-service";
 import {
   detail,
@@ -14,6 +16,39 @@ import {
   rejectBothFlags,
   withName,
 } from "@/cli/helpers";
+
+/**
+ * Refuse a write that targets a PUBLISHED (frozen) version.
+ *
+ * A course's Draft is simply its latest version (newest `createdAt`); every
+ * older version is a frozen snapshot that Publish left behind, and mutating one
+ * would silently corrupt history. Structural writes (`create`, `update`,
+ * `move`) all gate on this so a stale id can never edit a snapshot. `repoId` +
+ * `versionId` come off any lesson/section hierarchy (`repoVersion.repoId`,
+ * `repoVersionId`). Rejection is invalid-input (exit 3), not not-found — the id
+ * resolves fine, it just isn't editable.
+ */
+const assertDraftVersion = (coords: { repoId: string; versionId: string }) =>
+  Effect.gen(function* () {
+    const versionOps = yield* VersionOperationsService;
+    const latest = yield* versionOps.getLatestCourseVersion(coords.repoId);
+    if (!latest || latest.id !== coords.versionId) {
+      return yield* parseError(
+        "cannot edit a published version — edits go to the Draft " +
+          "(the course's latest version)",
+        "lesson"
+      );
+    }
+  });
+
+/** Draft guard for a lesson resolved via `getLessonWithHierarchyById`. */
+const assertDraftLesson = (lesson: {
+  section: { repoVersionId: string; repoVersion: { repoId: string } };
+}) =>
+  assertDraftVersion({
+    repoId: lesson.section.repoVersion.repoId,
+    versionId: lesson.section.repoVersionId,
+  });
 
 /**
  * `lesson` — read Lessons, the leaf authoring unit of a Course.
@@ -62,8 +97,16 @@ VERBS
   tree <id> [--depth N] Skeleton tree lesson -> videos -> clips.
   create --section <id> --title <t> [--before|--after <lessonId>]
                         Create a GHOST lesson in a Section (WRITE).
+  update <id> --title <t>
+                        Rename a lesson's display title (WRITE; slug unchanged).
+  move <id> [--section <id>] [--before|--after <lessonId>]
+                        Reorder within a section, or re-home to another (WRITE).
   search <id> <query>   Substring search down this lesson's subtree
                         (--type lesson|video|segment).
+
+WRITES honour DB↔disk correctness: reordering or moving a REAL (on-disk) lesson
+renumbers folder prefixes and git-moves directories, so those verbs need the
+course repo checked out. Writes only ever target the Draft (latest) version.
 
 EXAMPLES
   cvm lesson list --section sec_123
@@ -147,6 +190,45 @@ as one pretty JSON object.
 Examples:
   cvm lesson create --section sec_123 --title "Intro to Effect"
   cvm lesson create --section sec_123 --title "Setup" --before les_abc`;
+
+const UPDATE_HELP = `Rename a lesson's display TITLE by id. Requires --title <t> (an update with an
+empty title is invalid input, exit 3).
+
+This changes the human-readable 'title' only — the lesson's 'path' (its slug and,
+for a real lesson, its on-disk folder name) is deliberately left untouched, so
+renaming never moves a URL or a directory. Editing a lesson in a published
+(frozen) version is refused (exit 3); edits go to the Draft.
+
+Echoes the updated lesson with its Section/Version/Repo hierarchy (as 'get').
+
+Examples:
+  cvm lesson update les_abc --title "A clearer title"`;
+
+const MOVE_HELP = `Reposition a lesson: reorder it within its Section, or re-home it to another.
+
+  cvm lesson move <id> [--section <id>] [--before|--after <lessonId>]
+
+  --section <id>       destination Section (omit to reorder within the lesson's
+                       current section).
+  --before <lessonId>  place immediately before that lesson.
+  --after  <lessonId>  place immediately after that lesson.
+                       (omit both anchors to append to the end of the section.)
+
+--before/--after are mutually exclusive. Within-section, the anchor must be a
+sibling; cross-section, it must live in the destination section — otherwise
+not-found (exit 2). Editing a published (frozen) version is refused (exit 3).
+
+CORRECTNESS: moving/reordering a REAL (on-disk) lesson renumbers folder prefixes
+and git-moves directories to keep the DB and repo in lockstep, so the course repo
+must be checked out. Ghost (planned) lessons are a pure DB update.
+
+Echoes the moved lesson with its Section/Version/Repo hierarchy (as 'get').
+
+Examples:
+  cvm lesson move les_abc --before les_def          # reorder within section
+  cvm lesson move les_abc --after les_def           # reorder within section
+  cvm lesson move les_abc --section sec_9            # append to another section
+  cvm lesson move les_abc --section sec_9 --before les_ghi`;
 
 // ---------------------------------------------------------------------------
 // list --section <id>
@@ -312,11 +394,17 @@ const createCmd = Command.make(
       const svc = yield* LessonSectionOperationsService;
 
       // Section must exist (clean exit 2 instead of an FK violation, exit 4).
-      yield* svc
+      const targetSection = yield* svc
         .getSectionWithHierarchyById(section)
         .pipe(
           Effect.catchTag("NotFoundError", () => notFound("section", section))
         );
+
+      // Writes only ever target the Draft — never a frozen published snapshot.
+      yield* assertDraftVersion({
+        repoId: targetSection.repoVersion.repoId,
+        versionId: targetSection.repoVersionId,
+      });
 
       const siblings = yield* svc.getLessonsBySectionId(section);
       const maxOrder =
@@ -357,6 +445,157 @@ const createCmd = Command.make(
 ).pipe(Command.withDescription(detail(CREATE_HELP)));
 
 // ---------------------------------------------------------------------------
+// update <id> --title <t>
+// ---------------------------------------------------------------------------
+
+const updateId = Args.text({ name: "id" });
+const updateTitle = Options.text("title").pipe(
+  Options.withDescription(
+    "The lesson's new display title (the slug/path is left unchanged)."
+  )
+);
+
+const updateCmd = Command.make(
+  "update",
+  { id: updateId, title: updateTitle },
+  ({ id, title }) =>
+    Effect.gen(function* () {
+      if (title.trim().length === 0) {
+        return yield* parseError("update needs a non-empty --title", "lesson");
+      }
+
+      const svc = yield* LessonSectionOperationsService;
+
+      // Resolve the lesson (with hierarchy for the Draft guard); archived and
+      // absent both read as not-found (exit 2), matching `get`.
+      const lesson = yield* svc
+        .getLessonWithHierarchyById(id)
+        .pipe(Effect.catchTag("NotFoundError", () => notFound("lesson", id)));
+      if (lesson.archived) return yield* notFound("lesson", id);
+
+      yield* assertDraftLesson(lesson);
+
+      // Title-only patch: no path change, so the per-section slug guard never
+      // fires and no on-disk folder moves — a rename is a pure metadata write.
+      yield* svc.updateLesson(id, { title });
+
+      const updated = yield* svc.getLessonWithHierarchyById(id);
+      yield* emitObject(updated);
+    })
+).pipe(Command.withDescription(detail(UPDATE_HELP)));
+
+// ---------------------------------------------------------------------------
+// move <id> [--section <id>] [--before|--after <lessonId>]
+// ---------------------------------------------------------------------------
+
+const moveId = Args.text({ name: "id" });
+const moveSection = Options.text("section").pipe(
+  Options.withDescription(
+    "Destination Section id (omit to reorder within the current section)."
+  ),
+  Options.optional
+);
+const moveBefore = Options.text("before").pipe(
+  Options.withDescription(
+    "Place immediately before this lesson id (mutually exclusive with --after)."
+  ),
+  Options.optional
+);
+const moveAfter = Options.text("after").pipe(
+  Options.withDescription(
+    "Place immediately after this lesson id (mutually exclusive with --before)."
+  ),
+  Options.optional
+);
+
+const moveCmd = Command.make(
+  "move",
+  { id: moveId, section: moveSection, before: moveBefore, after: moveAfter },
+  ({ id, section, before, after }) =>
+    Effect.gen(function* () {
+      const b = Option.getOrUndefined(before);
+      const a = Option.getOrUndefined(after);
+      yield* rejectBothFlags({
+        a: b,
+        b: a,
+        flags: ["--before", "--after"],
+        entity: "lesson",
+      });
+      const anchorId = b ?? a;
+
+      const svc = yield* LessonSectionOperationsService;
+      const writes = yield* CourseWriteService;
+
+      // The lesson being moved must exist, be active, and live in the Draft.
+      const lesson = yield* svc
+        .getLessonWithHierarchyById(id)
+        .pipe(Effect.catchTag("NotFoundError", () => notFound("lesson", id)));
+      if (lesson.archived) return yield* notFound("lesson", id);
+      yield* assertDraftLesson(lesson);
+
+      if (anchorId === id) {
+        return yield* parseError(
+          "a lesson cannot be moved relative to itself",
+          "lesson"
+        );
+      }
+
+      const currentSectionId = lesson.sectionId;
+      const targetSectionId = Option.getOrUndefined(section) ?? currentSectionId;
+
+      // A cross-section destination must exist AND belong to the same version —
+      // a lesson can only move among its own version's sections.
+      if (targetSectionId !== currentSectionId) {
+        const target = yield* svc
+          .getSectionWithHierarchyById(targetSectionId)
+          .pipe(
+            Effect.catchTag("NotFoundError", () =>
+              notFound("section", targetSectionId)
+            )
+          );
+        if (target.repoVersionId !== lesson.section.repoVersionId) {
+          return yield* notFound("section", targetSectionId);
+        }
+      }
+
+      if (targetSectionId === currentSectionId) {
+        // -- Same-section reorder. planLessonMove no-ops a same-section move, so
+        // reordering goes through reorderLessons with the full desired id list:
+        // drop the lesson, reinsert it at the anchor (append when no anchor).
+        const siblings = yield* svc.getLessonsBySectionId(currentSectionId);
+        const rest = siblings.filter((l) => l.id !== id);
+        let insertAt = rest.length;
+        if (anchorId !== undefined) {
+          const idx = rest.findIndex((l) => l.id === anchorId);
+          if (idx === -1) return yield* notFound("lesson", anchorId);
+          insertAt = a !== undefined ? idx + 1 : idx;
+        }
+        const newOrderIds = [
+          ...rest.slice(0, insertAt).map((l) => l.id),
+          id,
+          ...rest.slice(insertAt).map((l) => l.id),
+        ];
+        yield* writes.reorderLessons(currentSectionId, newOrderIds);
+      } else {
+        // -- Cross-section move. moveToSection anchors on a `beforeLessonId`;
+        // translate --after into "before the anchor's successor" (null = append).
+        const targetLessons = yield* svc.getLessonsBySectionId(targetSectionId);
+        let beforeLessonId: string | null = null;
+        if (anchorId !== undefined) {
+          const idx = targetLessons.findIndex((l) => l.id === anchorId);
+          if (idx === -1) return yield* notFound("lesson", anchorId);
+          beforeLessonId =
+            a !== undefined ? (targetLessons[idx + 1]?.id ?? null) : anchorId;
+        }
+        yield* writes.moveToSection(id, targetSectionId, beforeLessonId);
+      }
+
+      const moved = yield* svc.getLessonWithHierarchyById(id);
+      yield* emitObject(moved);
+    })
+).pipe(Command.withDescription(detail(MOVE_HELP)));
+
+// ---------------------------------------------------------------------------
 // lesson (parent)
 // ---------------------------------------------------------------------------
 
@@ -367,6 +606,8 @@ export const lessonCommand = Command.make("lesson").pipe(
     getCmd,
     treeCmd,
     createCmd,
+    updateCmd,
+    moveCmd,
     lessonSearchCmd,
   ])
 );

--- a/app/cli/index.ts
+++ b/app/cli/index.ts
@@ -19,9 +19,9 @@ import { searchCommand } from "./commands/search";
 const ROOT_HELP = `cvm — agent-facing access to this Course Video Manager project's domain data.
 
 Read-mostly: most verbs are READS. A growing set of nouns has WRITE verbs —
-'segment' (add/update/move/delete), 'lesson' (create), 'video' (create/move/
-update) and 'pitch' (create/update). Every other verb is read-only, and each
-verb's own --help is authoritative about whether it reads or writes.
+'segment' (add/update/move/delete), 'lesson' (create/update/move), 'video'
+(create/move/update) and 'pitch' (create/update). Every other verb is read-only,
+and each verb's own --help is authoritative about whether it reads or writes.
 
 DOMAIN MODEL
   A Course is the primary entity. Its structure is snapshotted into Course
@@ -60,7 +60,8 @@ WRITES
   any positional <id> (a flag after it exits 3). The write surface:
     segment add/update/move/delete   author a Video's Segment plan
                                      (add --pitch <id> targets a pitch's video)
-    lesson  create                   create a GHOST lesson in a Section
+    lesson  create/update/move       create a GHOST lesson, rename its title,
+                                     or reorder / re-home it (DB↔disk in sync)
     video   create/move/update       create a Video, re-home it to a lesson/
                                      pitch, or rename it (--name)
     pitch   create/update            create a Pitch (--title required) or patch

--- a/app/cli/layer.ts
+++ b/app/cli/layer.ts
@@ -9,17 +9,26 @@ import { SegmentOperationsService } from "@/services/db-segment-operations.serve
 import { PitchOperationsService } from "@/services/db-pitch-operations.server";
 import { DeliverableOperationsService } from "@/services/db-deliverable-operations.server";
 import { SearchOperationsService } from "@/services/db-search-operations.server";
+import { CourseWriteService } from "@/services/course-write-service";
 
 /**
- * READ-ONLY layer for the `cvm` CLI. Mirrors app/services/layer.server.ts but
- * is DELIBERATELY narrowed to the read-operations services, provided over
- * DrizzleService.Default.
+ * Service layer for the `cvm` CLI. Mostly the read-operations services, provided
+ * over DrizzleService.Default.
  *
- * Write/publish services (CourseRepoWriteService, CoursePublishService,
- * CourseRepoParserService, CourseWriteService, ...) are intentionally OUT OF
- * SCOPE — the CLI is read-only by construction.
+ * WRITES. The CLI is read-mostly, but a handful of write verbs exist (lesson
+ * create/update/move, video create/move/update, pitch/segment authoring). Field
+ * edits with no on-disk coupling (a title, a link) go straight through the
+ * DB-operations services. Structural edits that MUST stay in sync with the
+ * course repo on disk — reordering or moving a REAL lesson renumbers folder
+ * prefixes and `git mv`s directories — route through CourseWriteService, the
+ * same disk-aware orchestrator the web app uses. Correctness (DB + disk in
+ * lockstep) is the rule for every write verb; the CLI does not get a DB-only
+ * shortcut that would silently diverge the two.
  *
- * The 8 services here cover all 10 nouns:
+ * Publish-only services (CoursePublishService, CourseRepoParserService, ...)
+ * remain out of scope.
+ *
+ * The read services cover all 10 nouns:
  *   course        -> CourseOperationsService
  *   version       -> VersionOperationsService
  *   section       -> LessonSectionOperationsService
@@ -44,7 +53,11 @@ export const cliLayer = Layer.mergeAll(
   SegmentOperationsService.Default,
   PitchOperationsService.Default,
   DeliverableOperationsService.Default,
-  SearchOperationsService.Default
+  SearchOperationsService.Default,
+  // Disk-aware write orchestrator for structural lesson edits (reorder / move).
+  // Its transitive deps (repo-write, sync-validation, NodeFileSystem) close
+  // under DrizzleService below; git/fs are only touched when a real lesson moves.
+  CourseWriteService.Default
 ).pipe(Layer.provideMerge(DrizzleService.Default));
 
 /**


### PR DESCRIPTION
## What

Adds two write verbs to the `cvm` CLI's `lesson` command:

```
cvm lesson update <id> --title <t>
cvm lesson move   <id> [--section <id>] [--before|--after <lessonId>]
```

- **`update`** renames a lesson's display **title only** — the `path`/slug (and, for a real lesson, its on-disk folder) is deliberately left untouched, so a rename never moves a URL or a directory. Title has no on-disk coupling (the repo parser never reads it; on-disk READMEs derive their heading from the slug), so this is a safe DB-only write.
- **`move`** reorders a lesson within its section, or re-homes it to another section.

## Correctness (DB ↔ disk in lockstep)

`move` routes through the disk-aware `CourseWriteService` so a **real** (on-disk) lesson stays in sync with the repo:

- **Same-section reorder** → `reorderLessons(sectionId, newOrderIds)`. (The shared move planner NOOPs a same-section move, so reorder can't go through `moveToSection`.) The CLI computes the complete, ordered id list — drop the lesson, reinsert at the anchor (append when no anchor).
- **Cross-section** → `moveToSection(lessonId, targetSectionId, beforeLessonId)`. `--after <anchor>` is desugared to the anchor's successor as `beforeLessonId` (`null` = append).
- **Ghost** (planned, no folder) lessons are a pure DB update; the disk-sync validation short-circuits on a null repo path.

To hold this rule for *every* lesson write, `CourseWriteService` is wired into the CLI layer (its repo-write / sync-validation / filesystem deps close under `DrizzleService`; git/fs are only touched when a real lesson actually moves).

## Draft guard

All three structural writes (`create`, `update`, `move`) now refuse to edit a **published (frozen) version** — writes only ever target the Draft (the course's latest version). Rejected as invalid-input (exit 3).

## Edge cases handled

- Anchor not a sibling / not in the destination → not-found (exit 2).
- Moving a lesson relative to itself → invalid-input (exit 3).
- Destination section missing, **archived**, or in another version → not-found (exit 2).
- Archived / missing lesson → not-found (exit 2).

## Tests

New `cli-lesson-move-update` suite (17 tests): ghost-course fixtures exercise the full CLI → `CourseWriteService` wiring, the planner, and the Draft guard as a pure DB path over PGlite. The on-disk renumber / git-mv cascade for real lessons is covered by the services' own suites. Read-only integration + write-harness layers updated for the new service dependency.

Full suite: **2341 tests pass**, typecheck clean.

## Notes / out of scope

- "Rename" was scoped to the display title only; changing a lesson's slug/folder is a distinct, disk-moving operation and not included here.
- A broader correctness audit of the other write nouns (video/pitch/segment) is a suggested fast-follow, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)