### PR TITLE
feat(cvm): video update patches body + SEO description

### DIFF
--- a/app/cli/cli-lesson-video-writes.test.ts
+++ b/app/cli/cli-lesson-video-writes.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import {
   createTestDb,
@@ -197,6 +200,8 @@ describe("video create / move / update", () => {
     lessonId: string | null;
     pitchId: string | null;
     archived: boolean;
+    body: string | null;
+    description: string | null;
   }
   const vobj = (stdout: string): Video => one<Video>(stdout);
 
@@ -440,6 +445,128 @@ describe("video create / move / update", () => {
       "video",
       "update",
       "--name",
+      "x",
+      "vid_missing",
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "video"
+    );
+  });
+
+  it("update --description sets the SEO description, echoing the row", async () => {
+    const updated = vobj(
+      (
+        await run([
+          "video",
+          "update",
+          "--description",
+          "Learn to refactor a reducer",
+          s.standaloneActiveId,
+        ])
+      ).stdout
+    );
+    expect(updated.id).toBe(s.standaloneActiveId);
+    expect(updated.description).toBe("Learn to refactor a reducer");
+    // Leaves the name/path untouched.
+    expect(updated.path).toBe("standalone-active.mp4");
+  });
+
+  it("update --body sets the markdown body from inline text", async () => {
+    const updated = vobj(
+      (
+        await run([
+          "video",
+          "update",
+          "--body",
+          "# Intro\n\nWelcome",
+          s.standaloneActiveId,
+        ])
+      ).stdout
+    );
+    expect(updated.body).toBe("# Intro\n\nWelcome");
+  });
+
+  it("update patches name, body and description together", async () => {
+    const updated = vobj(
+      (
+        await run([
+          "video",
+          "update",
+          "--name",
+          "renamed.mp4",
+          "--body",
+          "body text",
+          "--description",
+          "seo text",
+          s.standaloneActiveId,
+        ])
+      ).stdout
+    );
+    expect(updated.path).toBe("renamed.mp4");
+    expect(updated.body).toBe("body text");
+    expect(updated.description).toBe("seo text");
+  });
+
+  it("update with no fields => invalid input, exit 3", async () => {
+    const { exitCode, stdout } = await run([
+      "video",
+      "update",
+      s.standaloneActiveId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("update with both --body and --body-file => invalid input, exit 3", async () => {
+    const { exitCode, stdout } = await run([
+      "video",
+      "update",
+      "--body",
+      "x",
+      "--body-file",
+      "/tmp/does-not-matter.md",
+      s.standaloneActiveId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("update --body-file reads the markdown body from a file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cvm-body-"));
+    const file = join(dir, "notes.md");
+    writeFileSync(file, "# From file\n\nContents", "utf8");
+    const updated = vobj(
+      (
+        await run([
+          "video",
+          "update",
+          "--body-file",
+          file,
+          s.standaloneActiveId,
+        ])
+      ).stdout
+    );
+    expect(updated.body).toBe("# From file\n\nContents");
+  });
+
+  it("update --body-file with an unreadable path => invalid input, exit 3", async () => {
+    const { exitCode, stdout } = await run([
+      "video",
+      "update",
+      "--body-file",
+      "/no/such/file/anywhere.md",
+      s.standaloneActiveId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("update --description on an unknown video => NotFoundError(video), exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "video",
+      "update",
+      "--description",
       "x",
       "vid_missing",
     ]);

--- a/app/cli/commands/video.help.ts
+++ b/app/cli/commands/video.help.ts
@@ -1,0 +1,197 @@
+/**
+ * Long-form --help text for the `cvm video` verbs, split out of video.ts to
+ * keep that command module under the repo's per-file token budget (mirrors
+ * segment.help.ts). Domain-teaching prose consumed only by
+ * Command.withDescription — keep in sync with CONTEXT.md.
+ */
+
+export const VIDEO_HELP = `Video — a container of Clips and Chapters that represents a single producible video output.
+
+A Video holds two ordered, interleaved children:
+  - Clips:    timestamped slices of source footage (start/end time + a source
+              filename), each carrying transcribed 'text'. Clips are the words.
+  - Chapters: named markers/dividers that visually group Clips and map 1:1 to
+              YouTube chapters. Chapters are the headings.
+Together, projected in timeline order, Clips + Chapters form the Video's
+TRANSCRIPT (see 'video transcript').
+
+A Standalone Video has no lesson association (lessonId = NULL) and is used for
+reference or temporary content; it may be packaged by a Pitch. A lesson-bound
+Video belongs to a Lesson inside a Section of a Course Version.
+
+This command exposes ONLY Standalone Videos for 'list' (the complete set, not
+the UI's recent-5). 'get', 'tree' and 'transcript' accept ANY video id
+(standalone or lesson-bound).
+
+Archived Videos are soft-deleted (hidden from active views). Only Standalone
+Videos have a real viewable archive — pass --archived to 'list' to see them.
+
+Verbs:
+  list                 every Standalone Video (active by default; --archived for the archive)
+  get <id...>          a Video plus its Clips and Chapters (variadic; NDJSON when >1 id)
+  tree <id>            skeleton: video -> clips/chapters (id/kind/name/children)
+  transcript <id>      the ordered text projection (Clips + Chapters as prose)
+  create --name <n>    create a Video (--lesson <id> | --pitch <id> | neither=standalone) (WRITE)
+  move <id>            re-home a Video to a lesson/pitch (--lesson | --pitch) (WRITE)
+  update <id>          patch a Video's name / body / SEO description (WRITE)
+
+Worked example (find a video, then read it):
+  cvm video list | jq -r '.id'                     # map name -> id
+  cvm video get <id> | jq '.clips | length'        # how many clips
+  cvm video tree <id>                              # skeleton overview
+  cvm video transcript <id> | jq -r '.transcript'  # the prose transcript`;
+
+export const LIST_HELP = `List the COMPLETE set of Standalone Videos (lessonId = NULL, pitch-bound or not).
+
+Active videos only by default, ordered by most-recently-updated. Each row is the
+full video plus its non-archived Clips, so an agent can map name -> id in one
+call. Output is NDJSON (one compact JSON object per line); an empty set prints
+nothing and exits 0.
+
+Key fields:
+  id         the stable video id (use with get/tree/transcript)
+  name       uniform display label every noun's 'list' carries (mirrors 'path'),
+             so you never have to guess the label field
+  path       the video's name within its lesson (its display/file name)
+  pitchId    set when a Pitch packages this standalone video; else null
+  archived   soft-delete flag (always false here unless --archived)
+  clips[]    the video's clips in timeline order (order, text, source times)
+
+Flags:
+  --archived   include the ARCHIVE instead: only soft-deleted Standalone Videos
+               (getArchivedStandaloneVideos). Standalone Videos are the only
+               videos with a viewable archive.
+
+Examples:
+  cvm video list
+  cvm video list --archived
+  cvm video list | jq -r '"\\(.id)\\t\\(.path)"'`;
+
+export const GET_HELP = `Get one or more Videos by id (variadic), each with its immediate children.
+
+This is a shallow, fixed-depth read: the video row plus its non-archived Clips
+(in timeline order) and Chapters, and a little parent context (its Lesson /
+Section / Course Version when lesson-bound). Accepts ANY video id — standalone
+OR lesson-bound.
+
+Output:
+  - exactly one id, found    -> one pretty JSON object, exit 0
+  - exactly one id, missing  -> {"_tag":"NotFoundError","entity":"video",...} on
+                                stderr, exit 2
+  - multiple ids             -> NDJSON of the FOUND videos on stdout; any missing
+                                ids are reported on stderr and the exit code is 2
+                                (stdout stays pure data)
+
+Selected fields:
+  id, path, lessonId, pitchId, archived
+  clips[]    { id, order, text, videoFilename, sourceStartTime, sourceEndTime,
+               transcribedAt, beatType, ... } — order is a fractional index
+  chapters[] { id, order, name } — named YouTube-style dividers
+
+Examples:
+  cvm video get <id>
+  cvm video get <id1> <id2> <id3>
+  cvm video get <id> | jq '.clips[] | .text'`;
+
+export const TREE_HELP = `Print the SKELETON of a Video: its Clips and Chapters as a shallow tree.
+
+Each node is just { id, kind, name, children } — no full entity fields. Use this
+to see a video's shape at a glance, then 'video get'/'cvm clip get' to pull
+detail. A Video's natural children are its non-archived Clips (kind:"clip",
+name = clip text) and Chapters (kind:"chapter", name = chapter name), interleaved
+in timeline order.
+
+Depth:
+  --depth N      expand N levels (default 1 = video + its direct clips/chapters)
+  --depth all    expand the full subtree
+Clips and Chapters are leaves, so a Video's tree is fully expanded at depth 1.
+
+NOTE ON FLAG ORDER
+  Options must come BEFORE the positional id (e.g. 'tree --depth all <id>', NOT
+  'tree <id> --depth all') — a flag placed after the id is rejected (exit 3).
+
+Examples:
+  cvm video tree <id>
+  cvm video tree --depth all <id>
+  cvm video tree <id> | jq '.children[] | select(.kind=="chapter") | .name'`;
+
+export const TRANSCRIPT_HELP = `Render a Video's TRANSCRIPT — its ordered text projection.
+
+The Transcript interleaves the Video's Clips and Chapters in timeline order and
+renders each Chapter as a '## <name>' heading between paragraphs of clip text
+(the same projection shipped as {video}.transcript.md at Publish). This is the
+unit of comparison for changelog diffs.
+
+Accepts a SINGLE video id (standalone or lesson-bound). Missing id ->
+NotFoundError on stderr, exit 2.
+
+Output is one JSON object:
+  { id, path, lessonId, transcript, wordCount, items }
+where 'transcript' is the rendered prose string and 'items' is the structured
+sequence of { type:"section", name } / { type:"clip", text } entries.
+
+Examples:
+  cvm video transcript <id>
+  cvm video transcript <id> | jq -r '.transcript'
+  cvm video transcript <id> | jq '.wordCount'`;
+
+export const CREATE_HELP = `Create a Video. Requires --name <n> (the video's name / path).
+
+Choose the parent with a flag (they are mutually exclusive):
+  --lesson <id>   create the video inside that Lesson.
+  --pitch <id>    create the video packaged by that Pitch (a Standalone video).
+  (neither)       create a free Standalone video (no lesson, no pitch).
+
+--name is ALWAYS required, including under --pitch. Passing both --lesson and
+--pitch is invalid input (exit 3). An unknown --lesson / --pitch id is a
+not-found (exit 2). A --name that collides with an existing video in the same
+lesson is invalid input (exit 3). Echoes the created video row.
+
+Examples:
+  cvm video create --name "Intro"
+  cvm video create --name "01-setup" --lesson les_abc
+  cvm video create --name "My Pitch Cut" --pitch pit_123`;
+
+export const MOVE_HELP = `Re-home an existing Video to a Lesson or a Pitch. Requires EXACTLY ONE of
+--lesson <id> / --pitch <id> (passing both, or neither, is invalid input,
+exit 3).
+
+"move" enforces the single-parent invariant: moving to a lesson clears any pitch
+association, and moving to a pitch clears any lesson association — a Video always
+ends up with exactly one parent. An unknown video / lesson / pitch id is a
+not-found (exit 2). Moving into a lesson where the video's name is already taken
+is invalid input (exit 3). Flags must come BEFORE the <id>. Echoes the moved row.
+
+Examples:
+  cvm video move --lesson les_abc vid_123
+  cvm video move --pitch pit_123 vid_123`;
+
+export const UPDATE_HELP = `Patch a Video by id. A PARTIAL update: pass only the fields you want to change,
+and only those columns are written (unset flags are left untouched). At least one
+of --name / --body / --body-file / --description is required (an update with none
+is invalid input, exit 3).
+
+Fields:
+  --name <n>          the Video's 'name' (its 'path' column). For lesson-bound
+                      videos the new name must be unique within the lesson (a
+                      collision is invalid input, exit 3). Must be non-empty.
+  --body <md>         the Video's markdown BODY (the 'body' column) as inline
+                      text. Mutually exclusive with --body-file.
+  --body-file <path>  read the markdown BODY from a file; '-' reads STDIN.
+                      Mutually exclusive with --body. An unreadable path is
+                      invalid input (exit 3).
+  --description <s>   the Video's SEO DESCRIPTION (the 'video_description'
+                      column) as inline text.
+
+Body and SEO description are the DB-owned fields the AI Hero auto-link publishes.
+Passing an empty string ("") stores an empty value (it does not clear to null).
+An unknown id is a not-found (exit 2). Flags must come BEFORE the <id>. Echoes
+the updated video row.
+
+Examples:
+  cvm video update --name "02-refactor" vid_123
+  cvm video update --description "Learn to refactor a reducer" vid_123
+  cvm video update --body "# Intro\\n\\nWelcome…" vid_123
+  cvm video update --body-file ./notes.md vid_123
+  some-tool | cvm video update --body-file - vid_123
+  cvm video update --name "03-final" --description "The finished cut" vid_123`;

--- a/app/cli/commands/video.ts
+++ b/app/cli/commands/video.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
 import { VideoOperationsService } from "@/services/db-video-operations.server";
@@ -17,140 +18,16 @@ import {
   formatProseTranscript,
   toTranscriptItems,
 } from "@/lib/transcript-builder";
-
-// ---------------------------------------------------------------------------
-// Help text — domain-teaching prose (keep in sync with CONTEXT.md).
-// ---------------------------------------------------------------------------
-
-const VIDEO_HELP = `Video — a container of Clips and Chapters that represents a single producible video output.
-
-A Video holds two ordered, interleaved children:
-  - Clips:    timestamped slices of source footage (start/end time + a source
-              filename), each carrying transcribed 'text'. Clips are the words.
-  - Chapters: named markers/dividers that visually group Clips and map 1:1 to
-              YouTube chapters. Chapters are the headings.
-Together, projected in timeline order, Clips + Chapters form the Video's
-TRANSCRIPT (see 'video transcript').
-
-A Standalone Video has no lesson association (lessonId = NULL) and is used for
-reference or temporary content; it may be packaged by a Pitch. A lesson-bound
-Video belongs to a Lesson inside a Section of a Course Version.
-
-This command exposes ONLY Standalone Videos for 'list' (the complete set, not
-the UI's recent-5). 'get', 'tree' and 'transcript' accept ANY video id
-(standalone or lesson-bound).
-
-Archived Videos are soft-deleted (hidden from active views). Only Standalone
-Videos have a real viewable archive — pass --archived to 'list' to see them.
-
-Verbs:
-  list                 every Standalone Video (active by default; --archived for the archive)
-  get <id...>          a Video plus its Clips and Chapters (variadic; NDJSON when >1 id)
-  tree <id>            skeleton: video -> clips/chapters (id/kind/name/children)
-  transcript <id>      the ordered text projection (Clips + Chapters as prose)
-  create --name <n>    create a Video (--lesson <id> | --pitch <id> | neither=standalone) (WRITE)
-  move <id>            re-home a Video to a lesson/pitch (--lesson | --pitch) (WRITE)
-  update --name <n> <id>  rename a Video (its 'name'/path) (WRITE)
-
-Worked example (find a video, then read it):
-  cvm video list | jq -r '.id'                     # map name -> id
-  cvm video get <id> | jq '.clips | length'        # how many clips
-  cvm video tree <id>                              # skeleton overview
-  cvm video transcript <id> | jq -r '.transcript'  # the prose transcript`;
-
-const LIST_HELP = `List the COMPLETE set of Standalone Videos (lessonId = NULL, pitch-bound or not).
-
-Active videos only by default, ordered by most-recently-updated. Each row is the
-full video plus its non-archived Clips, so an agent can map name -> id in one
-call. Output is NDJSON (one compact JSON object per line); an empty set prints
-nothing and exits 0.
-
-Key fields:
-  id         the stable video id (use with get/tree/transcript)
-  name       uniform display label every noun's 'list' carries (mirrors 'path'),
-             so you never have to guess the label field
-  path       the video's name within its lesson (its display/file name)
-  pitchId    set when a Pitch packages this standalone video; else null
-  archived   soft-delete flag (always false here unless --archived)
-  clips[]    the video's clips in timeline order (order, text, source times)
-
-Flags:
-  --archived   include the ARCHIVE instead: only soft-deleted Standalone Videos
-               (getArchivedStandaloneVideos). Standalone Videos are the only
-               videos with a viewable archive.
-
-Examples:
-  cvm video list
-  cvm video list --archived
-  cvm video list | jq -r '"\\(.id)\\t\\(.path)"'`;
-
-const GET_HELP = `Get one or more Videos by id (variadic), each with its immediate children.
-
-This is a shallow, fixed-depth read: the video row plus its non-archived Clips
-(in timeline order) and Chapters, and a little parent context (its Lesson /
-Section / Course Version when lesson-bound). Accepts ANY video id — standalone
-OR lesson-bound.
-
-Output:
-  - exactly one id, found    -> one pretty JSON object, exit 0
-  - exactly one id, missing  -> {"_tag":"NotFoundError","entity":"video",...} on
-                                stderr, exit 2
-  - multiple ids             -> NDJSON of the FOUND videos on stdout; any missing
-                                ids are reported on stderr and the exit code is 2
-                                (stdout stays pure data)
-
-Selected fields:
-  id, path, lessonId, pitchId, archived
-  clips[]    { id, order, text, videoFilename, sourceStartTime, sourceEndTime,
-               transcribedAt, beatType, ... } — order is a fractional index
-  chapters[] { id, order, name } — named YouTube-style dividers
-
-Examples:
-  cvm video get <id>
-  cvm video get <id1> <id2> <id3>
-  cvm video get <id> | jq '.clips[] | .text'`;
-
-const TREE_HELP = `Print the SKELETON of a Video: its Clips and Chapters as a shallow tree.
-
-Each node is just { id, kind, name, children } — no full entity fields. Use this
-to see a video's shape at a glance, then 'video get'/'cvm clip get' to pull
-detail. A Video's natural children are its non-archived Clips (kind:"clip",
-name = clip text) and Chapters (kind:"chapter", name = chapter name), interleaved
-in timeline order.
-
-Depth:
-  --depth N      expand N levels (default 1 = video + its direct clips/chapters)
-  --depth all    expand the full subtree
-Clips and Chapters are leaves, so a Video's tree is fully expanded at depth 1.
-
-NOTE ON FLAG ORDER
-  Options must come BEFORE the positional id (e.g. 'tree --depth all <id>', NOT
-  'tree <id> --depth all') — a flag placed after the id is rejected (exit 3).
-
-Examples:
-  cvm video tree <id>
-  cvm video tree --depth all <id>
-  cvm video tree <id> | jq '.children[] | select(.kind=="chapter") | .name'`;
-
-const TRANSCRIPT_HELP = `Render a Video's TRANSCRIPT — its ordered text projection.
-
-The Transcript interleaves the Video's Clips and Chapters in timeline order and
-renders each Chapter as a '## <name>' heading between paragraphs of clip text
-(the same projection shipped as {video}.transcript.md at Publish). This is the
-unit of comparison for changelog diffs.
-
-Accepts a SINGLE video id (standalone or lesson-bound). Missing id ->
-NotFoundError on stderr, exit 2.
-
-Output is one JSON object:
-  { id, path, lessonId, transcript, wordCount, items }
-where 'transcript' is the rendered prose string and 'items' is the structured
-sequence of { type:"section", name } / { type:"clip", text } entries.
-
-Examples:
-  cvm video transcript <id>
-  cvm video transcript <id> | jq -r '.transcript'
-  cvm video transcript <id> | jq '.wordCount'`;
+import {
+  VIDEO_HELP,
+  LIST_HELP,
+  GET_HELP,
+  TREE_HELP,
+  TRANSCRIPT_HELP,
+  CREATE_HELP,
+  MOVE_HELP,
+  UPDATE_HELP,
+} from "./video.help";
 
 // ---------------------------------------------------------------------------
 // Shared fetch — return undefined for an absent row (CLI owns not-found).
@@ -277,47 +154,6 @@ const transcriptCmd = Command.make(
 // ---------------------------------------------------------------------------
 // Write verbs: create / move / update
 // ---------------------------------------------------------------------------
-
-const CREATE_HELP = `Create a Video. Requires --name <n> (the video's name / path).
-
-Choose the parent with a flag (they are mutually exclusive):
-  --lesson <id>   create the video inside that Lesson.
-  --pitch <id>    create the video packaged by that Pitch (a Standalone video).
-  (neither)       create a free Standalone video (no lesson, no pitch).
-
---name is ALWAYS required, including under --pitch. Passing both --lesson and
---pitch is invalid input (exit 3). An unknown --lesson / --pitch id is a
-not-found (exit 2). A --name that collides with an existing video in the same
-lesson is invalid input (exit 3). Echoes the created video row.
-
-Examples:
-  cvm video create --name "Intro"
-  cvm video create --name "01-setup" --lesson les_abc
-  cvm video create --name "My Pitch Cut" --pitch pit_123`;
-
-const MOVE_HELP = `Re-home an existing Video to a Lesson or a Pitch. Requires EXACTLY ONE of
---lesson <id> / --pitch <id> (passing both, or neither, is invalid input,
-exit 3).
-
-"move" enforces the single-parent invariant: moving to a lesson clears any pitch
-association, and moving to a pitch clears any lesson association — a Video always
-ends up with exactly one parent. An unknown video / lesson / pitch id is a
-not-found (exit 2). Moving into a lesson where the video's name is already taken
-is invalid input (exit 3). Flags must come BEFORE the <id>. Echoes the moved row.
-
-Examples:
-  cvm video move --lesson les_abc vid_123
-  cvm video move --pitch pit_123 vid_123`;
-
-const UPDATE_HELP = `Rename a Video by id — set its 'name' (the 'path' column). Requires --name <n>
-(an update with no --name is invalid input, exit 3).
-
-For lesson-bound videos the new name must be unique within the lesson (a
-collision is invalid input, exit 3). An unknown id is a not-found (exit 2).
-Flags must come BEFORE the <id>. Echoes the updated video row.
-
-Examples:
-  cvm video update --name "02-refactor" vid_123`;
 
 const nameOption = Options.text("name").pipe(
   Options.withDescription("The Video's name (its 'path').")
@@ -453,16 +289,89 @@ const updateNameOption = Options.text("name").pipe(
   Options.withDescription("The Video's new name (its 'path')."),
   Options.optional
 );
+const updateBodyOption = Options.text("body").pipe(
+  Options.withDescription(
+    "The Video's markdown body, inline (mutually exclusive with --body-file)."
+  ),
+  Options.optional
+);
+const updateBodyFileOption = Options.text("body-file").pipe(
+  Options.withDescription(
+    "Read the Video's markdown body from a file; '-' reads STDIN (mutually " +
+      "exclusive with --body)."
+  ),
+  Options.optional
+);
+const updateDescriptionOption = Options.text("description").pipe(
+  Options.withDescription(
+    "The Video's SEO description (the 'video_description' column)."
+  ),
+  Options.optional
+);
+
+/**
+ * Read the markdown body from a file path, or from STDIN when the path is '-'.
+ * An unreadable source is invalid input (exit 3), matching the CLI's treatment
+ * of other bad flag values.
+ */
+const readBodySource = (source: string) =>
+  Effect.try({
+    try: () => readFileSync(source === "-" ? 0 : source, "utf8"),
+    catch: () =>
+      parseError(
+        `could not read --body-file ${
+          source === "-" ? "(stdin)" : `"${source}"`
+        }`,
+        "video"
+      ),
+  });
 
 const updateCmd = Command.make(
   "update",
-  { id: updateId, name: updateNameOption },
-  ({ id, name }) =>
+  {
+    id: updateId,
+    name: updateNameOption,
+    body: updateBodyOption,
+    bodyFile: updateBodyFileOption,
+    description: updateDescriptionOption,
+  },
+  ({ id, name, body, bodyFile, description }) =>
     Effect.gen(function* () {
       const newName = Option.getOrUndefined(name);
-      if (newName === undefined || newName.trim() === "") {
-        return yield* parseError("update needs a non-empty --name", "video");
+      const inlineBody = Option.getOrUndefined(body);
+      const bodyFilePath = Option.getOrUndefined(bodyFile);
+      const newDescription = Option.getOrUndefined(description);
+
+      // --body and --body-file are two ways to spell the same field.
+      yield* rejectBothFlags({
+        a: inlineBody,
+        b: bodyFilePath,
+        flags: ["--body", "--body-file"],
+        entity: "video",
+      });
+
+      // A partial patch still needs at least one field to change.
+      if (
+        newName === undefined &&
+        inlineBody === undefined &&
+        bodyFilePath === undefined &&
+        newDescription === undefined
+      ) {
+        return yield* parseError(
+          "update needs at least one of --name / --body / --body-file / --description",
+          "video"
+        );
       }
+
+      if (newName !== undefined && newName.trim() === "") {
+        return yield* parseError("--name must not be empty", "video");
+      }
+
+      // Resolve the body from inline text or a file/STDIN (undefined = leave it).
+      const newBody =
+        bodyFilePath !== undefined
+          ? yield* readBodySource(bodyFilePath)
+          : inlineBody;
 
       const svc = yield* VideoOperationsService;
       // Existence guard first (clean exit 2).
@@ -470,13 +379,24 @@ const updateCmd = Command.make(
         .getVideoRowById(id)
         .pipe(Effect.catchTag("NotFoundError", () => notFound("video", id)));
 
-      yield* svc
-        .updateVideoPath({ videoId: id, path: newName })
-        .pipe(
-          Effect.catchTag("VideoPathTakenError", (e) =>
-            parseError(e.message, "video")
-          )
-        );
+      if (newName !== undefined) {
+        yield* svc
+          .updateVideoPath({ videoId: id, path: newName })
+          .pipe(
+            Effect.catchTag("VideoPathTakenError", (e) =>
+              parseError(e.message, "video")
+            )
+          );
+      }
+      if (newBody !== undefined) {
+        yield* svc.updateVideoBody({ videoId: id, body: newBody });
+      }
+      if (newDescription !== undefined) {
+        yield* svc.updateVideoDescription({
+          videoId: id,
+          description: newDescription,
+        });
+      }
 
       const updated = yield* svc.getVideoRowById(id);
       yield* emitObject(updated);


### PR DESCRIPTION
## What

Extends `cvm video update <id>` from a name-only rename into a **partial patch** over a Video's name, markdown **body**, and **SEO description**.

The `updateVideoBody` / `updateVideoDescription` write-ops already existed (added with the AI Hero auto-link, #1134) but were never wired into the CLI. This connects them.

## Flags

| flag | effect |
|------|--------|
| `--name <n>` | rename (existing; uniqueness guard for lesson-bound videos) |
| `--body <md>` | set the DB-owned markdown body inline |
| `--body-file <path>` | set the body from a file; `-` reads STDIN (mutually exclusive with `--body`) |
| `--description <s>` | set the DB-owned SEO description (`video_description`) |

- Partial: only the passed columns are written; unset flags are left untouched.
- At least one field is required; passing none is invalid input (exit 3).
- `--body` + `--body-file` together, or an unreadable `--body-file`, are invalid input (exit 3).
- Unknown id is a not-found (exit 2). Flags must come before the `<id>`.

## Tests

Adds integration tests (real `buildProgram` over PGlite) covering: `--description`, inline `--body`, `--body-file` (real file), combined name+body+description patch, no-field, both-body-flags, unreadable body-file, and not-found. Full suite (34 tests) green.

## Housekeeping

Split the video `--help` prose into `app/cli/commands/video.help.ts` (mirrors the existing `segment.help.ts`) to keep `video.ts` under the repo's per-file token budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)