### PR TITLE
docs(context): Pause Length → Silence Length, add clip Pause term (#1138)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,7 +124,7 @@ _Avoid_: Clip text (only covers Clips), Joined clips, Caption (reserved for the 
 
 **Segment**:
 A single film-time planning unit of a **Video**, classified by its **job** — what it does for the viewer. A Video's plan is an ordered sequence of Segments, authored _before_ the video is recorded; planning a video means choosing "one of these, then one of these". A first-class entity that belongs to a **Video** (not the **Lesson** or **Pitch**), so each Video carries its own plan and duplicating a Video copies its Segments. A Segment can be **moved between Videos** by dragging it from one video's plan into another's (reassigning its parent), but Videos themselves are not reordered — they sort alphabetically by name. Deliberately **distinct from a Chapter**: a Chapter is a recorded-timeline grouping that maps 1:1 to YouTube and groups **Clips**; a Segment is the _intended_ structure and need not correspond to any Chapter or Clip. The two are separate views — "what I planned to shoot" vs "what I shot". Five kinds, drawn from the Mise en Place glossary: **Definition**, **Walkthrough**, **Playthrough**, **Quest**, **Reaction**.
-_Avoid_: Chapter (the recorded YouTube grouping), Beat (the app's `beatType` means pause length; also a narrative-unit synonym rejected upstream), Section (course Section), Block, Unit
+_Avoid_: Chapter (the recorded YouTube grouping), Beat (a narrative-unit synonym; the clip field formerly `beatType` is now **Pause**), Section (course Section), Block, Unit
 
 **Segment Description**:
 A free-text planning note on a **Segment** — "what I'm actually going to do or say here" — distinct from its short **title**. Plain text, edited inline (auto-growing textarea). A purely in-app authoring aid: like the Segment itself, it is never published (Publish skips it). Surfaced and editable on the **Section Workbench** and on the editor's **Segments tab** (the current video's plan, read while recording); deliberately **hidden on the course view**, which is already information-dense.
@@ -168,9 +168,13 @@ _Avoid_: Clear, Delete from file system, Unexport
 A time-bounded window during which clips are captured via OBS, grouping optimistic clips before persistence.
 _Avoid_: Session, Take session
 
-**Pause Length**:
+**Silence Length**:
 A per-Recording-Session setting (`short` or `long`) that controls how long a silence must last before it ends a clip. `short` (default) cuts on brief mid-sentence pauses; `long` only cuts on extended pauses. Locked at the start of recording and applied symmetrically to both the frontend speech detector and the backend FFmpeg silence detection.
-_Avoid_: Silence mode, Silence sensitivity, Pause threshold
+_Avoid_: Pause Length (former name — reused "Pause", now the clip-level held pause), Silence mode, Silence sensitivity, Pause threshold
+
+**Pause**:
+A clip-level marker (`none`/`long`) that inserts a short held pause after a **Clip** in the edit — `long` holds ~0.18s, `none` is an ordinary clip. Toggled per clip, shown as an ellipsis ("…"). An enum, not a boolean, so it can gain more lengths later. Distinct from **Silence Length** (the recording cut threshold).
+_Avoid_: Beat (former `beatType`), Silence Length, Gap, Hold
 
 **Insertion Point**:
 The position in a video timeline where new clips or chapters will be added (start, after-clip, after-chapter, end).


### PR DESCRIPTION
Resolves the vocabulary-decision ticket **#1138** (Name the Pause vocabulary).

## What changed
Glossary only (`CONTEXT.md`). The decision: the clean way to give the clip-level held-pause field the name **Pause** is to rename the session-level setting at the *root* — **"Pause Length" → Silence Length** — since that setting is really a *silence → cut threshold*, not a held pause. That frees the word "Pause".

- **Pause Length** entry → **Silence Length** (values `short`/`long` unchanged).
- New **Pause** entry (clip-level held pause, formerly `beatType`; `none`/`long`), placed beside Silence Length, each marked distinct from the other.
- Stale ``beatType`` reference scrubbed from the **Segment** `_Avoid_` note.

No code changes — the code renames land in follow-up execution tickets:
- **#1144** — Execute session Pause Length → Silence Length rename (root; code-only, no migration).
- **#1141** — Execute clip Beat → Pause rename (blocked by #1144).

Full locked name/value map is in the [#1138 resolution comment](https://github.com/mattpocock/course-video-manager/issues/1138#issuecomment-4892752801). Map: **#1137**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
