### PR TITLE
prototype: field-bound writer modal + context token counter (#1113)

### DIFF
--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -17,8 +17,8 @@
  * always on-screen. Refinements baked in here:
  *
  *   • Each chip is a real toggle with a checkbox. A source made of parts
- *     (transcript segments, chapters, repo files, links) can be **partially on**
- *     → the checkbox shows an indeterminate state.
+ *     (transcript chapters, repo files, links) can be **partially on** → the
+ *     checkbox shows an indeterminate state.
  *   • The "Context" button opens a full-options panel — a **tabbed** editor, one
  *     tab per source (each chapter, each file, memory, links…) can be toggled.
  *   • Token counts read as `4.1K`.
@@ -131,39 +131,26 @@ type ContextSource = {
   items: ContextItem[];
 };
 
-const seg = (key: string, n: number, make: (i: number) => [string, string]) =>
-  Array.from({ length: n }, (_, i) => {
-    const [label, text] = make(i);
-    return { id: `${key}:${i}`, label, text };
-  });
-
 const CONTEXT_SOURCES: ContextSource[] = [
   {
+    // Transcript and chapters are the same thing: `clips.text` split by
+    // chapter. The parts ARE the chapters — deselect a chapter to trim that
+    // slice of transcript out of what's sent (mirrors the real
+    // `enabledSections`).
     key: "transcript",
     label: "Transcript",
-    note: "clips.text, per segment",
-    items: seg("transcript", 6, (i) => [
-      `Segment ${i + 1}`,
-      `In this segment we look at the satisfies operator. ${"The problem it solves: annotating a variable widens the value to the declared type and you lose the literal information. ".repeat(
-        6 + i
-      )}`,
-    ]),
-  },
-  {
-    key: "chapters",
-    label: "Chapters",
-    note: "meta.json chapter markers",
+    note: "clips.text, split by chapter — deselect chapters to trim it",
     items: [
-      ["00:00 The two bad options", 1],
-      ["01:12 Annotating widens the type", 2],
-      ["02:40 No annotation = no validation", 2],
-      ["03:55 Enter satisfies", 3],
-      ["05:30 A real config example", 4],
-      ["07:10 Gotchas with unions", 2],
+      ["00:00 The two bad options", 5],
+      ["01:12 Annotating widens the type", 7],
+      ["02:40 No annotation, no validation", 6],
+      ["03:55 Enter satisfies", 8],
+      ["05:30 A real config example", 6],
+      ["07:10 Gotchas with unions", 4],
     ].map(([label, w], i) => ({
-      id: `chapters:${i}`,
+      id: `transcript:${i}`,
       label: label as string,
-      text: `${label} — ${"chapter body text describing what happens in this section of the video. ".repeat(
+      text: `${label}\n${"In this part of the video Matt walks through the idea in plain language, working from a concrete example on screen before drawing out the general rule. ".repeat(
         (w as number) * 3
       )}`,
     })),

--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -1359,7 +1359,7 @@ function ContextView({
         </div>
         <div className="flex-1" />
         <span className={cn("font-mono text-sm", tone)}>
-          {fmtTok(model.totalTokens)} tok
+          {fmtTok(model.totalTokens)} tokens
         </span>
       </div>
 
@@ -1378,7 +1378,6 @@ function ContextView({
                   : "text-muted-foreground hover:text-foreground"
               )}
             >
-              <CheckGlyph state={s.check} />
               {s.source.label}
               <span className="font-mono tabular-nums opacity-70">
                 {fmtTok(s.tokens)}
@@ -1437,7 +1436,7 @@ function ContextTabBody({
           </div>
         </div>
         <div className="text-right font-mono text-xs text-muted-foreground">
-          {fmtTok(s.tokens)} tok
+          {fmtTok(s.tokens)} tokens
         </div>
       </label>
 

--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -8,38 +8,39 @@
  *
  * The modal opens from a long-form Post field (here, the AI Hero **Body**). It
  * collapses the fullscreen writer's 3-pane workspace to 2 panes — chat + document
- * — and treats the field's value as the document (Apply writes back, Cancel
- * discards). Mirrors the seam from #1113: the host injects
- * `videoId / fieldId / modes / initialDocument / onApply / context / layout`.
+ * — and treats the field's value as the document. Mirrors the seam from #1113:
+ * the host injects `videoId / fieldId / modes / initialDocument / onApply /
+ * context / layout`.
  *
- * The live design question is the **context token counter** (Matt's ask: a raw
- * token number, bytes ÷ 4, so you can see how much the "extra stuff" costs):
+ * DESIGN LOCKED (Matt's call, 2026-07-03): the winning token-counter treatment is
+ * the **inline context strip** — sources shown as chips docked above the document,
+ * always on-screen. Refinements baked in here:
  *
- *   ?variant=A — Context drawer (Sheet): per-source breakdown + big total, opened
- *                from a Context button that always shows the running total.
- *   ?variant=B — Header budget meter: an always-visible token meter in the modal
- *                header; click for the per-source Popover breakdown.
- *   ?variant=C — Inline context strip: sources as chips docked above the document,
- *                always on-screen, no drawer.
+ *   • Each chip is a real toggle with a checkbox. A source made of parts
+ *     (transcript segments, chapters, repo files, links) can be **partially on**
+ *     → the checkbox shows an indeterminate state.
+ *   • The "Context" button opens a full-options panel where individual parts
+ *     (each chapter, each file…) can be toggled.
+ *   • Token counts read as `4.1K`.
+ *   • The document pane matches the real writer: Edit ⇄ Preview and a lint
+ *     "Fix (N)" button (mirrors `document-panel.tsx`).
+ *   • Cancel reverts the conversation history to what it was before the modal
+ *     opened; closing with unsaved changes asks for confirmation first.
+ *   • Footer is just Cancel / Apply — no explanation blurb, no token count.
  *
  * Still a prototype: NOT wired to the real writer engine / useChat / endpoints.
- * Chat + document are hand-authored fixtures; toggling context sources only
- * recomputes the token estimate. Once a token-counter treatment wins, fold it
- * into the real modal host built in #1114 (writable-field-component), then delete
- * this file + its losing variants.
+ * Chat + document + context sources are hand-authored fixtures. Once this shape is
+ * folded into the real modal host built in #1114 (writable-field-component),
+ * delete this file.
  */
 
+import { AIResponse } from "components/ui/kibo-ui/ai/response";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -51,17 +52,17 @@ import { Textarea } from "@/components/ui/textarea";
 import { MarkdownMonacoEditor } from "@/components/markdown-monaco-editor";
 import { cn } from "@/lib/utils";
 import {
-  ChevronLeft,
-  ChevronRight,
+  AlertTriangleIcon,
+  CheckIcon,
+  EyeIcon,
   FileText,
-  GaugeIcon,
   Layers,
+  MinusIcon,
   PencilIcon,
   SendIcon,
-  SparklesIcon,
+  X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useSearchParams } from "react-router";
 
 /* ================================================================== */
 /* Token estimate — the whole point: raw tokens ≈ ceil(bytes / 4).     */
@@ -71,117 +72,153 @@ const encoder = new TextEncoder();
 const byteLength = (s: string) => encoder.encode(s).length;
 /** Deliberately crude gauge of injected-context weight — not a real tokenizer. */
 const estimateTokens = (s: string) => Math.ceil(byteLength(s) / 4);
-const fmt = (n: number) => n.toLocaleString("en-US");
-const fmtBytes = (n: number) =>
-  n < 1024 ? `${n} B` : `${(n / 1024).toFixed(1)} KB`;
 
-/** Illustrative budget bands so the number has a felt sense of "a lot". */
-function tokenTone(total: number): { text: string; bar: string } {
-  if (total > 12000) return { text: "text-destructive", bar: "bg-destructive" };
-  if (total > 6000) return { text: "text-amber-600", bar: "bg-amber-500" };
-  return { text: "text-emerald-600", bar: "bg-emerald-500" };
+/** Compact token label, Matt's format: 812 → "812", 4123 → "4.1K". */
+const fmtTok = (n: number) =>
+  n < 1000 ? String(n) : `${(n / 1000).toFixed(1)}K`;
+
+/** Illustrative budget bands so the total has a felt sense of "a lot". */
+function tokenTone(total: number): string {
+  if (total > 12000) return "text-destructive";
+  if (total > 6000) return "text-amber-600";
+  return "text-emerald-600";
 }
 
 /* ================================================================== */
-/* Fixtures — the injected `context: WriterContext` payload + document. */
+/* Fixtures — the injected `context` payload, modelled as sources made  */
+/* of individually-toggleable parts (so a source can be partially on).  */
 /* ================================================================== */
 
+type ContextItem = { id: string; label: string; text: string };
 type ContextSource = {
   key: string;
   label: string;
   note: string;
-  text: string;
+  /** Parts. A single-part source is atomic (no indeterminate state). */
+  items: ContextItem[];
 };
 
-const TRANSCRIPT =
-  `In this video we look at the satisfies operator, which shipped in TypeScript 4.9. `.repeat(
-    60
-  ) +
-  `The problem it solves: annotating a variable widens the value to the declared type and you lose the literal information; leaving the annotation off keeps the narrow inferred type but gives you no validation. satisfies gives you both — it checks the value against the type without changing the inferred type. `.repeat(
-    24
-  );
-const FILES =
-  `readme.md\nexercise.ts\nexercise.solution.ts\nexplainer.ts\n`.repeat(6) +
-  `const config = {\n  routes: { home: "/", about: "/about" },\n  theme: "dark",\n} satisfies Config;\n`.repeat(
-    10
-  );
-const LINKS =
-  `https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html\nhttps://github.com/microsoft/TypeScript/pull/46827\nhttps://www.totaltypescript.com/tips/satisfies\n`.repeat(
-    4
-  );
-const COURSE_STRUCTURE =
-  `Course: TypeScript Wizard\n  Section: Deriving Types\n    Lesson: The satisfies Operator [explainer, problem, solution]\n    Lesson: keyof and typeof\n    Lesson: Indexed Access Types\n  Section: Generics\n`.repeat(
-    8
-  );
-const CHAPTERS =
-  `00:00 The two bad options\n01:12 Annotating widens the type\n02:40 No annotation = no validation\n03:55 Enter satisfies\n05:30 A real config example\n07:10 Gotchas with unions\n`.repeat(
-    6
-  );
-const MEMORY =
-  `- Matt prefers examples before theory.\n- House style: no "simply" / "just".\n- AI Hero bodies open with the concrete problem, then mechanics, then a runnable example.\n- Keep paragraphs short; prefer code over prose where it is clearer.\n`.repeat(
-    4
-  );
-const FULL_PATH = `typescript-wizard/deriving-types/the-satisfies-operator/explainer/readme.md`;
+const seg = (key: string, n: number, make: (i: number) => [string, string]) =>
+  Array.from({ length: n }, (_, i) => {
+    const [label, text] = make(i);
+    return { id: `${key}:${i}`, label, text };
+  });
 
 const CONTEXT_SOURCES: ContextSource[] = [
   {
     key: "transcript",
     label: "Transcript",
-    note: "clips.text, all segments",
-    text: TRANSCRIPT,
-  },
-  {
-    key: "files",
-    label: "Repo files",
-    note: "readme + exercise/solution sources",
-    text: FILES,
-  },
-  {
-    key: "links",
-    label: "Links",
-    note: "reference URLs on the video",
-    text: LINKS,
-  },
-  {
-    key: "courseStructure",
-    label: "Course structure",
-    note: "sections / lessons tree",
-    text: COURSE_STRUCTURE,
+    note: "clips.text, per segment",
+    items: seg("transcript", 6, (i) => [
+      `Segment ${i + 1}`,
+      `In this segment we look at the satisfies operator. ${"The problem it solves: annotating a variable widens the value to the declared type and you lose the literal information. ".repeat(
+        6 + i
+      )}`,
+    ]),
   },
   {
     key: "chapters",
     label: "Chapters",
     note: "meta.json chapter markers",
-    text: CHAPTERS,
+    items: [
+      ["00:00 The two bad options", 1],
+      ["01:12 Annotating widens the type", 2],
+      ["02:40 No annotation = no validation", 2],
+      ["03:55 Enter satisfies", 3],
+      ["05:30 A real config example", 4],
+      ["07:10 Gotchas with unions", 2],
+    ].map(([label, w], i) => ({
+      id: `chapters:${i}`,
+      label: label as string,
+      text: `${label} — ${"chapter body text describing what happens in this section of the video. ".repeat(
+        (w as number) * 3
+      )}`,
+    })),
+  },
+  {
+    key: "files",
+    label: "Repo files",
+    note: "readme + exercise/solution sources",
+    items: [
+      ["explainer/readme.md", 8],
+      ["exercise.ts", 5],
+      ["exercise.solution.ts", 6],
+      ["explainer.ts", 4],
+    ].map(([label, w], i) => ({
+      id: `files:${i}`,
+      label: label as string,
+      text: `// ${label}\n${'const config = {\n  routes: { home: "/", about: "/about" },\n  theme: "dark",\n} satisfies Config;\n'.repeat(
+        w as number
+      )}`,
+    })),
+  },
+  {
+    key: "links",
+    label: "Links",
+    note: "reference URLs on the video",
+    items: [
+      "https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html",
+      "https://github.com/microsoft/TypeScript/pull/46827",
+      "https://www.totaltypescript.com/tips/satisfies",
+    ].map((url, i) => ({ id: `links:${i}`, label: url, text: url })),
+  },
+  {
+    key: "courseStructure",
+    label: "Course structure",
+    note: "sections / lessons tree",
+    items: [
+      {
+        id: "courseStructure:0",
+        label: "sections / lessons tree",
+        text: `Course: TypeScript Wizard\n  Section: Deriving Types\n    Lesson: The satisfies Operator [explainer, problem, solution]\n    Lesson: keyof and typeof\n    Lesson: Indexed Access Types\n  Section: Generics\n`.repeat(
+          8
+        ),
+      },
+    ],
   },
   {
     key: "memory",
     label: "Writer memory",
     note: "standing style preferences",
-    text: MEMORY,
+    items: [
+      {
+        id: "memory:0",
+        label: "standing style preferences",
+        text: `- Matt prefers examples before theory.\n- House style: no "simply" / "just".\n- AI Hero bodies open with the concrete problem, then mechanics, then a runnable example.\n- Keep paragraphs short; prefer code over prose where it is clearer.\n`.repeat(
+          4
+        ),
+      },
+    ],
   },
   {
     key: "fullPath",
     label: "Full path",
     note: "namespacing / source pointer",
-    text: FULL_PATH,
+    items: [
+      {
+        id: "fullPath:0",
+        label: "source pointer",
+        text: `typescript-wizard/deriving-types/the-satisfies-operator/explainer/readme.md`,
+      },
+    ],
   },
 ];
 
+/** An em dash + a leading heading are seeded so lint has something to catch. */
 const INITIAL_BODY = `## The two bad options
 
-Before \`satisfies\`, configuring a typed object forced a lose-lose choice.
+Before \`satisfies\`, configuring a typed object forced a lose-lose choice — you simply couldn't have both.
 
 Annotate it, and TypeScript **widens** every value to the declared type — you can
 no longer tell that \`theme\` was \`"dark"\` specifically.
 
-Leave the annotation off, and you keep the narrow inferred type — but nothing
+Leave the annotation off, and you keep the narrow inferred type, but nothing
 checks that the object actually matches \`Config\`.
 
 ## Enter satisfies
 
-\`satisfies\` validates the value against the type **without changing the inferred
-type**:
+\`satisfies\` validates the value against the type without changing the inferred
+type:
 
 \`\`\`ts
 const config = {
@@ -193,7 +230,7 @@ const config = {
 `;
 
 type ChatMsg = { role: "assistant" | "user" | "tool"; text: string };
-const CHAT: ChatMsg[] = [
+const INITIAL_CHAT: ChatMsg[] = [
   {
     role: "assistant",
     text: "I've got the transcript, chapters and course structure loaded. Want me to draft the AI Hero body from the transcript, or start from the current field value?",
@@ -208,7 +245,7 @@ const CHAT: ChatMsg[] = [
   },
   {
     role: "assistant",
-    text: "Done — drafted the intro and the “Enter satisfies” section into the document on the right. The widening example comes straight from chapter 3 of the transcript.",
+    text: "Done — drafted the intro and the “Enter satisfies” section into the document on the right. The widening example comes straight from chapter 3.",
   },
 ];
 
@@ -216,127 +253,191 @@ const CHAT: ChatMsg[] = [
 const MODES = ["article", "skill-building", "newsletter"];
 
 /* ================================================================== */
-/* Context token model — shared across all three presentations.        */
+/* Lint — a trimmed stand-in for use-lint.ts / lint-rules.ts.          */
 /* ================================================================== */
 
+type LintRule = {
+  id: string;
+  name: string;
+  count: (doc: string) => number;
+  fix: (doc: string) => string;
+};
+
+const LINT_RULES: LintRule[] = [
+  {
+    id: "no-em-dash",
+    name: "Em dashes",
+    count: (d) => (d.match(/—/g) ?? []).length,
+    fix: (d) => d.replace(/\s*—\s*/g, ", "),
+  },
+  {
+    id: "no-llm-phrase",
+    name: "LLM phrases",
+    count: (d) => (d.match(/\b(simply|just|dive in|unlock)\b/gi) ?? []).length,
+    fix: (d) => d.replace(/\b(simply|just|dive in|unlock)\s*/gi, ""),
+  },
+  {
+    id: "no-leading-heading",
+    name: "Leading heading",
+    count: (d) => (/^\s*#/.test(d) ? 1 : 0),
+    fix: (d) => d.replace(/^\s*#+\s.*(\r?\n)+/, ""),
+  },
+];
+
+function lint(doc: string) {
+  const violations = LINT_RULES.map((r) => ({
+    rule: r,
+    count: r.count(doc),
+  })).filter((v) => v.count > 0);
+  const total = violations.reduce((a, v) => a + v.count, 0);
+  return { violations, total };
+}
+function fixAll(doc: string) {
+  return LINT_RULES.reduce((d, r) => r.fix(d), doc);
+}
+
+/* ================================================================== */
+/* Context model — enabled parts live in a Set of item ids.            */
+/* ================================================================== */
+
+type SourceView = {
+  source: ContextSource;
+  items: (ContextItem & { on: boolean; tokens: number })[];
+  onCount: number;
+  /** true | false | "indeterminate" — feeds the checkbox directly. */
+  check: boolean | "indeterminate";
+  atomic: boolean;
+  tokens: number;
+};
+
 function useContextModel() {
-  const [enabled, setEnabled] = useState<Record<string, boolean>>(() =>
-    Object.fromEntries(CONTEXT_SOURCES.map((s) => [s.key, true]))
+  const [enabled, setEnabled] = useState<Set<string>>(
+    () => new Set(CONTEXT_SOURCES.flatMap((s) => s.items.map((i) => i.id)))
   );
-  const toggle = useCallback(
-    (key: string) => setEnabled((e) => ({ ...e, [key]: !e[key] })),
-    []
-  );
-  const rows = useMemo(
+
+  const toggleItem = useCallback((id: string) => {
+    setEnabled((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const toggleSource = useCallback((source: ContextSource) => {
+    setEnabled((prev) => {
+      const next = new Set(prev);
+      const allOn = source.items.every((i) => next.has(i.id));
+      if (allOn) source.items.forEach((i) => next.delete(i.id));
+      else source.items.forEach((i) => next.add(i.id));
+      return next;
+    });
+  }, []);
+
+  const sources = useMemo<SourceView[]>(
     () =>
-      CONTEXT_SOURCES.map((s) => ({
-        ...s,
-        on: enabled[s.key],
-        tokens: estimateTokens(s.text),
-        bytes: byteLength(s.text),
-      })),
+      CONTEXT_SOURCES.map((source) => {
+        const items = source.items.map((i) => ({
+          ...i,
+          on: enabled.has(i.id),
+          tokens: estimateTokens(i.text),
+        }));
+        const onCount = items.filter((i) => i.on).length;
+        const check: boolean | "indeterminate" =
+          onCount === 0
+            ? false
+            : onCount === items.length
+              ? true
+              : "indeterminate";
+        return {
+          source,
+          items,
+          onCount,
+          check,
+          atomic: items.length === 1,
+          tokens: items.reduce((a, i) => (i.on ? a + i.tokens : a), 0),
+        };
+      }),
     [enabled]
   );
-  const totalTokens = rows.reduce((a, r) => (r.on ? a + r.tokens : a), 0);
-  const totalBytes = rows.reduce((a, r) => (r.on ? a + r.bytes : a), 0);
-  const maxTokens = Math.max(1, ...rows.map((r) => r.tokens));
-  return { rows, toggle, totalTokens, totalBytes, maxTokens };
+
+  const totalTokens = sources.reduce((a, s) => a + s.tokens, 0);
+  return { sources, toggleItem, toggleSource, totalTokens };
 }
 
 type ContextModel = ReturnType<typeof useContextModel>;
-
-/* The per-source list, reused by the drawer / popover / inline strip. */
-function ContextBreakdown({ model }: { model: ContextModel }) {
-  return (
-    <div className="flex flex-col">
-      {model.rows.map((r) => (
-        <label
-          key={r.key}
-          className={cn(
-            "flex items-center gap-3 rounded-md px-2 py-2 hover:bg-muted cursor-pointer",
-            !r.on && "opacity-45"
-          )}
-        >
-          <Checkbox
-            checked={r.on}
-            onCheckedChange={() => model.toggle(r.key)}
-          />
-          <div className="min-w-0 flex-1">
-            <div className="text-sm leading-tight">{r.label}</div>
-            <div className="text-xs text-muted-foreground">{r.note}</div>
-            <div
-              className="mt-1 h-1 rounded-full bg-primary/50"
-              style={{
-                width: `${Math.round((r.tokens / model.maxTokens) * 100)}%`,
-              }}
-            />
-          </div>
-          <div className="text-right font-mono text-xs">
-            <div>{fmt(r.tokens)}</div>
-            <div className="text-[10px] text-muted-foreground">
-              {fmtBytes(r.bytes)}
-            </div>
-          </div>
-        </label>
-      ))}
-    </div>
-  );
-}
-
-function ContextTotalCard({ model }: { model: ContextModel }) {
-  const tone = tokenTone(model.totalTokens);
-  return (
-    <div className="flex items-baseline justify-between rounded-lg border bg-muted/40 px-4 py-3">
-      <div>
-        <div className={cn("font-mono text-2xl font-semibold", tone.text)}>
-          {fmt(model.totalTokens)}
-        </div>
-        <div className="text-xs text-muted-foreground">
-          tokens injected (bytes ÷ 4)
-        </div>
-      </div>
-      <div className="text-right">
-        <div className="font-mono text-sm">{fmtBytes(model.totalBytes)}</div>
-        <div className="text-xs text-muted-foreground">raw bytes</div>
-      </div>
-    </div>
-  );
-}
 
 /* ================================================================== */
 /* The field-bound writer modal.                                       */
 /* ================================================================== */
 
 function WriterModal({
-  variant,
   open,
-  onOpenChange,
-  initialValue,
+  onClose,
+  initialDoc,
+  initialChat,
   onApply,
 }: {
-  variant: string;
   open: boolean;
-  onOpenChange: (open: boolean) => void;
-  initialValue: string;
-  onApply: (value: string) => void;
+  onClose: () => void;
+  initialDoc: string;
+  initialChat: ChatMsg[];
+  onApply: (doc: string, chat: ChatMsg[]) => void;
 }) {
-  const [doc, setDoc] = useState(initialValue);
+  const [doc, setDoc] = useState(initialDoc);
+  const [chat, setChat] = useState<ChatMsg[]>(initialChat);
+  const [draft, setDraft] = useState("");
   const [mode, setMode] = useState(MODES[0]);
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(true);
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
   const ctx = useContextModel();
-  const tone = tokenTone(ctx.totalTokens);
-  const docTokens = estimateTokens(doc);
 
-  // Reseed the working copy whenever the field re-opens (D1/D5: field value IS the doc).
+  // Reseed the working copies each time the field re-opens (D1/D5: field value
+  // IS the doc; conversation history is restored to its pre-open state).
   useEffect(() => {
-    if (open) setDoc(initialValue);
-  }, [open, initialValue]);
+    if (open) {
+      setDoc(initialDoc);
+      setChat(initialChat);
+      setConfirmDiscard(false);
+      setPanelOpen(false);
+    }
+  }, [open, initialDoc, initialChat]);
+
+  const dirty = doc !== initialDoc || chat.length !== initialChat.length;
+
+  // Cancel/close: revert (host state is untouched, so simply dropping the
+  // working copies restores the prior conversation) — confirm first if dirty.
+  const requestClose = useCallback(() => {
+    if (dirty) setConfirmDiscard(true);
+    else onClose();
+  }, [dirty, onClose]);
+
+  const send = useCallback(() => {
+    const text = draft.trim();
+    if (!text) return;
+    setChat((c) => [
+      ...c,
+      { role: "user", text },
+      {
+        role: "assistant",
+        text: "Revised the document to match — see the working copy on the right.",
+      },
+    ]);
+    setDraft("");
+  }, [draft]);
+
+  const { violations, total: lintTotal } = lint(doc);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={(o) => !o && requestClose()}>
       <DialogContent
         showCloseButton={false}
         className="flex h-[82vh] max-h-[780px] w-[94vw] max-w-[1120px] flex-col gap-0 overflow-hidden p-0 sm:max-w-[1120px]"
+        onEscapeKeyDown={(e) => {
+          e.preventDefault();
+          requestClose();
+        }}
       >
         {/* Header */}
         <div className="flex h-13 flex-none items-center gap-3 border-b bg-muted/40 px-4 py-2">
@@ -363,29 +464,8 @@ function WriterModal({
 
           <div className="flex-1" />
 
-          {/* --- Variant A: Context button carrying the running total --- */}
-          {variant === "A" && (
-            <Button
-              variant={drawerOpen ? "secondary" : "outline"}
-              size="sm"
-              onClick={() => setDrawerOpen((o) => !o)}
-            >
-              <Layers className="size-4" />
-              Context
-              <Badge
-                variant="outline"
-                className={cn("ml-1 font-mono", tone.text)}
-              >
-                ~{fmt(ctx.totalTokens)} tok
-              </Badge>
-            </Button>
-          )}
-
-          {/* --- Variant B: always-on header budget meter (+ popover) --- */}
-          {variant === "B" && <HeaderMeter model={ctx} />}
-
-          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
-            Close
+          <Button variant="ghost" size="icon" onClick={requestClose}>
+            <X className="size-4" />
           </Button>
         </div>
 
@@ -394,17 +474,22 @@ function WriterModal({
           {/* Chat */}
           <div className="flex w-2/5 flex-col border-r">
             <div className="flex-1 space-y-3 overflow-y-auto p-4">
-              {CHAT.map((m, i) => (
+              {chat.map((m, i) => (
                 <ChatBubble key={i} msg={m} />
               ))}
             </div>
             <div className="flex flex-none items-end gap-2 border-t p-3">
               <Textarea
                 rows={1}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) send();
+                }}
                 placeholder="Ask the writer to revise the document…"
                 className="max-h-28 min-h-[42px] resize-none"
               />
-              <Button size="icon" className="flex-none">
+              <Button size="icon" className="flex-none" onClick={send}>
                 <SendIcon className="size-4" />
               </Button>
             </div>
@@ -412,82 +497,127 @@ function WriterModal({
 
           {/* Document */}
           <div className="flex flex-1 flex-col">
-            {/* Variant C: inline context strip docked above the document */}
-            {variant === "C" && <InlineContextStrip model={ctx} />}
+            {/* Inline context strip — the locked design. */}
+            <InlineContextStrip
+              model={ctx}
+              onOpenPanel={() => setPanelOpen(true)}
+            />
 
-            <div className="flex h-8 flex-none items-center gap-2 border-b px-3 text-xs text-muted-foreground">
-              <span className="size-1.5 rounded-full bg-emerald-500" />
-              <FileText className="size-3.5" />
-              document · working copy (unsaved)
-              <span className="ml-auto font-mono">{fmt(docTokens)} tok</span>
-            </div>
-            <div className="min-h-0 flex-1">
-              <MarkdownMonacoEditor
-                value={doc}
-                onChange={setDoc}
-                fallback={
-                  <div className="p-4 text-sm text-muted-foreground">
-                    Loading editor…
-                  </div>
-                }
+            {/* Document toolbar — mirrors document-panel.tsx. */}
+            <div className="flex h-10 flex-none items-center gap-2 border-b px-3 text-xs text-muted-foreground">
+              <span
+                className={cn(
+                  "size-1.5 rounded-full",
+                  dirty ? "bg-amber-500" : "bg-emerald-500"
+                )}
               />
+              <FileText className="size-3.5" />
+              document · working copy{dirty ? " (unsaved)" : ""}
+              <div className="flex-1" />
+              {lintTotal > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8"
+                  title={violations
+                    .map((v) => `${v.rule.name}: ${v.count}`)
+                    .join(" · ")}
+                  onClick={() => setDoc((d) => fixAll(d))}
+                >
+                  <AlertTriangleIcon className="mr-1 size-4 text-orange-500" />
+                  Fix ({lintTotal})
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8"
+                onClick={() => setIsEditing((e) => !e)}
+              >
+                {isEditing ? (
+                  <>
+                    <EyeIcon className="mr-1 size-4" /> Preview
+                  </>
+                ) : (
+                  <>
+                    <PencilIcon className="mr-1 size-4" /> Edit
+                  </>
+                )}
+              </Button>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-hidden">
+              {isEditing ? (
+                <MarkdownMonacoEditor
+                  value={doc}
+                  onChange={setDoc}
+                  fallback={
+                    <div className="p-4 text-sm text-muted-foreground">
+                      Loading editor…
+                    </div>
+                  }
+                />
+              ) : (
+                <div className="h-full overflow-y-auto p-6">
+                  <div className="mx-auto max-w-[75ch]">
+                    <AIResponse imageBasePath="prototype/the-satisfies-operator">
+                      {doc}
+                    </AIResponse>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
 
-          {/* Variant A: Context drawer — an in-modal sliding panel (not a
-              Sheet, so it sits alongside the document instead of dimming it). */}
-          {variant === "A" && (
-            <aside
-              className={cn(
-                "absolute inset-y-0 right-0 z-10 flex w-[380px] flex-col border-l bg-muted/40 shadow-xl transition-transform duration-200",
-                drawerOpen
-                  ? "translate-x-0"
-                  : "pointer-events-none translate-x-full"
-              )}
-            >
-              <div className="flex-none border-b px-4 py-3">
-                <div className="text-sm font-semibold">Injected context</div>
-                <p className="text-xs text-muted-foreground">
-                  Everything the host passes into the agent — the “extra stuff”
-                  behind the modal.
+          {/* Full-options context panel — toggle individual parts. */}
+          <ContextPanel
+            open={panelOpen}
+            model={ctx}
+            onClose={() => setPanelOpen(false)}
+          />
+
+          {/* Unsaved-changes confirm — in-modal overlay (no AlertDialog in
+              this codebase, and nested Radix dialogs fight over focus). */}
+          {confirmDiscard && (
+            <div className="absolute inset-0 z-20 flex items-center justify-center bg-background/70 backdrop-blur-sm">
+              <div className="w-[380px] rounded-lg border bg-background p-5 shadow-xl">
+                <div className="text-sm font-semibold">
+                  Discard unsaved changes?
+                </div>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  The document and this conversation will revert to how they
+                  were before you opened the writer.
                 </p>
+                <div className="mt-4 flex justify-end gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setConfirmDiscard(false)}
+                  >
+                    Keep editing
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => {
+                      setConfirmDiscard(false);
+                      onClose();
+                    }}
+                  >
+                    Discard
+                  </Button>
+                </div>
               </div>
-              <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-4">
-                <ContextTotalCard model={ctx} />
-                <ContextBreakdown model={ctx} />
-                <p className="text-xs text-muted-foreground">
-                  Estimate:{" "}
-                  <code className="font-mono">tokens ≈ ⌈bytes / 4⌉</code>{" "}
-                  (UTF-8). Toggle a source to see its cost. This is the{" "}
-                  <code className="font-mono">context: WriterContext</code>{" "}
-                  payload.
-                </p>
-              </div>
-            </aside>
+            </div>
           )}
         </div>
 
-        {/* Footer */}
+        {/* Footer — just Cancel / Apply. */}
         <div className="flex h-14 flex-none items-center justify-end gap-3 border-t bg-muted/40 px-4">
-          <span className="mr-auto text-xs text-muted-foreground">
-            Working copy — <b>Apply</b> writes back to the field · <b>Cancel</b>{" "}
-            discards ·{" "}
-            <span className={cn("font-mono", tone.text)}>
-              ~{fmt(ctx.totalTokens)}
-            </span>{" "}
-            context tok
-          </span>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button variant="outline" onClick={requestClose}>
             Cancel
           </Button>
-          <Button
-            onClick={() => {
-              onApply(doc);
-              onOpenChange(false);
-            }}
-          >
-            Apply
-          </Button>
+          <Button onClick={() => onApply(doc, chat)}>Apply</Button>
         </div>
       </DialogContent>
     </Dialog>
@@ -520,68 +650,154 @@ function ChatBubble({ msg }: { msg: ChatMsg }) {
   );
 }
 
-/* Variant B — always-visible header meter with a popover breakdown. */
-function HeaderMeter({ model }: { model: ContextModel }) {
-  const tone = tokenTone(model.totalTokens);
-  const pct = Math.min(100, Math.round((model.totalTokens / 16000) * 100));
+/* A checkbox glyph, drawn (not interactive) so it can live inside a <button>. */
+function CheckGlyph({ state }: { state: boolean | "indeterminate" }) {
   return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <button className="flex items-center gap-2 rounded-md border px-3 py-1.5 hover:bg-muted">
-          <GaugeIcon className={cn("size-4", tone.text)} />
-          <span className={cn("font-mono text-sm", tone.text)}>
-            {fmt(model.totalTokens)}
-          </span>
-          <span className="text-xs text-muted-foreground">ctx tok</span>
-          <span className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
-            <span
-              className={cn("block h-full", tone.bar)}
-              style={{ width: `${pct}%` }}
-            />
-          </span>
-        </button>
-      </PopoverTrigger>
-      <PopoverContent align="end" className="w-[340px]">
-        <div className="mb-2 text-sm font-medium">Injected context</div>
-        <ContextTotalCard model={model} />
-        <div className="mt-2">
-          <ContextBreakdown model={model} />
-        </div>
-        <p className="mt-2 text-xs text-muted-foreground">
-          <code className="font-mono">tokens ≈ ⌈bytes / 4⌉</code> (UTF-8)
-        </p>
-      </PopoverContent>
-    </Popover>
+    <span
+      className={cn(
+        "flex size-3.5 flex-none items-center justify-center rounded-[4px] border",
+        state === false
+          ? "border-muted-foreground/50"
+          : "border-primary bg-primary text-primary-foreground"
+      )}
+    >
+      {state === true && <CheckIcon className="size-3" />}
+      {state === "indeterminate" && <MinusIcon className="size-3" />}
+    </span>
   );
 }
 
-/* Variant C — inline context strip docked above the document. */
-function InlineContextStrip({ model }: { model: ContextModel }) {
+/* The locked design — sources as checkbox chips docked above the document. */
+function InlineContextStrip({
+  model,
+  onOpenPanel,
+}: {
+  model: ContextModel;
+  onOpenPanel: () => void;
+}) {
   const tone = tokenTone(model.totalTokens);
   return (
     <div className="flex flex-none flex-wrap items-center gap-1.5 border-b bg-muted/30 px-3 py-2">
-      <span className="mr-1 flex items-center gap-1.5 text-xs font-medium">
+      <button
+        onClick={onOpenPanel}
+        className="mr-1 flex items-center gap-1.5 rounded-md border bg-background px-2 py-1 text-xs font-medium hover:bg-muted"
+        title="Open the full context panel"
+      >
         <Layers className="size-3.5" /> Context
-        <span className={cn("font-mono", tone.text)}>
-          ~{fmt(model.totalTokens)} tok
+        <span className={cn("font-mono", tone)}>
+          {fmtTok(model.totalTokens)}
         </span>
-      </span>
-      {model.rows.map((r) => (
+      </button>
+      {model.sources.map((s) => (
         <button
-          key={r.key}
-          onClick={() => model.toggle(r.key)}
+          key={s.source.key}
+          onClick={() => model.toggleSource(s.source)}
           className={cn(
-            "rounded-full border px-2 py-0.5 font-mono text-[11px] transition-colors",
-            r.on
-              ? "bg-background hover:bg-muted"
-              : "bg-transparent text-muted-foreground line-through opacity-60"
+            "flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] transition-colors",
+            s.check === false
+              ? "bg-transparent text-muted-foreground opacity-70"
+              : "bg-background hover:bg-muted"
           )}
-          title={`${r.note} · ${fmtBytes(r.bytes)}`}
+          title={`${s.source.note} · ${s.onCount}/${s.items.length} on`}
         >
-          {r.label} {fmt(r.tokens)}
+          <CheckGlyph state={s.check} />
+          <span>{s.source.label}</span>
+          <span className="font-mono text-muted-foreground">
+            {fmtTok(s.tokens)}
+          </span>
         </button>
       ))}
     </div>
+  );
+}
+
+/* Full-options panel — an in-modal sliding panel over the document, so it
+   sits alongside the chat instead of dimming the whole modal. */
+function ContextPanel({
+  open,
+  model,
+  onClose,
+}: {
+  open: boolean;
+  model: ContextModel;
+  onClose: () => void;
+}) {
+  const tone = tokenTone(model.totalTokens);
+  return (
+    <aside
+      className={cn(
+        "absolute inset-y-0 right-0 z-10 flex w-[420px] flex-col border-l bg-background shadow-xl transition-transform duration-200",
+        open ? "translate-x-0" : "pointer-events-none translate-x-full"
+      )}
+    >
+      <div className="flex flex-none items-center gap-2 border-b px-4 py-3">
+        <Layers className="size-4" />
+        <div className="text-sm font-semibold">Context</div>
+        <span className={cn("ml-1 font-mono text-sm", tone)}>
+          {fmtTok(model.totalTokens)} tok
+        </span>
+        <div className="flex-1" />
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7"
+          onClick={onClose}
+        >
+          <X className="size-4" />
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {model.sources.map((s) => (
+          <div key={s.source.key} className="mb-1">
+            {/* Source header — tri-state; toggles the whole source. */}
+            <label className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 hover:bg-muted">
+              <Checkbox
+                checked={s.check}
+                onCheckedChange={() => model.toggleSource(s.source)}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="text-sm leading-tight">{s.source.label}</div>
+                <div className="text-xs text-muted-foreground">
+                  {s.source.note}
+                </div>
+              </div>
+              <div className="text-right font-mono text-xs text-muted-foreground">
+                {fmtTok(s.tokens)}
+              </div>
+            </label>
+            {/* Parts — only worth showing when the source has more than one. */}
+            {!s.atomic && (
+              <div className="ml-4 border-l pl-2">
+                {s.items.map((i) => (
+                  <label
+                    key={i.id}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted",
+                      !i.on && "opacity-50"
+                    )}
+                  >
+                    <Checkbox
+                      checked={i.on}
+                      onCheckedChange={() => model.toggleItem(i.id)}
+                    />
+                    <span className="min-w-0 flex-1 truncate text-xs">
+                      {i.label}
+                    </span>
+                    <span className="font-mono text-[10px] text-muted-foreground">
+                      {fmtTok(i.tokens)}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="flex-none border-t px-4 py-2 text-xs text-muted-foreground">
+        <code className="font-mono">tokens ≈ ⌈bytes / 4⌉</code> (UTF-8). This is
+        the <code className="font-mono">context</code> payload the host injects.
+      </div>
+    </aside>
   );
 }
 
@@ -590,52 +806,10 @@ function InlineContextStrip({ model }: { model: ContextModel }) {
 /* the modal is judged against the real page density.                  */
 /* ================================================================== */
 
-const VARIANTS = ["A", "B", "C"] as const;
-const VARIANT_NAMES: Record<string, string> = {
-  A: "Context drawer",
-  B: "Header meter",
-  C: "Inline strip",
-};
-
 export default function PrototypeWriterModal() {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const variant = (searchParams.get("variant") ?? "A").toUpperCase();
-
   const [body, setBody] = useState(INITIAL_BODY);
+  const [chat, setChat] = useState<ChatMsg[]>(INITIAL_CHAT);
   const [modalOpen, setModalOpen] = useState(false);
-
-  const setVariant = useCallback(
-    (v: string) => {
-      const next = new URLSearchParams(searchParams);
-      next.set("variant", v);
-      setSearchParams(next, { replace: true });
-    },
-    [searchParams, setSearchParams]
-  );
-
-  // ← / → cycle variants (ignore when typing / in the editor).
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
-      const el = document.activeElement;
-      if (
-        el instanceof HTMLInputElement ||
-        el instanceof HTMLTextAreaElement ||
-        (el as HTMLElement)?.isContentEditable ||
-        el?.closest(".monaco-editor")
-      )
-        return;
-      const i = VARIANTS.indexOf(variant as (typeof VARIANTS)[number]);
-      const j =
-        i < 0
-          ? 0
-          : (i + (e.key === "ArrowRight" ? 1 : VARIANTS.length - 1)) %
-            VARIANTS.length;
-      setVariant(VARIANTS[j]!);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [variant, setVariant]);
 
   return (
     <div className="h-screen overflow-y-auto bg-background">
@@ -724,48 +898,16 @@ export default function PrototypeWriterModal() {
       </div>
 
       <WriterModal
-        variant={variant}
         open={modalOpen}
-        onOpenChange={setModalOpen}
-        initialValue={body}
-        onApply={setBody}
+        onClose={() => setModalOpen(false)}
+        initialDoc={body}
+        initialChat={chat}
+        onApply={(doc, nextChat) => {
+          setBody(doc);
+          setChat(nextChat);
+          setModalOpen(false);
+        }}
       />
-
-      {/* Floating variant switcher (prototype only). */}
-      <div className="fixed bottom-4 left-1/2 z-[60] flex -translate-x-1/2 items-center gap-1 rounded-full border bg-background/95 px-2 py-1.5 shadow-lg backdrop-blur">
-        <SparklesIcon className="mx-1 size-3.5 text-muted-foreground" />
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-7"
-          onClick={() => {
-            const i = Math.max(
-              0,
-              VARIANTS.indexOf(variant as (typeof VARIANTS)[number])
-            );
-            setVariant(VARIANTS[(i + VARIANTS.length - 1) % VARIANTS.length]!);
-          }}
-        >
-          <ChevronLeft className="size-4" />
-        </Button>
-        <span className="min-w-[150px] text-center text-xs font-medium">
-          {variant} — {VARIANT_NAMES[variant] ?? "?"}
-        </span>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-7"
-          onClick={() => {
-            const i = Math.max(
-              0,
-              VARIANTS.indexOf(variant as (typeof VARIANTS)[number])
-            );
-            setVariant(VARIANTS[(i + 1) % VARIANTS.length]!);
-          }}
-        >
-          <ChevronRight className="size-4" />
-        </Button>
-      </div>
     </div>
   );
 }

--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -558,7 +558,7 @@ function WriterModal({
                   }
                 />
               ) : (
-                <div className="h-full overflow-y-auto p-6">
+                <div className="scrollbar scrollbar-track-transparent scrollbar-thumb-muted hover:scrollbar-thumb-muted-foreground h-full overflow-y-auto p-6">
                   <div className="mx-auto max-w-[75ch]">
                     <AIResponse imageBasePath="prototype/the-satisfies-operator">
                       {doc}

--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -50,7 +50,19 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { MarkdownMonacoEditor } from "@/components/markdown-monaco-editor";
+// The screenshot picker is a *document* citizen, not a chat message: the agent
+// writes a `<ChooseScreenshot clipIndex={n} alt="…" />` tag into the doc body,
+// and it renders inline in the document Preview. Reuse the real preprocessor +
+// pure mutation helpers so the prototype matches production exactly.
+import { preprocessChooseScreenshotMarkdown } from "@/features/article-writer/choose-screenshot-markdown";
+import {
+  removeChooseScreenshot,
+  replaceChooseScreenshotWithImage,
+  updateChooseScreenshotClipIndex,
+} from "@/features/article-writer/choose-screenshot-mutations";
 import { cn } from "@/lib/utils";
+import type { HTMLAttributes } from "react";
+import type { Options } from "react-markdown";
 import {
   AlertTriangleIcon,
   ArrowLeft,
@@ -236,27 +248,33 @@ const config = {
 } satisfies Config;
 // config.theme is "dark", not string — and it's still checked against Config
 \`\`\`
+
+<ChooseScreenshot clipIndex={4} alt="the satisfies config checked in the editor" />
 `;
 
 /**
- * A chat message. `kind` lets the assistant embed richer parts than plain text:
- *  - "tool"       → a tool-call card (writeDocument / editDocument)
- *  - "screenshot" → an inline ChooseScreenshot picker (capture a clip frame)
+ * A chat message. `kind: "tool"` renders a tool-call card (writeDocument /
+ * editDocument). Screenshots are NOT chat messages — see the doc-embedded
+ * `<ChooseScreenshot>` below.
  */
 type ChatMsg = {
   role: "assistant" | "user" | "tool";
   text: string;
-  kind?: "tool" | "screenshot";
+  kind?: "tool";
   streaming?: boolean;
 };
 
-/** Fixture clip frames the screenshot picker scrubs through. */
+/**
+ * Fixture "clips" the doc-embedded screenshot picker scrubs through — the
+ * analogue of `IndexedClip[]` in the real app. `clipIndex` in the doc tag is
+ * 1-based into this list; each clip spans `dur` seconds you can scrub within.
+ */
 const CLIP_FRAMES = [
-  { ts: 12, label: "00:12", hue: 210 },
-  { ts: 44, label: "00:44", hue: 265 },
-  { ts: 96, label: "01:36", hue: 150 },
-  { ts: 152, label: "02:32", hue: 25 },
-  { ts: 210, label: "03:30", hue: 340 },
+  { label: "The two bad options", dur: 7.5, hue: 210 },
+  { label: "Annotating widens the type", dur: 6.2, hue: 265 },
+  { label: "Enter satisfies", dur: 8.1, hue: 150 },
+  { label: "A real config example", dur: 5.4, hue: 25 },
+  { label: "Gotchas with unions", dur: 6.8, hue: 340 },
 ];
 
 const INITIAL_CHAT: ChatMsg[] = [
@@ -279,8 +297,7 @@ const INITIAL_CHAT: ChatMsg[] = [
   },
   {
     role: "assistant",
-    kind: "screenshot",
-    text: "Want a screenshot of the config example? Pick a frame and I'll drop it into the document.",
+    text: "I also dropped a **ChooseScreenshot** block into the document after the config example. Switch the document to **Preview** to scrub the clip and pick the frame — it becomes a real image on Apply.",
   },
 ];
 
@@ -495,7 +512,9 @@ function WriterModal({
   // The whole modal body swaps between these; the writer view is never
   // unmounted (so any background streaming survives the swap).
   const [view, setView] = useState<"writer" | "context" | "settings">("writer");
-  const [isEditing, setIsEditing] = useState(true);
+  // Default to Preview so the agent-generated <ChooseScreenshot> block in the
+  // document is visible on open (it only renders in Preview, like the real app).
+  const [isEditing, setIsEditing] = useState(false);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   const ctx = useContextModel();
   const streamRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -594,14 +613,49 @@ function WriterModal({
     setChat([]);
   }, [stopStream]);
 
-  // Screenshot capture drops a local image ref into the doc; the real upload to
-  // Cloudinary is deferred to Apply (below).
-  const captureScreenshot = useCallback((frameId: string, label: string) => {
-    setDoc(
-      (d) =>
-        `${d.replace(/\s*$/, "")}\n\n![Screenshot at ${label}](local:${frameId})\n`
-    );
-  }, []);
+  // The document Preview renders any `<ChooseScreenshot>` tag the agent wrote
+  // into the body as an inline, interactive picker — exactly how the real
+  // document panel injects it (extraComponents + the shared preprocessor). Its
+  // actions are pure string edits on the doc via the real mutation helpers:
+  //  • scrub + Capture → replace the tag with `![alt](local:…)` (Cloudinary on Apply)
+  //  • Prev / Next     → rewrite clipIndex in place
+  //  • Remove          → strip the tag
+  const docComponents = useMemo(
+    () => ({
+      choosescreenshot: ((
+        p: HTMLAttributes<HTMLElement> & Record<string, unknown>
+      ) => {
+        const clipIndex = parseInt(p.clipindex as string, 10);
+        const alt = (p.alt as string) ?? "";
+        return (
+          <DocScreenshotCard
+            clipIndex={clipIndex}
+            alt={alt}
+            isStreaming={status === "streaming"}
+            onClipIndexChange={(next) =>
+              setDoc((d) =>
+                updateChooseScreenshotClipIndex(d, clipIndex, next, alt)
+              )
+            }
+            onCapture={(ts) =>
+              setDoc((d) =>
+                replaceChooseScreenshotWithImage(
+                  d,
+                  clipIndex,
+                  alt,
+                  `local:clip${clipIndex}-${ts.toFixed(1)}`
+                )
+              )
+            }
+            onRemove={() =>
+              setDoc((d) => removeChooseScreenshot(d, clipIndex, alt))
+            }
+          />
+        );
+      }) as unknown,
+    }) as Options["components"],
+    [status]
+  );
 
   // Apply: if the doc still has local screenshot refs, "upload to Cloudinary"
   // first (rewrite local: → a hosted URL), then write back to the field.
@@ -712,12 +766,7 @@ function WriterModal({
 
             <div className="flex-1 space-y-3 overflow-y-auto p-4">
               {chat.map((m, i) => (
-                <ChatBubble
-                  key={i}
-                  msg={m}
-                  isStreaming={busy}
-                  onCapture={captureScreenshot}
-                />
+                <ChatBubble key={i} msg={m} isStreaming={busy} />
               ))}
             </div>
             <div className="flex flex-none items-end gap-2 border-t p-3">
@@ -804,9 +853,16 @@ function WriterModal({
                   }
                 />
               ) : (
-                <div className="scrollbar scrollbar-track-transparent scrollbar-thumb-muted hover:scrollbar-thumb-muted-foreground h-full overflow-y-auto p-6">
+                <div
+                  className="scrollbar scrollbar-track-transparent scrollbar-thumb-muted hover:scrollbar-thumb-muted-foreground h-full overflow-y-auto p-6"
+                  style={{ scrollbarGutter: "stable" }}
+                >
                   <div className="mx-auto max-w-[75ch]">
-                    <AIResponse imageBasePath="prototype/the-satisfies-operator">
+                    <AIResponse
+                      imageBasePath="prototype/the-satisfies-operator"
+                      extraComponents={docComponents}
+                      preprocessMarkdown={preprocessChooseScreenshotMarkdown}
+                    >
                       {doc}
                     </AIResponse>
                   </div>
@@ -893,11 +949,9 @@ function WriterModal({
 function ChatBubble({
   msg,
   isStreaming,
-  onCapture,
 }: {
   msg: ChatMsg;
   isStreaming: boolean;
-  onCapture: (frameId: string, label: string) => void;
 }) {
   if (msg.role === "tool") {
     return (
@@ -924,73 +978,129 @@ function ChatBubble({
           <span className="ml-0.5 inline-block h-3.5 w-1.5 animate-pulse bg-foreground/70 align-middle" />
         )}
       </div>
-      {msg.kind === "screenshot" && <ChooseScreenshotCard onCapture={onCapture} />}
     </div>
   );
 }
 
-/* Inline screenshot picker — scrub the clip's frames, capture one into the doc.
-   Stand-in for the real <choosescreenshot> component in write-chat.tsx. */
-function ChooseScreenshotCard({
+/* Doc-embedded screenshot picker — the analogue of the real <ChooseScreenshot>
+   from choose-screenshot.tsx. The agent writes a `<ChooseScreenshot clipIndex=…
+   alt=… />` tag into the document; in Preview it renders here, INLINE where the
+   tag sits in the body (not in chat). Scrub a frame + Capture to bake it into an
+   image; Prev/Next picks a different clip; the × removes the block. */
+function DocScreenshotCard({
+  clipIndex,
+  alt,
+  isStreaming,
+  onClipIndexChange,
   onCapture,
+  onRemove,
 }: {
-  onCapture: (frameId: string, label: string) => void;
+  clipIndex: number;
+  alt: string;
+  isStreaming: boolean;
+  onClipIndexChange: (next: number) => void;
+  onCapture: (timestamp: number) => void;
+  onRemove: () => void;
 }) {
-  const [idx, setIdx] = useState(2);
-  const [captured, setCaptured] = useState(false);
-  const frame = CLIP_FRAMES[idx]!;
+  const clip = CLIP_FRAMES[clipIndex - 1];
+  const [time, setTime] = useState(0);
+  // Reset the scrubber whenever the clip changes.
+  useEffect(() => setTime(0), [clipIndex]);
+
+  if (!clip) {
+    return (
+      <div className="my-4 flex items-center gap-2 rounded-lg border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
+        <AlertTriangleIcon className="size-4" />
+        Invalid clip index: {clipIndex}
+      </div>
+    );
+  }
+
+  const isFirst = clipIndex <= 1;
+  const isLast = clipIndex >= CLIP_FRAMES.length;
+
+  // While the agent is still streaming the doc, the real card shows a "waiting"
+  // placeholder rather than letting you capture mid-write.
+  if (isStreaming) {
+    return (
+      <div className="my-4 rounded-lg border bg-muted/50 p-4">
+        <p className="mb-2 text-xs text-muted-foreground">
+          Clip {clipIndex} — {alt}
+        </p>
+        <div className="flex aspect-video w-full items-center justify-center rounded-md bg-muted">
+          <span className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2Icon className="size-4 animate-spin" />
+            Waiting for the response to finish…
+          </span>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="mt-2 w-[92%] rounded-lg border bg-background p-2">
+    <div className="relative my-4 rounded-lg border bg-muted/50 p-4">
+      <button
+        onClick={onRemove}
+        className="absolute right-2 top-2 text-muted-foreground hover:text-foreground"
+        title="Remove screenshot block"
+      >
+        <X className="size-4" />
+      </button>
+      <p className="mb-2 text-xs text-muted-foreground">
+        Clip {clipIndex} of {CLIP_FRAMES.length} — {alt}
+      </p>
+      {/* Stand-in for the <video> frame (no real asset in the prototype). */}
       <div
-        className="flex h-28 items-end justify-between rounded-md p-2 text-[10px] font-medium text-white"
+        className="flex aspect-video w-full items-end justify-between rounded-md p-2 text-[11px] font-medium text-white"
         style={{
-          background: `linear-gradient(135deg, hsl(${frame.hue} 70% 45%), hsl(${(frame.hue + 40) % 360} 70% 35%))`,
+          background: `linear-gradient(135deg, hsl(${clip.hue} 70% 45%), hsl(${(clip.hue + 40) % 360} 70% 35%))`,
         }}
       >
-        <span className="rounded bg-black/40 px-1.5 py-0.5">
-          frame @ {frame.label}
+        <span className="rounded bg-black/40 px-1.5 py-0.5">{clip.label}</span>
+        <span className="rounded bg-black/40 px-1.5 py-0.5 tabular-nums">
+          {time.toFixed(1)}s
         </span>
-        <span className="rounded bg-black/40 px-1.5 py-0.5">
-          {idx + 1}/{CLIP_FRAMES.length}
+      </div>
+      {/* Scrub within the clip. */}
+      <div className="mt-2 flex items-center gap-2">
+        <span className="w-10 text-right font-mono text-[11px] text-muted-foreground">
+          {time.toFixed(1)}s
+        </span>
+        <input
+          type="range"
+          min={0}
+          max={clip.dur}
+          step={0.1}
+          value={time}
+          onChange={(e) => setTime(parseFloat(e.target.value))}
+          className="h-1.5 flex-1 accent-primary"
+        />
+        <span className="w-10 font-mono text-[11px] text-muted-foreground">
+          {clip.dur.toFixed(1)}s
         </span>
       </div>
       <div className="mt-2 flex items-center gap-2">
         <Button
           variant="outline"
-          size="icon"
-          className="size-7"
-          onClick={() => setIdx((i) => Math.max(0, i - 1))}
-          disabled={idx === 0}
+          size="sm"
+          className="h-7"
+          disabled={isFirst}
+          onClick={() => onClipIndexChange(clipIndex - 1)}
         >
-          <ChevronLeftIcon className="size-4" />
+          <ChevronLeftIcon className="mr-1 size-3.5" /> Prev
         </Button>
         <Button
           variant="outline"
-          size="icon"
-          className="size-7"
-          onClick={() => setIdx((i) => Math.min(CLIP_FRAMES.length - 1, i + 1))}
-          disabled={idx === CLIP_FRAMES.length - 1}
-        >
-          <ChevronRightIcon className="size-4" />
-        </Button>
-        <div className="flex-1" />
-        <Button
           size="sm"
           className="h-7"
-          onClick={() => {
-            onCapture(`frame-${frame.ts}`, frame.label);
-            setCaptured(true);
-          }}
+          disabled={isLast}
+          onClick={() => onClipIndexChange(clipIndex + 1)}
         >
-          {captured ? (
-            <>
-              <CheckIcon className="mr-1 size-4" /> Inserted
-            </>
-          ) : (
-            <>
-              <CameraIcon className="mr-1 size-4" /> Capture into doc
-            </>
-          )}
+          Next <ChevronRightIcon className="ml-1 size-3.5" />
+        </Button>
+        <div className="flex-1" />
+        <Button size="sm" className="h-7" onClick={() => onCapture(time)}>
+          <CameraIcon className="mr-1 size-3.5" /> Capture
         </Button>
       </div>
     </div>
@@ -1031,7 +1141,11 @@ function InlineContextStrip({
         title="Open the full context panel"
       >
         <Layers className="size-3.5" /> Context
-        <span className={cn("font-mono", tone)}>
+        {/* Fixed-width token slot so the whole strip never reflows as counts
+            change — the root of the layout shift when toggling chips. */}
+        <span
+          className={cn("w-10 text-right font-mono tabular-nums", tone)}
+        >
           {fmtTok(model.totalTokens)}
         </span>
       </button>
@@ -1054,7 +1168,7 @@ function InlineContextStrip({
         >
           <CheckGlyph state={s.check} />
           <span>{s.source.label}</span>
-          <span className="font-mono text-muted-foreground">
+          <span className="w-9 text-right font-mono tabular-nums text-muted-foreground">
             {fmtTok(s.tokens)}
           </span>
         </button>

--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -54,16 +54,24 @@ import { cn } from "@/lib/utils";
 import {
   AlertTriangleIcon,
   ArrowLeft,
+  CameraIcon,
   CheckIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
   EyeIcon,
   Layers,
+  Loader2Icon,
+  Maximize2Icon,
   MinusIcon,
   PencilIcon,
+  RefreshCwIcon,
   SendIcon,
   SettingsIcon,
+  SquareIcon,
+  Trash2Icon,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /* ================================================================== */
 /* Token estimate — the whole point: raw tokens ≈ ceil(bytes / 4).     */
@@ -230,7 +238,27 @@ const config = {
 \`\`\`
 `;
 
-type ChatMsg = { role: "assistant" | "user" | "tool"; text: string };
+/**
+ * A chat message. `kind` lets the assistant embed richer parts than plain text:
+ *  - "tool"       → a tool-call card (writeDocument / editDocument)
+ *  - "screenshot" → an inline ChooseScreenshot picker (capture a clip frame)
+ */
+type ChatMsg = {
+  role: "assistant" | "user" | "tool";
+  text: string;
+  kind?: "tool" | "screenshot";
+  streaming?: boolean;
+};
+
+/** Fixture clip frames the screenshot picker scrubs through. */
+const CLIP_FRAMES = [
+  { ts: 12, label: "00:12", hue: 210 },
+  { ts: 44, label: "00:44", hue: 265 },
+  { ts: 96, label: "01:36", hue: 150 },
+  { ts: 152, label: "02:32", hue: 25 },
+  { ts: 210, label: "03:30", hue: 340 },
+];
+
 const INITIAL_CHAT: ChatMsg[] = [
   {
     role: "assistant",
@@ -242,11 +270,17 @@ const INITIAL_CHAT: ChatMsg[] = [
   },
   {
     role: "tool",
+    kind: "tool",
     text: 'writeDocument(section: "intro") — streamed 412 chars into the document →',
   },
   {
     role: "assistant",
     text: "Done — drafted the intro and the “Enter satisfies” section into the document on the right. The widening example comes straight from chapter 3.",
+  },
+  {
+    role: "assistant",
+    kind: "screenshot",
+    text: "Want a screenshot of the config example? Pick a frame and I'll drop it into the document.",
   },
 ];
 
@@ -327,10 +361,22 @@ type SourceView = {
   tokens: number;
 };
 
+type LinkItem = { id: string; url: string };
+
+const memorySource = CONTEXT_SOURCES.find((s) => s.key === "memory")!;
+const linksSource = CONTEXT_SOURCES.find((s) => s.key === "links")!;
+
 function useContextModel() {
   const [enabled, setEnabled] = useState<Set<string>>(
     () => new Set(CONTEXT_SOURCES.flatMap((s) => s.items.map((i) => i.id)))
   );
+  // Writer memory and links are *editable* here, not just toggleable, so they
+  // live in state and override the static fixture text.
+  const [memoryText, setMemoryText] = useState(() => memorySource.items[0]!.text);
+  const [links, setLinks] = useState<LinkItem[]>(() =>
+    linksSource.items.map((i) => ({ id: i.id, url: i.text }))
+  );
+  const linkSeq = useRef(links.length);
 
   const toggleItem = useCallback((id: string) => {
     setEnabled((prev) => {
@@ -341,20 +387,48 @@ function useContextModel() {
     });
   }, []);
 
-  const toggleSource = useCallback((source: ContextSource) => {
+  const toggleSource = useCallback((ids: string[], allOn: boolean) => {
     setEnabled((prev) => {
       const next = new Set(prev);
-      const allOn = source.items.every((i) => next.has(i.id));
-      if (allOn) source.items.forEach((i) => next.delete(i.id));
-      else source.items.forEach((i) => next.add(i.id));
+      if (allOn) ids.forEach((id) => next.delete(id));
+      else ids.forEach((id) => next.add(id));
       return next;
     });
   }, []);
 
+  const addLink = useCallback((url: string) => {
+    const u = url.trim();
+    if (!u) return;
+    const id = `links:added-${linkSeq.current++}`;
+    setLinks((l) => [...l, { id, url: u }]);
+    setEnabled((e) => new Set(e).add(id));
+  }, []);
+
+  const removeLink = useCallback((id: string) => {
+    setLinks((l) => l.filter((x) => x.id !== id));
+    setEnabled((e) => {
+      const n = new Set(e);
+      n.delete(id);
+      return n;
+    });
+  }, []);
+
+  // The effective parts of a source — memory/links come from live state.
+  const itemsFor = useCallback(
+    (source: ContextSource): ContextItem[] => {
+      if (source.key === "memory")
+        return [{ ...source.items[0]!, text: memoryText }];
+      if (source.key === "links")
+        return links.map((l) => ({ id: l.id, label: l.url, text: l.url }));
+      return source.items;
+    },
+    [memoryText, links]
+  );
+
   const sources = useMemo<SourceView[]>(
     () =>
       CONTEXT_SOURCES.map((source) => {
-        const items = source.items.map((i) => ({
+        const items = itemsFor(source).map((i) => ({
           ...i,
           on: enabled.has(i.id),
           tokens: estimateTokens(i.text),
@@ -375,11 +449,20 @@ function useContextModel() {
           tokens: items.reduce((a, i) => (i.on ? a + i.tokens : a), 0),
         };
       }),
-    [enabled]
+    [enabled, itemsFor]
   );
 
   const totalTokens = sources.reduce((a, s) => a + s.tokens, 0);
-  return { sources, toggleItem, toggleSource, totalTokens };
+  return {
+    sources,
+    toggleItem,
+    toggleSource,
+    totalTokens,
+    memoryText,
+    setMemory: setMemoryText,
+    addLink,
+    removeLink,
+  };
 }
 
 type ContextModel = ReturnType<typeof useContextModel>;
@@ -407,23 +490,70 @@ function WriterModal({
   const [mode, setMode] = useState(MODES[0]);
   const [model, setModel] = useState("auto");
   const [banned, setBanned] = useState<string[]>(DEFAULT_BANNED);
+  const [status, setStatus] = useState<"ready" | "streaming">("ready");
+  const [applying, setApplying] = useState(false);
   // The whole modal body swaps between these; the writer view is never
   // unmounted (so any background streaming survives the swap).
   const [view, setView] = useState<"writer" | "context" | "settings">("writer");
   const [isEditing, setIsEditing] = useState(true);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   const ctx = useContextModel();
+  const streamRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopStream = useCallback(() => {
+    if (streamRef.current) clearInterval(streamRef.current);
+    streamRef.current = null;
+    setChat((c) => c.map((m) => (m.streaming ? { ...m, streaming: false } : m)));
+    setStatus("ready");
+  }, []);
+
+  // Fake a streamed response: a tool-call card, then the assistant reply typed
+  // in word-by-word while a line lands in the document. Stop halts it midway.
+  const runStream = useCallback(
+    (reply: string, docLine: string) => {
+      if (streamRef.current) clearInterval(streamRef.current);
+      setStatus("streaming");
+      setChat((c) => [
+        ...c,
+        {
+          role: "tool",
+          kind: "tool",
+          text: 'writeDocument(section: "body") — streaming →',
+        },
+        { role: "assistant", text: "", streaming: true },
+      ]);
+      setDoc((d) => `${d.replace(/\s*$/, "")}\n\n${docLine}\n`);
+      const words = reply.split(" ");
+      let i = 0;
+      streamRef.current = setInterval(() => {
+        i++;
+        setChat((c) => {
+          const copy = c.slice();
+          const last = copy[copy.length - 1];
+          if (last) copy[copy.length - 1] = { ...last, text: words.slice(0, i).join(" ") };
+          return copy;
+        });
+        if (i >= words.length) stopStream();
+      }, 55);
+    },
+    [stopStream]
+  );
 
   // Reseed the working copies each time the field re-opens (D1/D5: field value
   // IS the doc; conversation history is restored to its pre-open state).
   useEffect(() => {
     if (open) {
+      stopStream();
       setDoc(initialDoc);
       setChat(initialChat);
       setConfirmDiscard(false);
       setView("writer");
+      setApplying(false);
     }
-  }, [open, initialDoc, initialChat]);
+  }, [open, initialDoc, initialChat, stopStream]);
+
+  // Never leave an interval running past unmount.
+  useEffect(() => () => stopStream(), [stopStream]);
 
   const dirty = doc !== initialDoc || chat.length !== initialChat.length;
 
@@ -436,19 +566,64 @@ function WriterModal({
 
   const send = useCallback(() => {
     const text = draft.trim();
-    if (!text) return;
-    setChat((c) => [
-      ...c,
-      { role: "user", text },
-      {
-        role: "assistant",
-        text: "Revised the document to match — see the working copy on the right.",
-      },
-    ]);
+    if (!text || status === "streaming") return;
+    setChat((c) => [...c, { role: "user", text }]);
     setDraft("");
-  }, [draft]);
+    runStream(
+      "Revised the document to match — tightened the intro and grounded the example in the transcript. See the working copy on the right.",
+      "> Revised per your note — intro tightened, example grounded in the transcript."
+    );
+  }, [draft, status, runStream]);
+
+  const regenerate = useCallback(() => {
+    if (status === "streaming") return;
+    // Drop the trailing assistant/tool turn and re-run.
+    setChat((c) => {
+      let end = c.length;
+      while (end > 0 && c[end - 1]!.role !== "user") end--;
+      return c.slice(0, end);
+    });
+    runStream(
+      "Regenerated — here's a fresh take on the same request, leading harder with the concrete problem.",
+      "> Regenerated draft — leads with the concrete problem before the mechanics."
+    );
+  }, [status, runStream]);
+
+  const clearChat = useCallback(() => {
+    stopStream();
+    setChat([]);
+  }, [stopStream]);
+
+  // Screenshot capture drops a local image ref into the doc; the real upload to
+  // Cloudinary is deferred to Apply (below).
+  const captureScreenshot = useCallback((frameId: string, label: string) => {
+    setDoc(
+      (d) =>
+        `${d.replace(/\s*$/, "")}\n\n![Screenshot at ${label}](local:${frameId})\n`
+    );
+  }, []);
+
+  // Apply: if the doc still has local screenshot refs, "upload to Cloudinary"
+  // first (rewrite local: → a hosted URL), then write back to the field.
+  const handleApply = useCallback(() => {
+    const hasLocal = /\]\(local:/.test(doc);
+    if (!hasLocal) {
+      onApply(doc, chat);
+      return;
+    }
+    setApplying(true);
+    setTimeout(() => {
+      const uploaded = doc.replace(
+        /\]\(local:[^)]+\)/g,
+        "](https://res.cloudinary.com/aihero/image/upload/v1/screenshot.png)"
+      );
+      setApplying(false);
+      onApply(uploaded, chat);
+    }, 900);
+  }, [doc, chat, onApply]);
 
   const { violations, total: lintTotal } = lint(doc, banned);
+  const busy = status === "streaming";
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && requestClose()}>
@@ -504,9 +679,45 @@ function WriterModal({
         <div className="relative flex min-h-0 flex-1">
           {/* Chat */}
           <div className="flex w-2/5 flex-col border-r">
+            {/* Chat toolbar — regenerate / clear (mirrors write-toolbar.tsx). */}
+            <div className="flex h-10 flex-none items-center gap-1 border-b px-2 text-xs text-muted-foreground">
+              {busy && (
+                <span className="flex items-center gap-1.5 pl-1">
+                  <Loader2Icon className="size-3.5 animate-spin" />
+                  streaming…
+                </span>
+              )}
+              <div className="flex-1" />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8"
+                disabled={busy || chat.length === 0}
+                onClick={regenerate}
+                title="Regenerate last response"
+              >
+                <RefreshCwIcon className="mr-1 size-4" /> Regenerate
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8"
+                disabled={chat.length === 0}
+                onClick={clearChat}
+                title="Clear chat"
+              >
+                <Trash2Icon className="size-4" />
+              </Button>
+            </div>
+
             <div className="flex-1 space-y-3 overflow-y-auto p-4">
               {chat.map((m, i) => (
-                <ChatBubble key={i} msg={m} />
+                <ChatBubble
+                  key={i}
+                  msg={m}
+                  isStreaming={busy}
+                  onCapture={captureScreenshot}
+                />
               ))}
             </div>
             <div className="flex flex-none items-end gap-2 border-t p-3">
@@ -520,9 +731,21 @@ function WriterModal({
                 placeholder="Ask the writer to revise the document…"
                 className="max-h-28 min-h-[42px] resize-none"
               />
-              <Button size="icon" className="flex-none" onClick={send}>
-                <SendIcon className="size-4" />
-              </Button>
+              {busy ? (
+                <Button
+                  size="icon"
+                  variant="secondary"
+                  className="flex-none"
+                  onClick={stopStream}
+                  title="Stop"
+                >
+                  <SquareIcon className="size-4" />
+                </Button>
+              ) : (
+                <Button size="icon" className="flex-none" onClick={send}>
+                  <SendIcon className="size-4" />
+                </Button>
+              )}
             </div>
           </div>
 
@@ -645,23 +868,42 @@ function WriterModal({
           )}
         </div>
 
-        {/* Footer — just Cancel / Apply. */}
+        {/* Footer — Cancel / Apply. Apply uploads any captured screenshots to
+            Cloudinary before writing the field back. */}
         <div className="flex h-14 flex-none items-center justify-end gap-3 border-t bg-muted/40 px-4">
-          <Button variant="outline" onClick={requestClose}>
+          <Button variant="outline" onClick={requestClose} disabled={applying}>
             Cancel
           </Button>
-          <Button onClick={() => onApply(doc, chat)}>Apply</Button>
+          <Button onClick={handleApply} disabled={applying}>
+            {applying ? (
+              <>
+                <Loader2Icon className="mr-1 size-4 animate-spin" />
+                Uploading images…
+              </>
+            ) : (
+              "Apply"
+            )}
+          </Button>
         </div>
       </DialogContent>
     </Dialog>
   );
 }
 
-function ChatBubble({ msg }: { msg: ChatMsg }) {
+function ChatBubble({
+  msg,
+  isStreaming,
+  onCapture,
+}: {
+  msg: ChatMsg;
+  isStreaming: boolean;
+  onCapture: (frameId: string, label: string) => void;
+}) {
   if (msg.role === "tool") {
     return (
-      <div className="rounded-md border border-dashed px-3 py-2 font-mono text-xs text-muted-foreground">
-        ↳ tool: {msg.text}
+      <div className="flex items-center gap-2 rounded-md border border-dashed px-3 py-2 font-mono text-xs text-muted-foreground">
+        {isStreaming && <Loader2Icon className="size-3.5 animate-spin" />}
+        <span>↳ tool: {msg.text}</span>
       </div>
     );
   }
@@ -678,6 +920,78 @@ function ChatBubble({ msg }: { msg: ChatMsg }) {
         )}
       >
         {msg.text}
+        {msg.streaming && (
+          <span className="ml-0.5 inline-block h-3.5 w-1.5 animate-pulse bg-foreground/70 align-middle" />
+        )}
+      </div>
+      {msg.kind === "screenshot" && <ChooseScreenshotCard onCapture={onCapture} />}
+    </div>
+  );
+}
+
+/* Inline screenshot picker — scrub the clip's frames, capture one into the doc.
+   Stand-in for the real <choosescreenshot> component in write-chat.tsx. */
+function ChooseScreenshotCard({
+  onCapture,
+}: {
+  onCapture: (frameId: string, label: string) => void;
+}) {
+  const [idx, setIdx] = useState(2);
+  const [captured, setCaptured] = useState(false);
+  const frame = CLIP_FRAMES[idx]!;
+  return (
+    <div className="mt-2 w-[92%] rounded-lg border bg-background p-2">
+      <div
+        className="flex h-28 items-end justify-between rounded-md p-2 text-[10px] font-medium text-white"
+        style={{
+          background: `linear-gradient(135deg, hsl(${frame.hue} 70% 45%), hsl(${(frame.hue + 40) % 360} 70% 35%))`,
+        }}
+      >
+        <span className="rounded bg-black/40 px-1.5 py-0.5">
+          frame @ {frame.label}
+        </span>
+        <span className="rounded bg-black/40 px-1.5 py-0.5">
+          {idx + 1}/{CLIP_FRAMES.length}
+        </span>
+      </div>
+      <div className="mt-2 flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon"
+          className="size-7"
+          onClick={() => setIdx((i) => Math.max(0, i - 1))}
+          disabled={idx === 0}
+        >
+          <ChevronLeftIcon className="size-4" />
+        </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          className="size-7"
+          onClick={() => setIdx((i) => Math.min(CLIP_FRAMES.length - 1, i + 1))}
+          disabled={idx === CLIP_FRAMES.length - 1}
+        >
+          <ChevronRightIcon className="size-4" />
+        </Button>
+        <div className="flex-1" />
+        <Button
+          size="sm"
+          className="h-7"
+          onClick={() => {
+            onCapture(`frame-${frame.ts}`, frame.label);
+            setCaptured(true);
+          }}
+        >
+          {captured ? (
+            <>
+              <CheckIcon className="mr-1 size-4" /> Inserted
+            </>
+          ) : (
+            <>
+              <CameraIcon className="mr-1 size-4" /> Capture into doc
+            </>
+          )}
+        </Button>
       </div>
     </div>
   );
@@ -724,7 +1038,12 @@ function InlineContextStrip({
       {model.sources.map((s) => (
         <button
           key={s.source.key}
-          onClick={() => model.toggleSource(s.source)}
+          onClick={() =>
+            model.toggleSource(
+              s.items.map((i) => i.id),
+              s.check === true
+            )
+          }
           className={cn(
             "flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] transition-colors",
             s.check === false
@@ -817,7 +1136,12 @@ function ContextView({
           <label className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 hover:bg-muted">
             <Checkbox
               checked={s.check}
-              onCheckedChange={() => model.toggleSource(s.source)}
+              onCheckedChange={() =>
+                model.toggleSource(
+                  s.items.map((i) => i.id),
+                  s.check === true
+                )
+              }
             />
             <div className="min-w-0 flex-1">
               <div className="text-sm leading-tight">{s.source.label}</div>
@@ -829,34 +1153,104 @@ function ContextView({
               {fmtTok(s.tokens)}
             </div>
           </label>
-          {/* Parts — only worth showing when the source has more than one. */}
-          {!s.atomic && (
-            <div className="ml-4 border-l pl-2">
+
+          {/* Writer memory is editable, not just toggleable. */}
+          {s.source.key === "memory" && (
+            <div className="ml-6 mt-1">
+              <Textarea
+                value={model.memoryText}
+                onChange={(e) => model.setMemory(e.target.value)}
+                className="min-h-[120px] font-mono text-xs"
+              />
+            </div>
+          )}
+
+          {/* Links are editable — remove each, add new ones. */}
+          {s.source.key === "links" && (
+            <div className="ml-6 mt-1 space-y-1">
               {s.items.map((i) => (
-                <label
-                  key={i.id}
-                  className={cn(
-                    "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted",
-                    !i.on && "opacity-50"
-                  )}
-                >
+                <div key={i.id} className="flex items-center gap-2">
                   <Checkbox
                     checked={i.on}
                     onCheckedChange={() => model.toggleItem(i.id)}
                   />
-                  <span className="min-w-0 flex-1 truncate text-xs">
+                  <span
+                    className={cn(
+                      "min-w-0 flex-1 truncate text-xs",
+                      !i.on && "opacity-50"
+                    )}
+                  >
                     {i.label}
                   </span>
                   <span className="font-mono text-[10px] text-muted-foreground">
                     {fmtTok(i.tokens)}
                   </span>
-                </label>
+                  <button
+                    onClick={() => model.removeLink(i.id)}
+                    className="text-muted-foreground hover:text-foreground"
+                    title="Remove link"
+                  >
+                    <X className="size-3.5" />
+                  </button>
+                </div>
               ))}
+              <AddLinkRow onAdd={model.addLink} />
             </div>
           )}
+
+          {/* Other multi-part sources: plain per-part toggles. */}
+          {!s.atomic &&
+            s.source.key !== "links" &&
+            s.source.key !== "memory" && (
+              <div className="ml-4 border-l pl-2">
+                {s.items.map((i) => (
+                  <label
+                    key={i.id}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted",
+                      !i.on && "opacity-50"
+                    )}
+                  >
+                    <Checkbox
+                      checked={i.on}
+                      onCheckedChange={() => model.toggleItem(i.id)}
+                    />
+                    <span className="min-w-0 flex-1 truncate text-xs">
+                      {i.label}
+                    </span>
+                    <span className="font-mono text-[10px] text-muted-foreground">
+                      {fmtTok(i.tokens)}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            )}
         </div>
       ))}
     </FullCover>
+  );
+}
+
+/* Small add-a-link input used inside the Context view's Links source. */
+function AddLinkRow({ onAdd }: { onAdd: (url: string) => void }) {
+  const [url, setUrl] = useState("");
+  const add = () => {
+    onAdd(url);
+    setUrl("");
+  };
+  return (
+    <div className="flex gap-2 pt-1">
+      <Input
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && add()}
+        placeholder="Add a link…"
+        className="h-7 text-xs"
+      />
+      <Button size="sm" className="h-7" onClick={add}>
+        Add
+      </Button>
+    </div>
   );
 }
 
@@ -956,6 +1350,73 @@ function SettingsView({
   );
 }
 
+/* A long-form field that is itself an editable Monaco editor, with floating
+   Preview / Open-in-writer buttons — so you can read or tweak the value inline
+   without opening the full writer. */
+function BodyField({
+  value,
+  onChange,
+  onOpen,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onOpen: () => void;
+}) {
+  const [preview, setPreview] = useState(false);
+  return (
+    <div className="relative overflow-hidden rounded-md border bg-background">
+      <div className="absolute right-2 top-2 z-10 flex gap-1">
+        <Button
+          variant="secondary"
+          size="sm"
+          className="h-7 shadow-sm"
+          onClick={() => setPreview((p) => !p)}
+        >
+          {preview ? (
+            <>
+              <PencilIcon className="mr-1 size-3.5" /> Edit
+            </>
+          ) : (
+            <>
+              <EyeIcon className="mr-1 size-3.5" /> Preview
+            </>
+          )}
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          className="h-7 shadow-sm"
+          onClick={onOpen}
+        >
+          <Maximize2Icon className="mr-1 size-3.5" /> Open in writer
+        </Button>
+      </div>
+      <div className="h-[280px]">
+        {preview ? (
+          <div className="scrollbar scrollbar-track-transparent scrollbar-thumb-muted h-full overflow-y-auto p-4">
+            <div className="max-w-[75ch]">
+              <AIResponse imageBasePath="prototype/the-satisfies-operator">
+                {value}
+              </AIResponse>
+            </div>
+          </div>
+        ) : (
+          <MarkdownMonacoEditor
+            value={value}
+            onChange={onChange}
+            options={{ padding: { top: 12 } }}
+            fallback={
+              <div className="p-4 text-sm text-muted-foreground">
+                Loading editor…
+              </div>
+            }
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
 /* ================================================================== */
 /* Host page — a faithful copy of the AI Hero form's field layout, so  */
 /* the modal is judged against the real page density.                  */
@@ -1018,24 +1479,15 @@ export default function PrototypeWriterModal() {
           />
         </div>
 
-        {/* The click-to-edit long-form field (the point). */}
+        {/* The long-form field — a real editable Monaco field with floating
+            Preview / Open-in-writer buttons top-right. */}
         <div className="space-y-2">
-          <Label className="flex items-center gap-2">
-            Body (Markdown)
-            <span className="text-xs font-normal text-primary">
-              · click to edit in the writer
-            </span>
-          </Label>
-          <button
-            type="button"
-            onClick={() => setModalOpen(true)}
-            className="group relative block min-h-[220px] w-full rounded-md border bg-background p-4 text-left font-mono text-sm hover:border-primary/40 hover:bg-muted/30"
-          >
-            <span className="pointer-events-none absolute right-3 top-3 flex items-center gap-1.5 rounded border bg-background px-2 py-1 text-xs font-sans text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">
-              <PencilIcon className="size-3.5" /> Edit in writer
-            </span>
-            <span className="whitespace-pre-wrap text-foreground">{body}</span>
-          </button>
+          <Label>Body (Markdown)</Label>
+          <BodyField
+            value={body}
+            onChange={setBody}
+            onOpen={() => setModalOpen(true)}
+          />
           <p className="text-xs text-muted-foreground">
             This becomes <code className="font-mono">video.body</code> and
             exports into <code className="font-mono">course.json</code>. Its

--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -1,0 +1,771 @@
+"use client";
+
+/**
+ * PROTOTYPE — course-video-manager#1113 (writer-engine-extract), a ticket on the
+ * CVM → AI Hero CMS auto-link wayfinder map (#1111).
+ * Throwaway. Question: what should the *field-bound writer modal* look and feel
+ * like, and how should the injected-context **token cost** be surfaced?
+ *
+ * The modal opens from a long-form Post field (here, the AI Hero **Body**). It
+ * collapses the fullscreen writer's 3-pane workspace to 2 panes — chat + document
+ * — and treats the field's value as the document (Apply writes back, Cancel
+ * discards). Mirrors the seam from #1113: the host injects
+ * `videoId / fieldId / modes / initialDocument / onApply / context / layout`.
+ *
+ * The live design question is the **context token counter** (Matt's ask: a raw
+ * token number, bytes ÷ 4, so you can see how much the "extra stuff" costs):
+ *
+ *   ?variant=A — Context drawer (Sheet): per-source breakdown + big total, opened
+ *                from a Context button that always shows the running total.
+ *   ?variant=B — Header budget meter: an always-visible token meter in the modal
+ *                header; click for the per-source Popover breakdown.
+ *   ?variant=C — Inline context strip: sources as chips docked above the document,
+ *                always on-screen, no drawer.
+ *
+ * Still a prototype: NOT wired to the real writer engine / useChat / endpoints.
+ * Chat + document are hand-authored fixtures; toggling context sources only
+ * recomputes the token estimate. Once a token-counter treatment wins, fold it
+ * into the real modal host built in #1114 (writable-field-component), then delete
+ * this file + its losing variants.
+ */
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { MarkdownMonacoEditor } from "@/components/markdown-monaco-editor";
+import { cn } from "@/lib/utils";
+import {
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  GaugeIcon,
+  Layers,
+  PencilIcon,
+  SendIcon,
+  SparklesIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router";
+
+/* ================================================================== */
+/* Token estimate — the whole point: raw tokens ≈ ceil(bytes / 4).     */
+/* ================================================================== */
+
+const encoder = new TextEncoder();
+const byteLength = (s: string) => encoder.encode(s).length;
+/** Deliberately crude gauge of injected-context weight — not a real tokenizer. */
+const estimateTokens = (s: string) => Math.ceil(byteLength(s) / 4);
+const fmt = (n: number) => n.toLocaleString("en-US");
+const fmtBytes = (n: number) =>
+  n < 1024 ? `${n} B` : `${(n / 1024).toFixed(1)} KB`;
+
+/** Illustrative budget bands so the number has a felt sense of "a lot". */
+function tokenTone(total: number): { text: string; bar: string } {
+  if (total > 12000) return { text: "text-destructive", bar: "bg-destructive" };
+  if (total > 6000) return { text: "text-amber-600", bar: "bg-amber-500" };
+  return { text: "text-emerald-600", bar: "bg-emerald-500" };
+}
+
+/* ================================================================== */
+/* Fixtures — the injected `context: WriterContext` payload + document. */
+/* ================================================================== */
+
+type ContextSource = {
+  key: string;
+  label: string;
+  note: string;
+  text: string;
+};
+
+const TRANSCRIPT =
+  `In this video we look at the satisfies operator, which shipped in TypeScript 4.9. `.repeat(
+    60
+  ) +
+  `The problem it solves: annotating a variable widens the value to the declared type and you lose the literal information; leaving the annotation off keeps the narrow inferred type but gives you no validation. satisfies gives you both — it checks the value against the type without changing the inferred type. `.repeat(
+    24
+  );
+const FILES =
+  `readme.md\nexercise.ts\nexercise.solution.ts\nexplainer.ts\n`.repeat(6) +
+  `const config = {\n  routes: { home: "/", about: "/about" },\n  theme: "dark",\n} satisfies Config;\n`.repeat(
+    10
+  );
+const LINKS =
+  `https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html\nhttps://github.com/microsoft/TypeScript/pull/46827\nhttps://www.totaltypescript.com/tips/satisfies\n`.repeat(
+    4
+  );
+const COURSE_STRUCTURE =
+  `Course: TypeScript Wizard\n  Section: Deriving Types\n    Lesson: The satisfies Operator [explainer, problem, solution]\n    Lesson: keyof and typeof\n    Lesson: Indexed Access Types\n  Section: Generics\n`.repeat(
+    8
+  );
+const CHAPTERS =
+  `00:00 The two bad options\n01:12 Annotating widens the type\n02:40 No annotation = no validation\n03:55 Enter satisfies\n05:30 A real config example\n07:10 Gotchas with unions\n`.repeat(
+    6
+  );
+const MEMORY =
+  `- Matt prefers examples before theory.\n- House style: no "simply" / "just".\n- AI Hero bodies open with the concrete problem, then mechanics, then a runnable example.\n- Keep paragraphs short; prefer code over prose where it is clearer.\n`.repeat(
+    4
+  );
+const FULL_PATH = `typescript-wizard/deriving-types/the-satisfies-operator/explainer/readme.md`;
+
+const CONTEXT_SOURCES: ContextSource[] = [
+  {
+    key: "transcript",
+    label: "Transcript",
+    note: "clips.text, all segments",
+    text: TRANSCRIPT,
+  },
+  {
+    key: "files",
+    label: "Repo files",
+    note: "readme + exercise/solution sources",
+    text: FILES,
+  },
+  {
+    key: "links",
+    label: "Links",
+    note: "reference URLs on the video",
+    text: LINKS,
+  },
+  {
+    key: "courseStructure",
+    label: "Course structure",
+    note: "sections / lessons tree",
+    text: COURSE_STRUCTURE,
+  },
+  {
+    key: "chapters",
+    label: "Chapters",
+    note: "meta.json chapter markers",
+    text: CHAPTERS,
+  },
+  {
+    key: "memory",
+    label: "Writer memory",
+    note: "standing style preferences",
+    text: MEMORY,
+  },
+  {
+    key: "fullPath",
+    label: "Full path",
+    note: "namespacing / source pointer",
+    text: FULL_PATH,
+  },
+];
+
+const INITIAL_BODY = `## The two bad options
+
+Before \`satisfies\`, configuring a typed object forced a lose-lose choice.
+
+Annotate it, and TypeScript **widens** every value to the declared type — you can
+no longer tell that \`theme\` was \`"dark"\` specifically.
+
+Leave the annotation off, and you keep the narrow inferred type — but nothing
+checks that the object actually matches \`Config\`.
+
+## Enter satisfies
+
+\`satisfies\` validates the value against the type **without changing the inferred
+type**:
+
+\`\`\`ts
+const config = {
+  routes: { home: "/", about: "/about" },
+  theme: "dark",
+} satisfies Config;
+// config.theme is "dark", not string — and it's still checked against Config
+\`\`\`
+`;
+
+type ChatMsg = { role: "assistant" | "user" | "tool"; text: string };
+const CHAT: ChatMsg[] = [
+  {
+    role: "assistant",
+    text: "I've got the transcript, chapters and course structure loaded. Want me to draft the AI Hero body from the transcript, or start from the current field value?",
+  },
+  {
+    role: "user",
+    text: "Draft from the transcript. Lead with the problem satisfies solves, then the mechanics.",
+  },
+  {
+    role: "tool",
+    text: 'writeDocument(section: "intro") — streamed 412 chars into the document →',
+  },
+  {
+    role: "assistant",
+    text: "Done — drafted the intro and the “Enter satisfies” section into the document on the right. The widening example comes straight from chapter 3 of the transcript.",
+  },
+];
+
+/** Field → mode (D6): one mode ⇒ static label, many ⇒ a real selector. */
+const MODES = ["article", "skill-building", "newsletter"];
+
+/* ================================================================== */
+/* Context token model — shared across all three presentations.        */
+/* ================================================================== */
+
+function useContextModel() {
+  const [enabled, setEnabled] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(CONTEXT_SOURCES.map((s) => [s.key, true]))
+  );
+  const toggle = useCallback(
+    (key: string) => setEnabled((e) => ({ ...e, [key]: !e[key] })),
+    []
+  );
+  const rows = useMemo(
+    () =>
+      CONTEXT_SOURCES.map((s) => ({
+        ...s,
+        on: enabled[s.key],
+        tokens: estimateTokens(s.text),
+        bytes: byteLength(s.text),
+      })),
+    [enabled]
+  );
+  const totalTokens = rows.reduce((a, r) => (r.on ? a + r.tokens : a), 0);
+  const totalBytes = rows.reduce((a, r) => (r.on ? a + r.bytes : a), 0);
+  const maxTokens = Math.max(1, ...rows.map((r) => r.tokens));
+  return { rows, toggle, totalTokens, totalBytes, maxTokens };
+}
+
+type ContextModel = ReturnType<typeof useContextModel>;
+
+/* The per-source list, reused by the drawer / popover / inline strip. */
+function ContextBreakdown({ model }: { model: ContextModel }) {
+  return (
+    <div className="flex flex-col">
+      {model.rows.map((r) => (
+        <label
+          key={r.key}
+          className={cn(
+            "flex items-center gap-3 rounded-md px-2 py-2 hover:bg-muted cursor-pointer",
+            !r.on && "opacity-45"
+          )}
+        >
+          <Checkbox
+            checked={r.on}
+            onCheckedChange={() => model.toggle(r.key)}
+          />
+          <div className="min-w-0 flex-1">
+            <div className="text-sm leading-tight">{r.label}</div>
+            <div className="text-xs text-muted-foreground">{r.note}</div>
+            <div
+              className="mt-1 h-1 rounded-full bg-primary/50"
+              style={{
+                width: `${Math.round((r.tokens / model.maxTokens) * 100)}%`,
+              }}
+            />
+          </div>
+          <div className="text-right font-mono text-xs">
+            <div>{fmt(r.tokens)}</div>
+            <div className="text-[10px] text-muted-foreground">
+              {fmtBytes(r.bytes)}
+            </div>
+          </div>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+function ContextTotalCard({ model }: { model: ContextModel }) {
+  const tone = tokenTone(model.totalTokens);
+  return (
+    <div className="flex items-baseline justify-between rounded-lg border bg-muted/40 px-4 py-3">
+      <div>
+        <div className={cn("font-mono text-2xl font-semibold", tone.text)}>
+          {fmt(model.totalTokens)}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          tokens injected (bytes ÷ 4)
+        </div>
+      </div>
+      <div className="text-right">
+        <div className="font-mono text-sm">{fmtBytes(model.totalBytes)}</div>
+        <div className="text-xs text-muted-foreground">raw bytes</div>
+      </div>
+    </div>
+  );
+}
+
+/* ================================================================== */
+/* The field-bound writer modal.                                       */
+/* ================================================================== */
+
+function WriterModal({
+  variant,
+  open,
+  onOpenChange,
+  initialValue,
+  onApply,
+}: {
+  variant: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialValue: string;
+  onApply: (value: string) => void;
+}) {
+  const [doc, setDoc] = useState(initialValue);
+  const [mode, setMode] = useState(MODES[0]);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const ctx = useContextModel();
+  const tone = tokenTone(ctx.totalTokens);
+  const docTokens = estimateTokens(doc);
+
+  // Reseed the working copy whenever the field re-opens (D1/D5: field value IS the doc).
+  useEffect(() => {
+    if (open) setDoc(initialValue);
+  }, [open, initialValue]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="flex h-[82vh] max-h-[780px] w-[94vw] max-w-[1120px] flex-col gap-0 overflow-hidden p-0 sm:max-w-[1120px]"
+      >
+        {/* Header */}
+        <div className="flex h-13 flex-none items-center gap-3 border-b bg-muted/40 px-4 py-2">
+          <DialogTitle className="flex items-center gap-2 text-sm font-semibold">
+            <Badge variant="secondary" className="font-mono text-[11px]">
+              writer
+            </Badge>
+            AI Hero Body
+          </DialogTitle>
+
+          {/* D6: one mode ⇒ static label; many ⇒ selector. */}
+          <Select value={mode} onValueChange={setMode}>
+            <SelectTrigger size="sm" className="w-[190px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {MODES.map((m) => (
+                <SelectItem key={m} value={m} className="font-mono text-xs">
+                  {m}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <div className="flex-1" />
+
+          {/* --- Variant A: Context button carrying the running total --- */}
+          {variant === "A" && (
+            <Button
+              variant={drawerOpen ? "secondary" : "outline"}
+              size="sm"
+              onClick={() => setDrawerOpen((o) => !o)}
+            >
+              <Layers className="size-4" />
+              Context
+              <Badge
+                variant="outline"
+                className={cn("ml-1 font-mono", tone.text)}
+              >
+                ~{fmt(ctx.totalTokens)} tok
+              </Badge>
+            </Button>
+          )}
+
+          {/* --- Variant B: always-on header budget meter (+ popover) --- */}
+          {variant === "B" && <HeaderMeter model={ctx} />}
+
+          <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </div>
+
+        {/* Body: 2 panes — chat + document */}
+        <div className="relative flex min-h-0 flex-1">
+          {/* Chat */}
+          <div className="flex w-2/5 flex-col border-r">
+            <div className="flex-1 space-y-3 overflow-y-auto p-4">
+              {CHAT.map((m, i) => (
+                <ChatBubble key={i} msg={m} />
+              ))}
+            </div>
+            <div className="flex flex-none items-end gap-2 border-t p-3">
+              <Textarea
+                rows={1}
+                placeholder="Ask the writer to revise the document…"
+                className="max-h-28 min-h-[42px] resize-none"
+              />
+              <Button size="icon" className="flex-none">
+                <SendIcon className="size-4" />
+              </Button>
+            </div>
+          </div>
+
+          {/* Document */}
+          <div className="flex flex-1 flex-col">
+            {/* Variant C: inline context strip docked above the document */}
+            {variant === "C" && <InlineContextStrip model={ctx} />}
+
+            <div className="flex h-8 flex-none items-center gap-2 border-b px-3 text-xs text-muted-foreground">
+              <span className="size-1.5 rounded-full bg-emerald-500" />
+              <FileText className="size-3.5" />
+              document · working copy (unsaved)
+              <span className="ml-auto font-mono">{fmt(docTokens)} tok</span>
+            </div>
+            <div className="min-h-0 flex-1">
+              <MarkdownMonacoEditor
+                value={doc}
+                onChange={setDoc}
+                fallback={
+                  <div className="p-4 text-sm text-muted-foreground">
+                    Loading editor…
+                  </div>
+                }
+              />
+            </div>
+          </div>
+
+          {/* Variant A: Context drawer — an in-modal sliding panel (not a
+              Sheet, so it sits alongside the document instead of dimming it). */}
+          {variant === "A" && (
+            <aside
+              className={cn(
+                "absolute inset-y-0 right-0 z-10 flex w-[380px] flex-col border-l bg-muted/40 shadow-xl transition-transform duration-200",
+                drawerOpen
+                  ? "translate-x-0"
+                  : "pointer-events-none translate-x-full"
+              )}
+            >
+              <div className="flex-none border-b px-4 py-3">
+                <div className="text-sm font-semibold">Injected context</div>
+                <p className="text-xs text-muted-foreground">
+                  Everything the host passes into the agent — the “extra stuff”
+                  behind the modal.
+                </p>
+              </div>
+              <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-4">
+                <ContextTotalCard model={ctx} />
+                <ContextBreakdown model={ctx} />
+                <p className="text-xs text-muted-foreground">
+                  Estimate:{" "}
+                  <code className="font-mono">tokens ≈ ⌈bytes / 4⌉</code>{" "}
+                  (UTF-8). Toggle a source to see its cost. This is the{" "}
+                  <code className="font-mono">context: WriterContext</code>{" "}
+                  payload.
+                </p>
+              </div>
+            </aside>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex h-14 flex-none items-center justify-end gap-3 border-t bg-muted/40 px-4">
+          <span className="mr-auto text-xs text-muted-foreground">
+            Working copy — <b>Apply</b> writes back to the field · <b>Cancel</b>{" "}
+            discards ·{" "}
+            <span className={cn("font-mono", tone.text)}>
+              ~{fmt(ctx.totalTokens)}
+            </span>{" "}
+            context tok
+          </span>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              onApply(doc);
+              onOpenChange(false);
+            }}
+          >
+            Apply
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ChatBubble({ msg }: { msg: ChatMsg }) {
+  if (msg.role === "tool") {
+    return (
+      <div className="rounded-md border border-dashed px-3 py-2 font-mono text-xs text-muted-foreground">
+        ↳ tool: {msg.text}
+      </div>
+    );
+  }
+  const isUser = msg.role === "user";
+  return (
+    <div className={cn("flex flex-col", isUser ? "items-end" : "items-start")}>
+      <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+        {isUser ? "you" : "writer"}
+      </div>
+      <div
+        className={cn(
+          "max-w-[92%] rounded-lg px-3 py-2 text-sm",
+          isUser ? "bg-accent" : "border bg-muted"
+        )}
+      >
+        {msg.text}
+      </div>
+    </div>
+  );
+}
+
+/* Variant B — always-visible header meter with a popover breakdown. */
+function HeaderMeter({ model }: { model: ContextModel }) {
+  const tone = tokenTone(model.totalTokens);
+  const pct = Math.min(100, Math.round((model.totalTokens / 16000) * 100));
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button className="flex items-center gap-2 rounded-md border px-3 py-1.5 hover:bg-muted">
+          <GaugeIcon className={cn("size-4", tone.text)} />
+          <span className={cn("font-mono text-sm", tone.text)}>
+            {fmt(model.totalTokens)}
+          </span>
+          <span className="text-xs text-muted-foreground">ctx tok</span>
+          <span className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
+            <span
+              className={cn("block h-full", tone.bar)}
+              style={{ width: `${pct}%` }}
+            />
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-[340px]">
+        <div className="mb-2 text-sm font-medium">Injected context</div>
+        <ContextTotalCard model={model} />
+        <div className="mt-2">
+          <ContextBreakdown model={model} />
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          <code className="font-mono">tokens ≈ ⌈bytes / 4⌉</code> (UTF-8)
+        </p>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/* Variant C — inline context strip docked above the document. */
+function InlineContextStrip({ model }: { model: ContextModel }) {
+  const tone = tokenTone(model.totalTokens);
+  return (
+    <div className="flex flex-none flex-wrap items-center gap-1.5 border-b bg-muted/30 px-3 py-2">
+      <span className="mr-1 flex items-center gap-1.5 text-xs font-medium">
+        <Layers className="size-3.5" /> Context
+        <span className={cn("font-mono", tone.text)}>
+          ~{fmt(model.totalTokens)} tok
+        </span>
+      </span>
+      {model.rows.map((r) => (
+        <button
+          key={r.key}
+          onClick={() => model.toggle(r.key)}
+          className={cn(
+            "rounded-full border px-2 py-0.5 font-mono text-[11px] transition-colors",
+            r.on
+              ? "bg-background hover:bg-muted"
+              : "bg-transparent text-muted-foreground line-through opacity-60"
+          )}
+          title={`${r.note} · ${fmtBytes(r.bytes)}`}
+        >
+          {r.label} {fmt(r.tokens)}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ================================================================== */
+/* Host page — a faithful copy of the AI Hero form's field layout, so  */
+/* the modal is judged against the real page density.                  */
+/* ================================================================== */
+
+const VARIANTS = ["A", "B", "C"] as const;
+const VARIANT_NAMES: Record<string, string> = {
+  A: "Context drawer",
+  B: "Header meter",
+  C: "Inline strip",
+};
+
+export default function PrototypeWriterModal() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const variant = (searchParams.get("variant") ?? "A").toUpperCase();
+
+  const [body, setBody] = useState(INITIAL_BODY);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const setVariant = useCallback(
+    (v: string) => {
+      const next = new URLSearchParams(searchParams);
+      next.set("variant", v);
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams]
+  );
+
+  // ← / → cycle variants (ignore when typing / in the editor).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+      const el = document.activeElement;
+      if (
+        el instanceof HTMLInputElement ||
+        el instanceof HTMLTextAreaElement ||
+        (el as HTMLElement)?.isContentEditable ||
+        el?.closest(".monaco-editor")
+      )
+        return;
+      const i = VARIANTS.indexOf(variant as (typeof VARIANTS)[number]);
+      const j =
+        i < 0
+          ? 0
+          : (i + (e.key === "ArrowRight" ? 1 : VARIANTS.length - 1)) %
+            VARIANTS.length;
+      setVariant(VARIANTS[j]!);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [variant, setVariant]);
+
+  return (
+    <div className="h-screen overflow-y-auto bg-background">
+      {/* Fake app chrome so the field sits in a realistic page. */}
+      <div className="flex h-12 items-center gap-3 border-b px-4">
+        <span className="text-sm font-medium text-muted-foreground">
+          course-video-manager
+        </span>
+        <span className="text-sm text-muted-foreground">
+          TypeScript Wizard / Deriving Types /{" "}
+          <b className="text-foreground">The satisfies Operator</b>
+        </span>
+        <div className="ml-auto flex gap-1 text-sm">
+          <span className="rounded px-3 py-1.5 text-muted-foreground">
+            Video
+          </span>
+          <span className="rounded px-3 py-1.5 text-muted-foreground">
+            Write
+          </span>
+          <span className="rounded bg-muted px-3 py-1.5 text-foreground">
+            Post
+          </span>
+        </div>
+      </div>
+      <div className="flex h-10 items-center gap-1 border-b px-4 text-sm">
+        <span className="px-3 py-1 text-muted-foreground">YouTube</span>
+        <span className="px-3 py-1 text-muted-foreground">X / LinkedIn</span>
+        <span className="border-b-2 border-primary px-3 py-1 text-foreground">
+          AI Hero
+        </span>
+        <span className="px-3 py-1 text-muted-foreground">
+          Skills Changelog
+        </span>
+        <span className="px-3 py-1 text-muted-foreground">Newsletter</span>
+      </div>
+
+      <div className="mx-auto max-w-2xl space-y-6 p-6">
+        <div className="space-y-2">
+          <Label htmlFor="title">Title</Label>
+          <Input
+            id="title"
+            defaultValue="The satisfies Operator: type-safe config without widening"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="slug">Slug</Label>
+          <Input
+            id="slug"
+            className="font-mono text-sm"
+            defaultValue="the-satisfies-operator"
+          />
+        </div>
+
+        {/* The click-to-edit long-form field (the point). */}
+        <div className="space-y-2">
+          <Label className="flex items-center gap-2">
+            Body (Markdown)
+            <span className="text-xs font-normal text-primary">
+              · click to edit in the writer
+            </span>
+          </Label>
+          <button
+            type="button"
+            onClick={() => setModalOpen(true)}
+            className="group relative block min-h-[220px] w-full rounded-md border bg-background p-4 text-left font-mono text-sm hover:border-primary/40 hover:bg-muted/30"
+          >
+            <span className="pointer-events-none absolute right-3 top-3 flex items-center gap-1.5 rounded border bg-background px-2 py-1 text-xs font-sans text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">
+              <PencilIcon className="size-3.5" /> Edit in writer
+            </span>
+            <span className="whitespace-pre-wrap text-foreground">{body}</span>
+          </button>
+          <p className="text-xs text-muted-foreground">
+            This becomes <code className="font-mono">video.body</code> and
+            exports into <code className="font-mono">course.json</code>. Its
+            value <b>is</b> the writer document.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="seo">SEO Description</Label>
+          <Textarea
+            id="seo"
+            defaultValue="Learn how TypeScript's satisfies operator validates a value against a type while preserving its narrow inferred literal type."
+          />
+        </div>
+      </div>
+
+      <WriterModal
+        variant={variant}
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        initialValue={body}
+        onApply={setBody}
+      />
+
+      {/* Floating variant switcher (prototype only). */}
+      <div className="fixed bottom-4 left-1/2 z-[60] flex -translate-x-1/2 items-center gap-1 rounded-full border bg-background/95 px-2 py-1.5 shadow-lg backdrop-blur">
+        <SparklesIcon className="mx-1 size-3.5 text-muted-foreground" />
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7"
+          onClick={() => {
+            const i = Math.max(
+              0,
+              VARIANTS.indexOf(variant as (typeof VARIANTS)[number])
+            );
+            setVariant(VARIANTS[(i + VARIANTS.length - 1) % VARIANTS.length]!);
+          }}
+        >
+          <ChevronLeft className="size-4" />
+        </Button>
+        <span className="min-w-[150px] text-center text-xs font-medium">
+          {variant} — {VARIANT_NAMES[variant] ?? "?"}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7"
+          onClick={() => {
+            const i = Math.max(
+              0,
+              VARIANTS.indexOf(variant as (typeof VARIANTS)[number])
+            );
+            setVariant(VARIANTS[(i + 1) % VARIANTS.length]!);
+          }}
+        >
+          <ChevronRight className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -223,18 +223,6 @@ const CONTEXT_SOURCES: ContextSource[] = [
       },
     ],
   },
-  {
-    key: "fullPath",
-    label: "Full path",
-    note: "namespacing / source pointer",
-    items: [
-      {
-        id: "fullPath:0",
-        label: "source pointer",
-        text: `typescript-wizard/deriving-types/the-satisfies-operator/explainer/readme.md`,
-      },
-    ],
-  },
 ];
 
 /** An em dash + a leading heading are seeded so lint has something to catch. */

--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -82,12 +82,14 @@ import {
   ChevronDown,
   ChevronLeftIcon,
   ChevronRightIcon,
+  ExternalLinkIcon,
   EyeIcon,
   Layers,
   Loader2Icon,
   Maximize2Icon,
   MinusIcon,
   PencilIcon,
+  PlusIcon,
   RefreshCwIcon,
   SendIcon,
   SettingsIcon,
@@ -387,10 +389,30 @@ type SourceView = {
   tokens: number;
 };
 
-type LinkItem = { id: string; url: string };
+/** Links carry a title + optional description (mirrors the real link model). */
+type LinkItem = { id: string; url: string; title: string; description?: string };
 
 const memorySource = CONTEXT_SOURCES.find((s) => s.key === "memory")!;
-const linksSource = CONTEXT_SOURCES.find((s) => s.key === "links")!;
+
+const INITIAL_LINKS: LinkItem[] = [
+  {
+    id: "links:0",
+    url: "https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html",
+    title: "TypeScript 4.9 release notes",
+    description: "Where `satisfies` shipped",
+  },
+  {
+    id: "links:1",
+    url: "https://github.com/microsoft/TypeScript/pull/46827",
+    title: "satisfies operator — PR #46827",
+    description: "The original implementation",
+  },
+  {
+    id: "links:2",
+    url: "https://www.totaltypescript.com/tips/satisfies",
+    title: "Total TypeScript: satisfies",
+  },
+];
 
 function useContextModel() {
   const [enabled, setEnabled] = useState<Set<string>>(
@@ -399,9 +421,7 @@ function useContextModel() {
   // Writer memory and links are *editable* here, not just toggleable, so they
   // live in state and override the static fixture text.
   const [memoryText, setMemoryText] = useState(() => memorySource.items[0]!.text);
-  const [links, setLinks] = useState<LinkItem[]>(() =>
-    linksSource.items.map((i) => ({ id: i.id, url: i.text }))
-  );
+  const [links, setLinks] = useState<LinkItem[]>(() => INITIAL_LINKS);
   const linkSeq = useRef(links.length);
 
   const toggleItem = useCallback((id: string) => {
@@ -435,13 +455,24 @@ function useContextModel() {
     []
   );
 
-  const addLink = useCallback((url: string) => {
-    const u = url.trim();
-    if (!u) return;
-    const id = `links:added-${linkSeq.current++}`;
-    setLinks((l) => [...l, { id, url: u }]);
-    setEnabled((e) => new Set(e).add(id));
-  }, []);
+  const addLink = useCallback(
+    (link: { url: string; title: string; description?: string }) => {
+      const url = link.url.trim();
+      if (!url) return;
+      const id = `links:added-${linkSeq.current++}`;
+      setLinks((l) => [
+        ...l,
+        {
+          id,
+          url,
+          title: link.title.trim() || url,
+          description: link.description?.trim() || undefined,
+        },
+      ]);
+      setEnabled((e) => new Set(e).add(id));
+    },
+    []
+  );
 
   const removeLink = useCallback((id: string) => {
     setLinks((l) => l.filter((x) => x.id !== id));
@@ -458,7 +489,11 @@ function useContextModel() {
       if (source.key === "memory")
         return [{ ...source.items[0]!, text: memoryText }];
       if (source.key === "links")
-        return links.map((l) => ({ id: l.id, label: l.url, text: l.url }));
+        return links.map((l) => ({
+          id: l.id,
+          label: l.title || l.url,
+          text: [l.title, l.url, l.description].filter(Boolean).join("\n"),
+        }));
       return source.items;
     },
     [memoryText, links]
@@ -500,6 +535,7 @@ function useContextModel() {
     totalTokens,
     memoryText,
     setMemory: setMemoryText,
+    links,
     addLink,
     removeLink,
   };
@@ -1427,41 +1463,8 @@ function ContextTabBody({
         />
       )}
 
-      {/* Links — editable (remove each, add new ones). */}
-      {s.source.key === "links" && (
-        <div className="space-y-1">
-          {s.items.map((i) => (
-            <div
-              key={i.id}
-              className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
-            >
-              <Checkbox
-                checked={i.on}
-                onCheckedChange={() => model.toggleItem(i.id)}
-              />
-              <span
-                className={cn(
-                  "min-w-0 flex-1 truncate text-xs",
-                  !i.on && "opacity-50"
-                )}
-              >
-                {i.label}
-              </span>
-              <span className="font-mono text-[10px] text-muted-foreground">
-                {fmtTok(i.tokens)}
-              </span>
-              <button
-                onClick={() => model.removeLink(i.id)}
-                className="text-muted-foreground hover:text-foreground"
-                title="Remove link"
-              >
-                <X className="size-3.5" />
-              </button>
-            </div>
-          ))}
-          <AddLinkRow onAdd={model.addLink} />
-        </div>
-      )}
+      {/* Links — rich model (title + description), add via a form pane. */}
+      {s.source.key === "links" && <LinksTab model={model} view={s} />}
 
       {/* Repo files use the real <FileTree> picker (collapsible dirs, tri-state
           folders) rather than a flat list. */}
@@ -1526,25 +1529,191 @@ function ContextTabBody({
   );
 }
 
-/* Small add-a-link input used inside the Context view's Links source. */
-function AddLinkRow({ onAdd }: { onAdd: (url: string) => void }) {
-  const [url, setUrl] = useState("");
-  const add = () => {
-    onAdd(url);
-    setUrl("");
-  };
+const isValidUrl = (s: string) => {
+  try {
+    new URL(s);
+    return true;
+  } catch {
+    return false;
+  }
+};
+/** Cheap stand-in for the real /api/links/fetch-title endpoint. */
+const guessTitle = (s: string) => {
+  try {
+    const u = new URL(s);
+    const last = u.pathname.split("/").filter(Boolean).pop();
+    const host = u.hostname.replace(/^www\./, "");
+    return last ? `${host} — ${last.replace(/[-_]/g, " ")}` : host;
+  } catch {
+    return s;
+  }
+};
+
+/* Links source — rich rows (title + description + external link) plus an
+   "Add link" form pane with the typical URL / Title / Description inputs
+   (mirrors the real AddLinkModal, including title auto-fetch on paste). */
+function LinksTab({ model, view }: { model: ContextModel; view: SourceView }) {
+  const [adding, setAdding] = useState(false);
+  const meta = new Map(view.items.map((i) => [i.id, i]));
+
   return (
-    <div className="flex gap-2 pt-1">
-      <Input
-        value={url}
-        onChange={(e) => setUrl(e.target.value)}
-        onKeyDown={(e) => e.key === "Enter" && add()}
-        placeholder="Add a link…"
-        className="h-7 text-xs"
-      />
-      <Button size="sm" className="h-7" onClick={add}>
-        Add
-      </Button>
+    <div className="space-y-1">
+      {model.links.map((l) => {
+        const vi = meta.get(l.id);
+        const on = vi?.on ?? false;
+        return (
+          <div
+            key={l.id}
+            className="group flex items-start gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
+          >
+            <Checkbox
+              checked={on}
+              onCheckedChange={() => model.toggleItem(l.id)}
+              className="mt-0.5"
+            />
+            <a
+              href={l.url}
+              target="_blank"
+              rel="noreferrer"
+              className={cn(
+                "flex min-w-0 flex-1 items-start gap-2",
+                !on && "opacity-50"
+              )}
+            >
+              <ExternalLinkIcon className="mt-0.5 size-3 flex-none text-muted-foreground" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-xs font-medium">{l.title}</div>
+                {l.description && (
+                  <div className="truncate text-[11px] text-muted-foreground">
+                    {l.description}
+                  </div>
+                )}
+                <div className="truncate text-[10px] text-muted-foreground">
+                  {l.url}
+                </div>
+              </div>
+            </a>
+            <span className="font-mono text-[10px] text-muted-foreground">
+              {fmtTok(vi?.tokens ?? 0)}
+            </span>
+            <button
+              onClick={() => model.removeLink(l.id)}
+              className="text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+              title="Remove link"
+            >
+              <Trash2Icon className="size-3.5" />
+            </button>
+          </div>
+        );
+      })}
+
+      {adding ? (
+        <AddLinkForm
+          onCancel={() => setAdding(false)}
+          onAdd={(l) => {
+            model.addLink(l);
+            setAdding(false);
+          }}
+        />
+      ) : (
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-1 h-8"
+          onClick={() => setAdding(true)}
+        >
+          <PlusIcon className="mr-1 size-4" /> Add link
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/* The add-link form pane — URL (required), Title (required, auto-fetched from
+   the URL on paste/blur), Description (optional). */
+function AddLinkForm({
+  onCancel,
+  onAdd,
+}: {
+  onCancel: () => void;
+  onAdd: (l: { url: string; title: string; description?: string }) => void;
+}) {
+  const [url, setUrl] = useState("");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [fetching, setFetching] = useState(false);
+  const [touched, setTouched] = useState(false);
+  const valid = isValidUrl(url) && title.trim().length > 0;
+
+  // Simulate the real title auto-fetch when a valid URL lands and title is empty.
+  const autofill = (candidate: string) => {
+    if (!isValidUrl(candidate) || title) return;
+    setFetching(true);
+    setTimeout(() => {
+      setTitle((t) => t || guessTitle(candidate));
+      setFetching(false);
+    }, 450);
+  };
+
+  return (
+    <div className="mt-1 space-y-3 rounded-lg border bg-muted/30 p-3">
+      <div className="text-xs font-semibold">Add link</div>
+      <div className="space-y-1">
+        <Label className="text-xs">URL</Label>
+        <Input
+          value={url}
+          autoFocus
+          onChange={(e) => setUrl(e.target.value)}
+          onBlur={() => {
+            setTouched(true);
+            autofill(url);
+          }}
+          onPaste={(e) => autofill(e.clipboardData.getData("text"))}
+          placeholder="https://example.com"
+          className="h-8"
+        />
+        {touched && url && !isValidUrl(url) && (
+          <p className="text-xs text-destructive">
+            Enter a valid URL (e.g. https://example.com)
+          </p>
+        )}
+      </div>
+      <div className="space-y-1">
+        <Label className="text-xs">Title</Label>
+        <div className="relative">
+          <Input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="My Link"
+            className="h-8"
+          />
+          {fetching && (
+            <Loader2Icon className="absolute right-2 top-2 size-4 animate-spin text-muted-foreground" />
+          )}
+        </div>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-xs">Description (optional)</Label>
+        <Input
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="A brief description of this link"
+          className="h-8"
+        />
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button variant="outline" size="sm" className="h-8" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          className="h-8"
+          disabled={!valid}
+          onClick={() => onAdd({ url, title, description })}
+        >
+          Add link
+        </Button>
+      </div>
     </div>
   );
 }

--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -19,14 +19,18 @@
  *   • Each chip is a real toggle with a checkbox. A source made of parts
  *     (transcript segments, chapters, repo files, links) can be **partially on**
  *     → the checkbox shows an indeterminate state.
- *   • The "Context" button opens a full-options panel where individual parts
- *     (each chapter, each file…) can be toggled.
+ *   • The "Context" button opens a full-options panel — a **tabbed** editor, one
+ *     tab per source (each chapter, each file, memory, links…) can be toggled.
  *   • Token counts read as `4.1K`.
- *   • The document pane matches the real writer: Edit ⇄ Preview and a lint
- *     "Fix (N)" button (mirrors `document-panel.tsx`).
+ *   • Fewer bars: the strip above the document carries the context chips *and*
+ *     the Edit ⇄ Preview toggle; everything else (mode, Regenerate, Clear, the
+ *     lint "Fix (N)" control, and writer Settings) is consolidated into the
+ *     bottom bar's left cluster, away from Cancel / Apply on the right.
  *   • Cancel reverts the conversation history to what it was before the modal
  *     opened; closing with unsaved changes asks for confirmation first.
- *   • Footer is just Cancel / Apply — no explanation blurb, no token count.
+ *   • The modal's open state and the active context tab live in the **URL search
+ *     params** (`?writer=1&view=context&tab=chapters`) — deep-linkable, and the
+ *     browser Back button steps out of a view.
  *
  * Still a prototype: NOT wired to the real writer engine / useChat / endpoints.
  * Chat + document + context sources are hand-authored fixtures. Once this shape is
@@ -35,10 +39,16 @@
  */
 
 import { AIResponse } from "components/ui/kibo-ui/ai/response";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -68,6 +78,7 @@ import {
   ArrowLeft,
   CameraIcon,
   CheckIcon,
+  ChevronDown,
   ChevronLeftIcon,
   ChevronRightIcon,
   EyeIcon,
@@ -84,6 +95,7 @@ import {
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router";
 
 /* ================================================================== */
 /* Token estimate — the whole point: raw tokens ≈ ceil(bytes / 4).     */
@@ -301,8 +313,35 @@ const INITIAL_CHAT: ChatMsg[] = [
   },
 ];
 
-/** Field → mode (D6): one mode ⇒ static label, many ⇒ a real selector. */
-const MODES = ["article", "skill-building", "newsletter"];
+/**
+ * Field → mode (D6). The host injects the set of modes a given field is allowed
+ * to write in (part of the #1113 `context`/contract); the picker shows a FLAT
+ * list of just those. This catalog is only a label/description lookup — the
+ * allowed values come from the `modes` prop, not from here.
+ */
+const MODE_CATALOG: Record<string, { label: string; note: string }> = {
+  article: { label: "Article", note: "Educational content and explanations" },
+  "article-plan": {
+    label: "Article Plan",
+    note: "Plan structure with concise bullet points",
+  },
+  newsletter: {
+    label: "Newsletter",
+    note: "Friendly preview for the AI Hero audience",
+  },
+  "skill-building": {
+    label: "Skill Building Steps",
+    note: "Write steps for a skill-building problem",
+  },
+  "seo-description": {
+    label: "SEO Description",
+    note: "Generate an SEO description (max 160 chars)",
+  },
+};
+const modeLabel = (m: string) => MODE_CATALOG[m]?.label ?? m;
+
+/** The AI Hero Body field's contract: the only modes it may be written in. */
+const BODY_FIELD_MODES = ["article", "article-plan", "newsletter"];
 
 /* ================================================================== */
 /* Lint — a trimmed stand-in for use-lint.ts / lint-rules.ts.          */
@@ -484,9 +523,53 @@ function useContextModel() {
 
 type ContextModel = ReturnType<typeof useContextModel>;
 
+/* Mode picker — the write page's dropdown trigger (outline button + chevron,
+   items showing name + description), but a FLAT list of only the modes the
+   host's contract allows for this field. */
+function ModePicker({
+  modes,
+  mode,
+  onModeChange,
+}: {
+  modes: string[];
+  mode: string;
+  onModeChange: (m: string) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="min-w-[180px] justify-between"
+        >
+          {modeLabel(mode)}
+          <ChevronDown className="ml-2 size-4 opacity-50" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64">
+        <DropdownMenuRadioGroup value={mode} onValueChange={onModeChange}>
+          {modes.map((m) => (
+            <DropdownMenuRadioItem key={m} value={m}>
+              <div>
+                <div>{modeLabel(m)}</div>
+                <div className="text-xs text-muted-foreground">
+                  {MODE_CATALOG[m]?.note}
+                </div>
+              </div>
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 /* ================================================================== */
 /* The field-bound writer modal.                                       */
 /* ================================================================== */
+
+type WriterView = "writer" | "context" | "settings";
 
 function WriterModal({
   open,
@@ -494,24 +577,38 @@ function WriterModal({
   initialDoc,
   initialChat,
   onApply,
+  modes,
+  view,
+  onView,
+  ctxTab,
+  onCtxTab,
 }: {
   open: boolean;
   onClose: () => void;
   initialDoc: string;
   initialChat: ChatMsg[];
   onApply: (doc: string, chat: ChatMsg[]) => void;
+  // The field's allowed modes — injected by the host per the #1113 contract.
+  modes: string[];
+  // The full-body view + active context tab are URL-backed (search params), so
+  // they live in the host and are passed down controlled.
+  view: WriterView;
+  onView: (v: WriterView) => void;
+  ctxTab: string;
+  onCtxTab: (k: string) => void;
 }) {
   const [doc, setDoc] = useState(initialDoc);
   const [chat, setChat] = useState<ChatMsg[]>(initialChat);
   const [draft, setDraft] = useState("");
-  const [mode, setMode] = useState(MODES[0]);
+  const [mode, setMode] = useState(modes[0] ?? "article");
   const [model, setModel] = useState("auto");
   const [banned, setBanned] = useState<string[]>(DEFAULT_BANNED);
   const [status, setStatus] = useState<"ready" | "streaming">("ready");
   const [applying, setApplying] = useState(false);
-  // The whole modal body swaps between these; the writer view is never
-  // unmounted (so any background streaming survives the swap).
-  const [view, setView] = useState<"writer" | "context" | "settings">("writer");
+  // The whole modal body swaps between context/settings and the writer; the
+  // writer view is never unmounted (so any background streaming survives the
+  // swap). `view` itself is controlled by the URL (see props).
+  //
   // Default to Preview so the agent-generated <ChooseScreenshot> block in the
   // document is visible on open (it only renders in Preview, like the real app).
   const [isEditing, setIsEditing] = useState(false);
@@ -566,7 +663,6 @@ function WriterModal({
       setDoc(initialDoc);
       setChat(initialChat);
       setConfirmDiscard(false);
-      setView("writer");
       setApplying(false);
     }
   }, [open, initialDoc, initialChat, stopStream]);
@@ -689,41 +785,22 @@ function WriterModal({
           requestClose();
         }}
       >
-        {/* Header */}
+        {/* Header — trimmed to identity + streaming state + close. Everything
+            operational moved to the bottom bar / context strip. */}
         <div className="flex h-13 flex-none items-center gap-3 border-b bg-muted/40 px-4 py-2">
-          <DialogTitle className="flex items-center gap-2 text-sm font-semibold">
-            <Badge variant="secondary" className="font-mono text-[11px]">
-              writer
-            </Badge>
+          <DialogTitle className="text-sm font-semibold">
             AI Hero Body
           </DialogTitle>
 
-          {/* D6: one mode ⇒ static label; many ⇒ selector. */}
-          <Select value={mode} onValueChange={setMode}>
-            <SelectTrigger size="sm" className="w-[190px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {MODES.map((m) => (
-                <SelectItem key={m} value={m} className="font-mono text-xs">
-                  {m}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          {busy && (
+            <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Loader2Icon className="size-3.5 animate-spin" />
+              streaming…
+            </span>
+          )}
 
           <div className="flex-1" />
 
-          <Button
-            variant={view === "settings" ? "secondary" : "ghost"}
-            size="icon"
-            title="Settings"
-            onClick={() =>
-              setView((v) => (v === "settings" ? "writer" : "settings"))
-            }
-          >
-            <SettingsIcon className="size-4" />
-          </Button>
           <Button variant="ghost" size="icon" onClick={requestClose}>
             <X className="size-4" />
           </Button>
@@ -733,37 +810,6 @@ function WriterModal({
         <div className="relative flex min-h-0 flex-1">
           {/* Chat */}
           <div className="flex w-2/5 flex-col border-r">
-            {/* Chat toolbar — regenerate / clear (mirrors write-toolbar.tsx). */}
-            <div className="flex h-10 flex-none items-center gap-1 border-b px-2 text-xs text-muted-foreground">
-              {busy && (
-                <span className="flex items-center gap-1.5 pl-1">
-                  <Loader2Icon className="size-3.5 animate-spin" />
-                  streaming…
-                </span>
-              )}
-              <div className="flex-1" />
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8"
-                disabled={busy || chat.length === 0}
-                onClick={regenerate}
-                title="Regenerate last response"
-              >
-                <RefreshCwIcon className="mr-1 size-4" /> Regenerate
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="size-8"
-                disabled={chat.length === 0}
-                onClick={clearChat}
-                title="Clear chat"
-              >
-                <Trash2Icon className="size-4" />
-              </Button>
-            </div>
-
             <div className="flex-1 space-y-3 overflow-y-auto p-4">
               {chat.map((m, i) => (
                 <ChatBubble key={i} msg={m} isStreaming={busy} />
@@ -800,64 +846,56 @@ function WriterModal({
 
           {/* Document */}
           <div className="flex flex-1 flex-col">
-            {/* Inline context strip — the locked design. */}
+            {/* The one bar above the document: just the context chips. */}
             <InlineContextStrip
               model={ctx}
-              onOpenPanel={() => setView("context")}
+              onOpenPanel={() => onView("context")}
             />
 
-            {/* Document toolbar — mirrors document-panel.tsx. */}
-            <div className="flex h-10 flex-none items-center gap-2 border-b px-3 text-xs text-muted-foreground">
-              <div className="flex-1" />
-              {lintTotal > 0 && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-8"
-                  title={violations
-                    .map((v) => `${v.rule.name}: ${v.count}`)
-                    .join(" · ")}
-                  onClick={() => setDoc((d) => fixAll(d, banned))}
-                >
-                  <AlertTriangleIcon className="mr-1 size-4 text-orange-500" />
-                  Fix ({lintTotal})
-                </Button>
-              )}
+            {/* Edit ⇄ Preview floats over the top-right of the pane, mirroring
+                the field's own floating buttons on the host page. */}
+            <div className="relative min-h-0 flex-1 overflow-hidden">
               <Button
-                variant="ghost"
+                variant="secondary"
                 size="sm"
-                className="h-8"
+                className="absolute right-3 top-2 z-10 h-7 shadow-sm"
                 onClick={() => setIsEditing((e) => !e)}
               >
                 {isEditing ? (
                   <>
-                    <EyeIcon className="mr-1 size-4" /> Preview
+                    <EyeIcon className="mr-1 size-3.5" /> Preview
                   </>
                 ) : (
                   <>
-                    <PencilIcon className="mr-1 size-4" /> Edit
+                    <PencilIcon className="mr-1 size-3.5" /> Edit
                   </>
                 )}
               </Button>
-            </div>
-
-            <div className="min-h-0 flex-1 overflow-hidden">
+              {/* Edit and Preview share one identical scroll box (same size,
+                  same stable scrollbar gutter, same top padding) so toggling
+                  between them doesn't move or reflow anything. */}
               {isEditing ? (
-                <MarkdownMonacoEditor
-                  value={doc}
-                  onChange={setDoc}
-                  fallback={
-                    <div className="p-4 text-sm text-muted-foreground">
-                      Loading editor…
-                    </div>
-                  }
-                />
+                <div className="h-full overflow-hidden">
+                  <MarkdownMonacoEditor
+                    value={doc}
+                    onChange={setDoc}
+                    options={{
+                      padding: { top: 20, bottom: 20 },
+                      scrollBeyondLastLine: false,
+                    }}
+                    fallback={
+                      <div className="p-5 text-sm text-muted-foreground">
+                        Loading editor…
+                      </div>
+                    }
+                  />
+                </div>
               ) : (
                 <div
-                  className="scrollbar scrollbar-track-transparent scrollbar-thumb-muted hover:scrollbar-thumb-muted-foreground h-full overflow-y-auto p-6"
+                  className="scrollbar scrollbar-track-transparent scrollbar-thumb-muted hover:scrollbar-thumb-muted-foreground h-full overflow-y-auto px-6 py-5"
                   style={{ scrollbarGutter: "stable" }}
                 >
-                  <div className="mx-auto max-w-[75ch]">
+                  <div className="max-w-[75ch]">
                     <AIResponse
                       imageBasePath="prototype/the-satisfies-operator"
                       extraComponents={docComponents}
@@ -876,7 +914,12 @@ function WriterModal({
               covers render on top — so background streaming is never torn out of
               the DOM when you step into Context / Settings and back. */}
           {view === "context" && (
-            <ContextView model={ctx} onBack={() => setView("writer")} />
+            <ContextView
+              model={ctx}
+              activeKey={ctxTab}
+              onTab={onCtxTab}
+              onBack={() => onView("writer")}
+            />
           )}
           {view === "settings" && (
             <SettingsView
@@ -884,7 +927,7 @@ function WriterModal({
               onModelChange={setModel}
               banned={banned}
               onBannedChange={setBanned}
-              onBack={() => setView("writer")}
+              onBack={() => onView("writer")}
             />
           )}
 
@@ -924,9 +967,70 @@ function WriterModal({
           )}
         </div>
 
-        {/* Footer — Cancel / Apply. Apply uploads any captured screenshots to
-            Cloudinary before writing the field back. */}
-        <div className="flex h-14 flex-none items-center justify-end gap-3 border-t bg-muted/40 px-4">
+        {/* Footer — one bar for everything. Left cluster: mode + chat actions +
+            lint + writer settings. Right cluster: Cancel / Apply (Apply uploads
+            any captured screenshots to Cloudinary before writing the field
+            back). */}
+        <div className="flex h-14 flex-none items-center gap-1.5 border-t bg-muted/40 px-3">
+          <ModePicker modes={modes} mode={mode} onModeChange={setMode} />
+
+          <div className="mx-0.5 h-6 w-px bg-border" />
+
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8"
+            disabled={busy || chat.length === 0}
+            onClick={regenerate}
+            title="Regenerate last response"
+          >
+            <RefreshCwIcon className="size-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8"
+            disabled={chat.length === 0}
+            onClick={clearChat}
+            title="Clear chat"
+          >
+            <Trash2Icon className="size-4" />
+          </Button>
+
+          <div className="mx-0.5 h-6 w-px bg-border" />
+
+          {/* Lint display — the "Fix (N)" action, or a clean state. */}
+          {lintTotal > 0 ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8"
+              title={violations
+                .map((v) => `${v.rule.name}: ${v.count}`)
+                .join(" · ")}
+              onClick={() => setDoc((d) => fixAll(d, banned))}
+            >
+              <AlertTriangleIcon className="mr-1 size-4 text-orange-500" />
+              Fix ({lintTotal})
+            </Button>
+          ) : (
+            <span className="flex items-center gap-1 px-1 text-xs text-muted-foreground">
+              <CheckIcon className="size-3.5 text-emerald-600" /> No lint issues
+            </span>
+          )}
+          {/* Lint settings (model + banned phrases). */}
+          <Button
+            variant={view === "settings" ? "secondary" : "ghost"}
+            size="icon"
+            className="size-8"
+            title="Writer settings"
+            onClick={() => onView(view === "settings" ? "writer" : "settings")}
+          >
+            <SettingsIcon className="size-4" />
+          </Button>
+
+          <div className="flex-1" />
+
           <Button variant="outline" onClick={requestClose} disabled={applying}>
             Cancel
           </Button>
@@ -1143,9 +1247,7 @@ function InlineContextStrip({
         <Layers className="size-3.5" /> Context
         {/* Fixed-width token slot so the whole strip never reflows as counts
             change — the root of the layout shift when toggling chips. */}
-        <span
-          className={cn("w-10 text-right font-mono tabular-nums", tone)}
-        >
+        <span className={cn("w-10 text-right font-mono tabular-nums", tone)}>
           {fmtTok(model.totalTokens)}
         </span>
       </button>
@@ -1214,134 +1316,202 @@ function FullCover({
   );
 }
 
-/* Full-body Context view — toggle whole sources or individual parts. */
+/* Full-body Context view — a tabbed editor, one tab per source. The active tab
+   is URL-backed (`?tab=…`). Each tab shows the source's parts to toggle / edit;
+   the tab button itself carries the source's tri-state + token count so the
+   whole context payload reads at a glance across the row. */
 function ContextView({
   model,
+  activeKey,
+  onTab,
   onBack,
 }: {
   model: ContextModel;
+  activeKey: string;
+  onTab: (k: string) => void;
   onBack: () => void;
 }) {
   const tone = tokenTone(model.totalTokens);
+  const active =
+    model.sources.find((s) => s.source.key === activeKey) ?? model.sources[0]!;
+
   return (
-    <FullCover
-      onBack={onBack}
-      title={
-        <span className="flex items-center gap-2">
+    <div className="absolute inset-0 z-10 flex flex-col bg-background">
+      {/* Header */}
+      <div className="flex h-11 flex-none items-center gap-2 border-b px-3">
+        <Button variant="ghost" size="sm" className="h-8" onClick={onBack}>
+          <ArrowLeft className="mr-1 size-4" /> Back
+        </Button>
+        <div className="flex items-center gap-2 text-sm font-semibold">
           <Layers className="size-4" /> Context
-        </span>
-      }
-      right={
+        </div>
+        <div className="flex-1" />
         <span className={cn("font-mono text-sm", tone)}>
           {fmtTok(model.totalTokens)} tok
         </span>
-      }
-      footer={
-        <>
-          <code className="font-mono">tokens ≈ ⌈bytes / 4⌉</code> (UTF-8). This
-          is the <code className="font-mono">context</code> payload the host
-          injects into the agent.
-        </>
-      }
-    >
-      {model.sources.map((s) => (
-        <div key={s.source.key} className="mb-1">
-          {/* Source header — tri-state; toggles the whole source. */}
-          <label className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 hover:bg-muted">
-            <Checkbox
-              checked={s.check}
-              onCheckedChange={() =>
-                model.toggleSource(
-                  s.items.map((i) => i.id),
-                  s.check === true
-                )
-              }
-            />
-            <div className="min-w-0 flex-1">
-              <div className="text-sm leading-tight">{s.source.label}</div>
-              <div className="text-xs text-muted-foreground">
-                {s.source.note}
-              </div>
-            </div>
-            <div className="text-right font-mono text-xs text-muted-foreground">
-              {fmtTok(s.tokens)}
-            </div>
-          </label>
+      </div>
 
-          {/* Writer memory is editable, not just toggleable. */}
-          {s.source.key === "memory" && (
-            <div className="ml-6 mt-1">
-              <Textarea
-                value={model.memoryText}
-                onChange={(e) => model.setMemory(e.target.value)}
-                className="min-h-[120px] font-mono text-xs"
-              />
-            </div>
-          )}
+      {/* Tab row — one per source, with status glyph + token count. */}
+      <div className="scrollbar scrollbar-track-transparent scrollbar-thumb-muted flex flex-none items-center gap-1 overflow-x-auto border-b px-2 py-1.5">
+        {model.sources.map((s) => {
+          const on = s.source.key === active.source.key;
+          return (
+            <button
+              key={s.source.key}
+              onClick={() => onTab(s.source.key)}
+              className={cn(
+                "flex flex-none items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors",
+                on
+                  ? "bg-muted text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              <CheckGlyph state={s.check} />
+              {s.source.label}
+              <span className="font-mono tabular-nums opacity-70">
+                {fmtTok(s.tokens)}
+              </span>
+            </button>
+          );
+        })}
+      </div>
 
-          {/* Links are editable — remove each, add new ones. */}
-          {s.source.key === "links" && (
-            <div className="ml-6 mt-1 space-y-1">
-              {s.items.map((i) => (
-                <div key={i.id} className="flex items-center gap-2">
-                  <Checkbox
-                    checked={i.on}
-                    onCheckedChange={() => model.toggleItem(i.id)}
-                  />
-                  <span
-                    className={cn(
-                      "min-w-0 flex-1 truncate text-xs",
-                      !i.on && "opacity-50"
-                    )}
-                  >
-                    {i.label}
-                  </span>
-                  <span className="font-mono text-[10px] text-muted-foreground">
-                    {fmtTok(i.tokens)}
-                  </span>
-                  <button
-                    onClick={() => model.removeLink(i.id)}
-                    className="text-muted-foreground hover:text-foreground"
-                    title="Remove link"
-                  >
-                    <X className="size-3.5" />
-                  </button>
-                </div>
-              ))}
-              <AddLinkRow onAdd={model.addLink} />
-            </div>
-          )}
-
-          {/* Other multi-part sources: plain per-part toggles. */}
-          {!s.atomic &&
-            s.source.key !== "links" &&
-            s.source.key !== "memory" && (
-              <div className="ml-4 border-l pl-2">
-                {s.items.map((i) => (
-                  <label
-                    key={i.id}
-                    className={cn(
-                      "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted",
-                      !i.on && "opacity-50"
-                    )}
-                  >
-                    <Checkbox
-                      checked={i.on}
-                      onCheckedChange={() => model.toggleItem(i.id)}
-                    />
-                    <span className="min-w-0 flex-1 truncate text-xs">
-                      {i.label}
-                    </span>
-                    <span className="font-mono text-[10px] text-muted-foreground">
-                      {fmtTok(i.tokens)}
-                    </span>
-                  </label>
-                ))}
-              </div>
-            )}
+      {/* Active tab body */}
+      <div className="scrollbar scrollbar-track-transparent scrollbar-thumb-muted min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-2xl p-4">
+          <ContextTabBody model={model} view={active} />
         </div>
-      ))}
-    </FullCover>
+      </div>
+
+      {/* Footer note */}
+      <div className="flex-none border-t px-4 py-2 text-xs text-muted-foreground">
+        <code className="font-mono">tokens ≈ ⌈bytes / 4⌉</code> (UTF-8). This is
+        the <code className="font-mono">context</code> payload the host injects
+        into the agent.
+      </div>
+    </div>
+  );
+}
+
+/* The body of one Context tab — a master "include" toggle plus the source's
+   parts (editable memory, editable links, per-part toggles, or a read-only
+   preview for atomic sources). */
+function ContextTabBody({
+  model,
+  view,
+}: {
+  model: ContextModel;
+  view: SourceView;
+}) {
+  const s = view;
+  const toggleSource = () =>
+    model.toggleSource(
+      s.items.map((i) => i.id),
+      s.check === true
+    );
+
+  return (
+    <div className="space-y-3">
+      {/* Master enable row. */}
+      <label className="flex cursor-pointer items-center gap-2 rounded-md border bg-muted/40 px-3 py-2">
+        <Checkbox checked={s.check} onCheckedChange={toggleSource} />
+        <div className="min-w-0 flex-1">
+          <div className="text-sm leading-tight">
+            {s.atomic ? "Include this source" : "Include all parts"}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {s.source.note}
+            {!s.atomic && ` · ${s.onCount}/${s.items.length} on`}
+          </div>
+        </div>
+        <div className="text-right font-mono text-xs text-muted-foreground">
+          {fmtTok(s.tokens)} tok
+        </div>
+      </label>
+
+      {/* Writer memory — editable. */}
+      {s.source.key === "memory" && (
+        <Textarea
+          value={model.memoryText}
+          onChange={(e) => model.setMemory(e.target.value)}
+          className="min-h-[220px] font-mono text-xs"
+        />
+      )}
+
+      {/* Links — editable (remove each, add new ones). */}
+      {s.source.key === "links" && (
+        <div className="space-y-1">
+          {s.items.map((i) => (
+            <div
+              key={i.id}
+              className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
+            >
+              <Checkbox
+                checked={i.on}
+                onCheckedChange={() => model.toggleItem(i.id)}
+              />
+              <span
+                className={cn(
+                  "min-w-0 flex-1 truncate text-xs",
+                  !i.on && "opacity-50"
+                )}
+              >
+                {i.label}
+              </span>
+              <span className="font-mono text-[10px] text-muted-foreground">
+                {fmtTok(i.tokens)}
+              </span>
+              <button
+                onClick={() => model.removeLink(i.id)}
+                className="text-muted-foreground hover:text-foreground"
+                title="Remove link"
+              >
+                <X className="size-3.5" />
+              </button>
+            </div>
+          ))}
+          <AddLinkRow onAdd={model.addLink} />
+        </div>
+      )}
+
+      {/* Other multi-part sources: per-part toggles. */}
+      {!s.atomic && s.source.key !== "links" && s.source.key !== "memory" && (
+        <div className="space-y-0.5">
+          {s.items.map((i) => (
+            <label
+              key={i.id}
+              className={cn(
+                "flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 hover:bg-muted",
+                !i.on && "opacity-50"
+              )}
+            >
+              <Checkbox
+                checked={i.on}
+                onCheckedChange={() => model.toggleItem(i.id)}
+                className="mt-0.5"
+              />
+              <span className="min-w-0 flex-1 text-xs">{i.label}</span>
+              <span className="font-mono text-[10px] text-muted-foreground">
+                {fmtTok(i.tokens)}
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
+
+      {/* Atomic, non-editable sources (course structure, full path): show the
+          injected text so the tab isn't empty. */}
+      {s.atomic &&
+        s.source.key !== "memory" &&
+        s.items.map((i) => (
+          <pre
+            key={i.id}
+            className="max-h-[320px] overflow-auto whitespace-pre-wrap rounded-md border bg-muted/40 p-3 font-mono text-[11px] leading-relaxed text-muted-foreground"
+          >
+            {i.text}
+          </pre>
+        ))}
+    </div>
   );
 }
 
@@ -1539,7 +1709,54 @@ function BodyField({
 export default function PrototypeWriterModal() {
   const [body, setBody] = useState(INITIAL_BODY);
   const [chat, setChat] = useState<ChatMsg[]>(INITIAL_CHAT);
-  const [modalOpen, setModalOpen] = useState(false);
+
+  // Modal open state + active full-body view + active context tab all live in
+  // the URL search params, so the writer is deep-linkable and Back steps out.
+  const [sp, setSp] = useSearchParams();
+  const open = sp.get("writer") === "1";
+  const view = ((sp.get("view") as WriterView) || "writer") as WriterView;
+  const ctxTab = sp.get("tab") || CONTEXT_SOURCES[0]!.key;
+
+  const patch = useCallback(
+    (mut: (p: URLSearchParams) => void) =>
+      setSp(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          mut(next);
+          return next;
+        },
+        { replace: true }
+      ),
+    [setSp]
+  );
+  const openWriter = () =>
+    patch((p) => {
+      p.set("writer", "1");
+      p.delete("view");
+      p.delete("tab");
+    });
+  const closeWriter = () =>
+    patch((p) => {
+      p.delete("writer");
+      p.delete("view");
+      p.delete("tab");
+    });
+  const setView = (v: WriterView) =>
+    patch((p) => {
+      p.set("writer", "1");
+      if (v === "writer") {
+        p.delete("view");
+        p.delete("tab");
+      } else {
+        p.set("view", v);
+      }
+    });
+  const setCtxTab = (k: string) =>
+    patch((p) => {
+      p.set("writer", "1");
+      p.set("view", "context");
+      p.set("tab", k);
+    });
 
   return (
     <div className="h-screen overflow-y-auto bg-background">
@@ -1597,11 +1814,7 @@ export default function PrototypeWriterModal() {
             Preview / Open-in-writer buttons top-right. */}
         <div className="space-y-2">
           <Label>Body (Markdown)</Label>
-          <BodyField
-            value={body}
-            onChange={setBody}
-            onOpen={() => setModalOpen(true)}
-          />
+          <BodyField value={body} onChange={setBody} onOpen={openWriter} />
           <p className="text-xs text-muted-foreground">
             This becomes <code className="font-mono">video.body</code> and
             exports into <code className="font-mono">course.json</code>. Its
@@ -1619,14 +1832,19 @@ export default function PrototypeWriterModal() {
       </div>
 
       <WriterModal
-        open={modalOpen}
-        onClose={() => setModalOpen(false)}
+        open={open}
+        onClose={closeWriter}
         initialDoc={body}
         initialChat={chat}
+        modes={BODY_FIELD_MODES}
+        view={view}
+        onView={setView}
+        ctxTab={ctxTab}
+        onCtxTab={setCtxTab}
         onApply={(doc, nextChat) => {
           setBody(doc);
           setChat(nextChat);
-          setModalOpen(false);
+          closeWriter();
         }}
       />
     </div>

--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -53,13 +53,14 @@ import { MarkdownMonacoEditor } from "@/components/markdown-monaco-editor";
 import { cn } from "@/lib/utils";
 import {
   AlertTriangleIcon,
+  ArrowLeft,
   CheckIcon,
   EyeIcon,
-  FileText,
   Layers,
   MinusIcon,
   PencilIcon,
   SendIcon,
+  SettingsIcon,
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -263,18 +264,17 @@ type LintRule = {
   fix: (doc: string) => string;
 };
 
-const LINT_RULES: LintRule[] = [
+/** Default banned phrases — editable in the Settings view (feeds the rule). */
+const DEFAULT_BANNED = ["simply", "just", "dive in", "unlock"];
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/** Rules that don't depend on user settings. */
+const STATIC_RULES: LintRule[] = [
   {
     id: "no-em-dash",
     name: "Em dashes",
     count: (d) => (d.match(/—/g) ?? []).length,
     fix: (d) => d.replace(/\s*—\s*/g, ", "),
-  },
-  {
-    id: "no-llm-phrase",
-    name: "LLM phrases",
-    count: (d) => (d.match(/\b(simply|just|dive in|unlock)\b/gi) ?? []).length,
-    fix: (d) => d.replace(/\b(simply|just|dive in|unlock)\s*/gi, ""),
   },
   {
     id: "no-leading-heading",
@@ -284,16 +284,33 @@ const LINT_RULES: LintRule[] = [
   },
 ];
 
-function lint(doc: string) {
-  const violations = LINT_RULES.map((r) => ({
-    rule: r,
-    count: r.count(doc),
-  })).filter((v) => v.count > 0);
+/** The banned-phrase rule is built from the Settings list, so the two connect. */
+function bannedRule(banned: string[]): LintRule | null {
+  const words = banned.map((s) => s.trim()).filter(Boolean);
+  if (words.length === 0) return null;
+  const body = words.map(escapeRe).join("|");
+  return {
+    id: "no-llm-phrase",
+    name: "Banned phrases",
+    count: (d) => (d.match(new RegExp(`\\b(${body})\\b`, "gi")) ?? []).length,
+    fix: (d) => d.replace(new RegExp(`\\b(${body})\\b\\s*`, "gi"), ""),
+  };
+}
+
+function rulesFor(banned: string[]): LintRule[] {
+  const b = bannedRule(banned);
+  return b ? [...STATIC_RULES, b] : STATIC_RULES;
+}
+
+function lint(doc: string, banned: string[]) {
+  const violations = rulesFor(banned)
+    .map((r) => ({ rule: r, count: r.count(doc) }))
+    .filter((v) => v.count > 0);
   const total = violations.reduce((a, v) => a + v.count, 0);
   return { violations, total };
 }
-function fixAll(doc: string) {
-  return LINT_RULES.reduce((d, r) => r.fix(d), doc);
+function fixAll(doc: string, banned: string[]) {
+  return rulesFor(banned).reduce((d, r) => r.fix(d), doc);
 }
 
 /* ================================================================== */
@@ -388,7 +405,11 @@ function WriterModal({
   const [chat, setChat] = useState<ChatMsg[]>(initialChat);
   const [draft, setDraft] = useState("");
   const [mode, setMode] = useState(MODES[0]);
-  const [panelOpen, setPanelOpen] = useState(false);
+  const [model, setModel] = useState("auto");
+  const [banned, setBanned] = useState<string[]>(DEFAULT_BANNED);
+  // The whole modal body swaps between these; the writer view is never
+  // unmounted (so any background streaming survives the swap).
+  const [view, setView] = useState<"writer" | "context" | "settings">("writer");
   const [isEditing, setIsEditing] = useState(true);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
   const ctx = useContextModel();
@@ -400,7 +421,7 @@ function WriterModal({
       setDoc(initialDoc);
       setChat(initialChat);
       setConfirmDiscard(false);
-      setPanelOpen(false);
+      setView("writer");
     }
   }, [open, initialDoc, initialChat]);
 
@@ -427,7 +448,7 @@ function WriterModal({
     setDraft("");
   }, [draft]);
 
-  const { violations, total: lintTotal } = lint(doc);
+  const { violations, total: lintTotal } = lint(doc, banned);
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && requestClose()}>
@@ -464,6 +485,16 @@ function WriterModal({
 
           <div className="flex-1" />
 
+          <Button
+            variant={view === "settings" ? "secondary" : "ghost"}
+            size="icon"
+            title="Settings"
+            onClick={() =>
+              setView((v) => (v === "settings" ? "writer" : "settings"))
+            }
+          >
+            <SettingsIcon className="size-4" />
+          </Button>
           <Button variant="ghost" size="icon" onClick={requestClose}>
             <X className="size-4" />
           </Button>
@@ -500,19 +531,11 @@ function WriterModal({
             {/* Inline context strip — the locked design. */}
             <InlineContextStrip
               model={ctx}
-              onOpenPanel={() => setPanelOpen(true)}
+              onOpenPanel={() => setView("context")}
             />
 
             {/* Document toolbar — mirrors document-panel.tsx. */}
             <div className="flex h-10 flex-none items-center gap-2 border-b px-3 text-xs text-muted-foreground">
-              <span
-                className={cn(
-                  "size-1.5 rounded-full",
-                  dirty ? "bg-amber-500" : "bg-emerald-500"
-                )}
-              />
-              <FileText className="size-3.5" />
-              document · working copy{dirty ? " (unsaved)" : ""}
               <div className="flex-1" />
               {lintTotal > 0 && (
                 <Button
@@ -522,7 +545,7 @@ function WriterModal({
                   title={violations
                     .map((v) => `${v.rule.name}: ${v.count}`)
                     .join(" · ")}
-                  onClick={() => setDoc((d) => fixAll(d))}
+                  onClick={() => setDoc((d) => fixAll(d, banned))}
                 >
                   <AlertTriangleIcon className="mr-1 size-4 text-orange-500" />
                   Fix ({lintTotal})
@@ -569,12 +592,22 @@ function WriterModal({
             </div>
           </div>
 
-          {/* Full-options context panel — toggle individual parts. */}
-          <ContextPanel
-            open={panelOpen}
-            model={ctx}
-            onClose={() => setPanelOpen(false)}
-          />
+          {/* "Extra stuff" replaces the whole modal body rather than floating
+              over it. The writer (chat + document) above stays mounted — these
+              covers render on top — so background streaming is never torn out of
+              the DOM when you step into Context / Settings and back. */}
+          {view === "context" && (
+            <ContextView model={ctx} onBack={() => setView("writer")} />
+          )}
+          {view === "settings" && (
+            <SettingsView
+              model={model}
+              onModelChange={setModel}
+              banned={banned}
+              onBannedChange={setBanned}
+              onBack={() => setView("writer")}
+            />
+          )}
 
           {/* Unsaved-changes confirm — in-modal overlay (no AlertDialog in
               this codebase, and nested Radix dialogs fight over focus). */}
@@ -711,93 +744,215 @@ function InlineContextStrip({
   );
 }
 
-/* Full-options panel — an in-modal sliding panel over the document, so it
-   sits alongside the chat instead of dimming the whole modal. */
-function ContextPanel({
-  open,
-  model,
-  onClose,
+/* A full-body cover with a Back header. Rendered on top of the still-mounted
+   writer so stepping into Context / Settings never unmounts it. */
+function FullCover({
+  title,
+  right,
+  onBack,
+  children,
+  footer,
 }: {
-  open: boolean;
+  title: React.ReactNode;
+  right?: React.ReactNode;
+  onBack: () => void;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}) {
+  return (
+    <div className="absolute inset-0 z-10 flex flex-col bg-background">
+      <div className="flex h-11 flex-none items-center gap-2 border-b px-3">
+        <Button variant="ghost" size="sm" className="h-8" onClick={onBack}>
+          <ArrowLeft className="mr-1 size-4" /> Back
+        </Button>
+        <div className="text-sm font-semibold">{title}</div>
+        <div className="flex-1" />
+        {right}
+      </div>
+      <div className="scrollbar scrollbar-track-transparent scrollbar-thumb-muted min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-2xl p-4">{children}</div>
+      </div>
+      {footer && (
+        <div className="flex-none border-t px-4 py-2 text-xs text-muted-foreground">
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* Full-body Context view — toggle whole sources or individual parts. */
+function ContextView({
+  model,
+  onBack,
+}: {
   model: ContextModel;
-  onClose: () => void;
+  onBack: () => void;
 }) {
   const tone = tokenTone(model.totalTokens);
   return (
-    <aside
-      className={cn(
-        "absolute inset-y-0 right-0 z-10 flex w-[420px] flex-col border-l bg-background shadow-xl transition-transform duration-200",
-        open ? "translate-x-0" : "pointer-events-none translate-x-full"
-      )}
-    >
-      <div className="flex flex-none items-center gap-2 border-b px-4 py-3">
-        <Layers className="size-4" />
-        <div className="text-sm font-semibold">Context</div>
-        <span className={cn("ml-1 font-mono text-sm", tone)}>
+    <FullCover
+      onBack={onBack}
+      title={
+        <span className="flex items-center gap-2">
+          <Layers className="size-4" /> Context
+        </span>
+      }
+      right={
+        <span className={cn("font-mono text-sm", tone)}>
           {fmtTok(model.totalTokens)} tok
         </span>
-        <div className="flex-1" />
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-7"
-          onClick={onClose}
-        >
-          <X className="size-4" />
-        </Button>
-      </div>
-      <div className="min-h-0 flex-1 overflow-y-auto p-2">
-        {model.sources.map((s) => (
-          <div key={s.source.key} className="mb-1">
-            {/* Source header — tri-state; toggles the whole source. */}
-            <label className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 hover:bg-muted">
-              <Checkbox
-                checked={s.check}
-                onCheckedChange={() => model.toggleSource(s.source)}
-              />
-              <div className="min-w-0 flex-1">
-                <div className="text-sm leading-tight">{s.source.label}</div>
-                <div className="text-xs text-muted-foreground">
-                  {s.source.note}
-                </div>
+      }
+      footer={
+        <>
+          <code className="font-mono">tokens ≈ ⌈bytes / 4⌉</code> (UTF-8). This
+          is the <code className="font-mono">context</code> payload the host
+          injects into the agent.
+        </>
+      }
+    >
+      {model.sources.map((s) => (
+        <div key={s.source.key} className="mb-1">
+          {/* Source header — tri-state; toggles the whole source. */}
+          <label className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 hover:bg-muted">
+            <Checkbox
+              checked={s.check}
+              onCheckedChange={() => model.toggleSource(s.source)}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="text-sm leading-tight">{s.source.label}</div>
+              <div className="text-xs text-muted-foreground">
+                {s.source.note}
               </div>
-              <div className="text-right font-mono text-xs text-muted-foreground">
-                {fmtTok(s.tokens)}
-              </div>
-            </label>
-            {/* Parts — only worth showing when the source has more than one. */}
-            {!s.atomic && (
-              <div className="ml-4 border-l pl-2">
-                {s.items.map((i) => (
-                  <label
-                    key={i.id}
-                    className={cn(
-                      "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted",
-                      !i.on && "opacity-50"
-                    )}
-                  >
-                    <Checkbox
-                      checked={i.on}
-                      onCheckedChange={() => model.toggleItem(i.id)}
-                    />
-                    <span className="min-w-0 flex-1 truncate text-xs">
-                      {i.label}
-                    </span>
-                    <span className="font-mono text-[10px] text-muted-foreground">
-                      {fmtTok(i.tokens)}
-                    </span>
-                  </label>
-                ))}
-              </div>
+            </div>
+            <div className="text-right font-mono text-xs text-muted-foreground">
+              {fmtTok(s.tokens)}
+            </div>
+          </label>
+          {/* Parts — only worth showing when the source has more than one. */}
+          {!s.atomic && (
+            <div className="ml-4 border-l pl-2">
+              {s.items.map((i) => (
+                <label
+                  key={i.id}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted",
+                    !i.on && "opacity-50"
+                  )}
+                >
+                  <Checkbox
+                    checked={i.on}
+                    onCheckedChange={() => model.toggleItem(i.id)}
+                  />
+                  <span className="min-w-0 flex-1 truncate text-xs">
+                    {i.label}
+                  </span>
+                  <span className="font-mono text-[10px] text-muted-foreground">
+                    {fmtTok(i.tokens)}
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </FullCover>
+  );
+}
+
+/* Full-body Settings view — model + banned phrases (which feed the linter). */
+function SettingsView({
+  model,
+  onModelChange,
+  banned,
+  onBannedChange,
+  onBack,
+}: {
+  model: string;
+  onModelChange: (m: string) => void;
+  banned: string[];
+  onBannedChange: (b: string[]) => void;
+  onBack: () => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const addPhrase = () => {
+    const p = draft.trim();
+    if (p && !banned.includes(p)) onBannedChange([...banned, p]);
+    setDraft("");
+  };
+  return (
+    <FullCover
+      onBack={onBack}
+      title={
+        <span className="flex items-center gap-2">
+          <SettingsIcon className="size-4" /> Settings
+        </span>
+      }
+    >
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <Label>Model</Label>
+          <Select value={model} onValueChange={onModelChange}>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="auto">
+                Auto — Haiku to generate, Sonnet to edit
+              </SelectItem>
+              <SelectItem value="claude-haiku-4-5">
+                Haiku 4.5 — fast and cost-effective
+              </SelectItem>
+              <SelectItem value="claude-sonnet-4-5">
+                Sonnet 4.5 — more capable and thorough
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label>Banned phrases</Label>
+          <p className="text-xs text-muted-foreground">
+            The linter flags these in the document. Editing them changes the{" "}
+            <b>Fix</b> count live.
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {banned.map((p) => (
+              <span
+                key={p}
+                className="flex items-center gap-1 rounded-full border bg-muted px-2 py-0.5 text-xs"
+              >
+                {p}
+                <button
+                  onClick={() => onBannedChange(banned.filter((x) => x !== p))}
+                  className="text-muted-foreground hover:text-foreground"
+                  title={`Remove "${p}"`}
+                >
+                  <X className="size-3" />
+                </button>
+              </span>
+            ))}
+            {banned.length === 0 && (
+              <span className="text-xs text-muted-foreground">
+                No banned phrases.
+              </span>
             )}
           </div>
-        ))}
+          <div className="flex gap-2 pt-1">
+            <Input
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && addPhrase()}
+              placeholder="Add a phrase…"
+              className="h-8"
+            />
+            <Button size="sm" className="h-8" onClick={addPhrase}>
+              Add
+            </Button>
+          </div>
+        </div>
       </div>
-      <div className="flex-none border-t px-4 py-2 text-xs text-muted-foreground">
-        <code className="font-mono">tokens ≈ ⌈bytes / 4⌉</code> (UTF-8). This is
-        the <code className="font-mono">context</code> payload the host injects.
-      </div>
-    </aside>
+    </FullCover>
   );
 }
 

--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -1297,8 +1297,14 @@ function FullCover({
   return (
     <div className="absolute inset-0 z-10 flex flex-col bg-background">
       <div className="flex h-11 flex-none items-center gap-2 border-b px-3">
-        <Button variant="ghost" size="sm" className="h-8" onClick={onBack}>
-          <ArrowLeft className="mr-1 size-4" /> Back
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          title="Back"
+          onClick={onBack}
+        >
+          <ArrowLeft className="size-4" />
         </Button>
         <div className="text-sm font-semibold">{title}</div>
         <div className="flex-1" />
@@ -1339,8 +1345,14 @@ function ContextView({
     <div className="absolute inset-0 z-10 flex flex-col bg-background">
       {/* Header */}
       <div className="flex h-11 flex-none items-center gap-2 border-b px-3">
-        <Button variant="ghost" size="sm" className="h-8" onClick={onBack}>
-          <ArrowLeft className="mr-1 size-4" /> Back
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          title="Back"
+          onClick={onBack}
+        >
+          <ArrowLeft className="size-4" />
         </Button>
         <div className="flex items-center gap-2 text-sm font-semibold">
           <Layers className="size-4" /> Context

--- a/app/routes/prototype.writer-modal.tsx
+++ b/app/routes/prototype.writer-modal.tsx
@@ -60,6 +60,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { MarkdownMonacoEditor } from "@/components/markdown-monaco-editor";
+import { FileTree } from "@/components/FileTree";
 // The screenshot picker is a *document* citizen, not a chat message: the agent
 // writes a `<ChooseScreenshot clipIndex={n} alt="…" />` tag into the doc body,
 // and it renders inline in the document Preview. Reuse the real preprocessor +
@@ -110,13 +111,6 @@ const estimateTokens = (s: string) => Math.ceil(byteLength(s) / 4);
 const fmtTok = (n: number) =>
   n < 1000 ? String(n) : `${(n / 1000).toFixed(1)}K`;
 
-/** Illustrative budget bands so the total has a felt sense of "a lot". */
-function tokenTone(total: number): string {
-  if (total > 12000) return "text-destructive";
-  if (total > 6000) return "text-amber-600";
-  return "text-emerald-600";
-}
-
 /* ================================================================== */
 /* Fixtures — the injected `context` payload, modelled as sources made  */
 /* of individually-toggleable parts (so a source can be partially on).  */
@@ -159,15 +153,16 @@ const CONTEXT_SOURCES: ContextSource[] = [
     key: "files",
     label: "Repo files",
     note: "readme + exercise/solution sources",
+    // ids ARE the file paths so they feed straight into <FileTree>.
     items: [
-      ["explainer/readme.md", 8],
-      ["exercise.ts", 5],
-      ["exercise.solution.ts", 6],
-      ["explainer.ts", 4],
-    ].map(([label, w], i) => ({
-      id: `files:${i}`,
-      label: label as string,
-      text: `// ${label}\n${'const config = {\n  routes: { home: "/", about: "/about" },\n  theme: "dark",\n} satisfies Config;\n'.repeat(
+      ["the-satisfies-operator/explainer/readme.md", 8],
+      ["the-satisfies-operator/explainer/explainer.ts", 4],
+      ["the-satisfies-operator/problem/exercise.ts", 5],
+      ["the-satisfies-operator/solution/exercise.solution.ts", 6],
+    ].map(([path, w]) => ({
+      id: path as string,
+      label: path as string,
+      text: `// ${path}\n${'const config = {\n  routes: { home: "/", about: "/about" },\n  theme: "dark",\n} satisfies Config;\n'.repeat(
         w as number
       )}`,
     })),
@@ -198,7 +193,7 @@ const CONTEXT_SOURCES: ContextSource[] = [
   },
   {
     key: "memory",
-    label: "Writer memory",
+    label: "Course memory",
     note: "standing style preferences",
     items: [
       {
@@ -427,6 +422,19 @@ function useContextModel() {
     });
   }, []);
 
+  // Reconcile a source's enablement against an exact target set (what <FileTree>
+  // hands back via onEnabledFilesChange).
+  const setSourceEnabled = useCallback(
+    (ids: string[], nextOn: Set<string>) => {
+      setEnabled((prev) => {
+        const next = new Set(prev);
+        ids.forEach((id) => (nextOn.has(id) ? next.add(id) : next.delete(id)));
+        return next;
+      });
+    },
+    []
+  );
+
   const addLink = useCallback((url: string) => {
     const u = url.trim();
     if (!u) return;
@@ -488,6 +496,7 @@ function useContextModel() {
     sources,
     toggleItem,
     toggleSource,
+    setSourceEnabled,
     totalTokens,
     memoryText,
     setMemory: setMemoryText,
@@ -945,7 +954,9 @@ function WriterModal({
         {/* Footer — one bar for everything. Left cluster: mode + chat actions +
             lint + writer settings. Right cluster: Cancel / Apply (Apply uploads
             any captured screenshots to Cloudinary before writing the field
-            back). */}
+            back). Hidden entirely on the Context / Settings pages — they are
+            self-contained, with their own Back. */}
+        {view === "writer" && (
         <div className="flex h-14 flex-none items-center gap-1.5 border-t bg-muted/40 px-3">
           <ModePicker modes={modes} mode={mode} onModeChange={setMode} />
 
@@ -1020,6 +1031,7 @@ function WriterModal({
             )}
           </Button>
         </div>
+        )}
       </DialogContent>
     </Dialog>
   );
@@ -1211,7 +1223,6 @@ function InlineContextStrip({
   model: ContextModel;
   onOpenPanel: () => void;
 }) {
-  const tone = tokenTone(model.totalTokens);
   return (
     <div className="flex flex-none flex-wrap items-center gap-1.5 border-b bg-muted/30 px-3 py-2">
       <button
@@ -1222,7 +1233,7 @@ function InlineContextStrip({
         <Layers className="size-3.5" /> Context
         {/* Fixed-width token slot so the whole strip never reflows as counts
             change — the root of the layout shift when toggling chips. */}
-        <span className={cn("w-10 text-right font-mono tabular-nums", tone)}>
+        <span className="w-10 text-right font-mono tabular-nums text-muted-foreground">
           {fmtTok(model.totalTokens)}
         </span>
       </button>
@@ -1312,7 +1323,6 @@ function ContextView({
   onTab: (k: string) => void;
   onBack: () => void;
 }) {
-  const tone = tokenTone(model.totalTokens);
   const active =
     model.sources.find((s) => s.source.key === activeKey) ?? model.sources[0]!;
 
@@ -1331,11 +1341,11 @@ function ContextView({
         </Button>
         <div className="flex items-center gap-2 text-sm font-semibold">
           <Layers className="size-4" /> Context
+          <span className="font-mono text-xs font-normal text-muted-foreground">
+            {fmtTok(model.totalTokens)} tokens
+          </span>
         </div>
         <div className="flex-1" />
-        <span className={cn("font-mono text-sm", tone)}>
-          {fmtTok(model.totalTokens)} tokens
-        </span>
       </div>
 
       {/* Tab row — one per source, with status glyph + token count. */}
@@ -1367,13 +1377,6 @@ function ContextView({
         <div className="mx-auto max-w-2xl p-4">
           <ContextTabBody model={model} view={active} />
         </div>
-      </div>
-
-      {/* Footer note */}
-      <div className="flex-none border-t px-4 py-2 text-xs text-muted-foreground">
-        <code className="font-mono">tokens ≈ ⌈bytes / 4⌉</code> (UTF-8). This is
-        the <code className="font-mono">context</code> payload the host injects
-        into the agent.
       </div>
     </div>
   );
@@ -1460,30 +1463,52 @@ function ContextTabBody({
         </div>
       )}
 
-      {/* Other multi-part sources: per-part toggles. */}
-      {!s.atomic && s.source.key !== "links" && s.source.key !== "memory" && (
-        <div className="space-y-0.5">
-          {s.items.map((i) => (
-            <label
-              key={i.id}
-              className={cn(
-                "flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 hover:bg-muted",
-                !i.on && "opacity-50"
-              )}
-            >
-              <Checkbox
-                checked={i.on}
-                onCheckedChange={() => model.toggleItem(i.id)}
-                className="mt-0.5"
-              />
-              <span className="min-w-0 flex-1 text-xs">{i.label}</span>
-              <span className="font-mono text-[10px] text-muted-foreground">
-                {fmtTok(i.tokens)}
-              </span>
-            </label>
-          ))}
-        </div>
+      {/* Repo files use the real <FileTree> picker (collapsible dirs, tri-state
+          folders) rather than a flat list. */}
+      {s.source.key === "files" && (
+        <FileTree
+          files={s.items.map((i) => ({
+            path: i.id,
+            size: byteLength(i.text),
+            defaultEnabled: true,
+          }))}
+          enabledFiles={new Set(s.items.filter((i) => i.on).map((i) => i.id))}
+          onEnabledFilesChange={(next) =>
+            model.setSourceEnabled(
+              s.items.map((i) => i.id),
+              next
+            )
+          }
+        />
       )}
+
+      {/* Other multi-part sources (transcript chapters): per-part toggles. */}
+      {!s.atomic &&
+        s.source.key !== "links" &&
+        s.source.key !== "memory" &&
+        s.source.key !== "files" && (
+          <div className="space-y-0.5">
+            {s.items.map((i) => (
+              <label
+                key={i.id}
+                className={cn(
+                  "flex cursor-pointer items-start gap-2 rounded-md px-2 py-1.5 hover:bg-muted",
+                  !i.on && "opacity-50"
+                )}
+              >
+                <Checkbox
+                  checked={i.on}
+                  onCheckedChange={() => model.toggleItem(i.id)}
+                  className="mt-0.5"
+                />
+                <span className="min-w-0 flex-1 text-xs">{i.label}</span>
+                <span className="font-mono text-[10px] text-muted-foreground">
+                  {fmtTok(i.tokens)}
+                </span>
+              </label>
+            ))}
+          </div>
+        )}
 
       {/* Atomic, non-editable sources (course structure, full path): show the
           injected text so the tab isn't empty. */}


### PR DESCRIPTION
Runnable prototype for **#1113 (writer-engine-extract)** — the field-bound writer modal, built in-repo following CVM's prototype conventions (`app/routes/prototype.writer-modal.tsx`, throwaway, not wired to live backends).

**Run:** `pnpm dev` → open `/prototype/writer-modal` → click the **Body** field.

### Design (locked)
The token-counter treatment is the **inline context strip** (Matt's pick). Sources are checkbox chips docked above the document:

- chips toggle their source on/off; multi-part sources (transcript segments, chapters, files, links) show an **indeterminate** state
- the **Context** button opens a full-options panel to toggle individual parts
- token counts read as `4.1K` (`tokens ≈ ⌈bytes / 4⌉`, UTF-8, per source + total)
- document pane mirrors `document-panel.tsx`: **Edit ⇄ Preview** + a lint **Fix (N)** button
- **Cancel reverts the conversation history** to its pre-open state; closing with unsaved changes confirms first
- footer is just **Cancel / Apply**

Once the shape is signed off, it folds into the real modal host in **#1114 (writable-field-component)** and this file gets deleted.

> Note: the repo's pre-commit typecheck currently fails on a pre-existing, unrelated error in `write-page.tsx` (node_modules version skew) — the prototype file itself is type-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)