### PR TITLE
fix(cvm): make pitch contentPlan read-only in the CLI

### DIFF
--- a/app/cli/cli-pitch-beat-writes.test.ts
+++ b/app/cli/cli-pitch-beat-writes.test.ts
@@ -76,8 +76,6 @@ describe("pitch create / update", () => {
           "Zod v4",
           "--description",
           "d",
-          "--content-plan",
-          "cp",
           "--youtube-title",
           "yt",
           "--youtube-thumbnail",
@@ -94,7 +92,6 @@ describe("pitch create / update", () => {
       ).stdout
     );
     expect(p.description).toBe("d");
-    expect(p.contentPlan).toBe("cp");
     expect(p.youtubeTitle).toBe("yt");
     expect(p.youtubeThumbnailDescription).toBe("thumb");
     expect(p.newsletterTitle).toBe("nl");
@@ -117,6 +114,38 @@ describe("pitch create / update", () => {
     ]);
     expect(exitCode).toBe(3);
     expect(stdout).toBe("");
+  });
+
+  // contentPlan is retired (ADR 0015): the CLI must NOT expose it as a writable
+  // flag on create/update, but it stays readable in get output.
+  it("create rejects the retired --content-plan flag => exit 3", async () => {
+    const { exitCode, stdout } = await run([
+      "pitch",
+      "create",
+      "--title",
+      "No plan writes",
+      "--content-plan",
+      "cp",
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("update rejects the retired --content-plan flag => exit 3", async () => {
+    const { exitCode, stdout } = await run([
+      "pitch",
+      "update",
+      "--content-plan",
+      "cp",
+      s.pitchActiveId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("contentPlan stays readable in get output (read-only, not stripped)", async () => {
+    const p = one<Pitch>((await run(["pitch", "get", s.pitchActiveId])).stdout);
+    expect(p).toHaveProperty("contentPlan");
   });
 
   it("update --title renames (patches only what is passed)", async () => {

--- a/app/cli/commands/pitch.ts
+++ b/app/cli/commands/pitch.ts
@@ -47,8 +47,11 @@ RANKING FIELDS
                overrides priority across bands.
 
 COPY FIELDS
-  title, description, contentPlan, youtubeTitle, youtubeThumbnailDescription,
+  title, description, youtubeTitle, youtubeThumbnailDescription,
   newsletterTitle, tweet — the packaging copy authored ahead of recording.
+  contentPlan is retired (deprecated, ADR 0015): still surfaced in list/get
+  output as a read-only transitional reference, but no longer writable via
+  create/update.
 
 VERBS
   list   — every active pitch (optionally filtered by --state). Identity-rich.
@@ -132,7 +135,6 @@ defaults ("" for copy; priority 2; effort 2). Echoes the created pitch row.
 Flags:
   --title <t>              (required) the pitch title / packaging headline.
   --description <t>        free-text description.
-  --content-plan <t>       the content plan.
   --youtube-title <t>      YouTube title copy.
   --youtube-thumbnail <t>  YouTube thumbnail concept (youtubeThumbnailDescription).
   --newsletter-title <t>   newsletter title copy.
@@ -149,7 +151,7 @@ const UPDATE_HELP = `Patch a Pitch's copy/ranking fields by id. At least one fie
 change; the rest are left untouched. Renaming is just --title.
 
 Flags (all optional; same meanings as 'pitch create'):
-  --title, --description, --content-plan, --youtube-title, --youtube-thumbnail,
+  --title, --description, --youtube-title, --youtube-thumbnail,
   --newsletter-title, --tweet, --priority <n>, --effort <1|2|3>.
 
 An unknown or archived (deleted) pitch id is a not-found (exit 2). Flags must
@@ -216,7 +218,6 @@ const optText = (name: string, description: string) =>
   );
 
 const descriptionOption = optText("description", "Free-text description.");
-const contentPlanOption = optText("content-plan", "The content plan.");
 const youtubeTitleOption = optText("youtube-title", "YouTube title copy.");
 const youtubeThumbnailOption = optText(
   "youtube-thumbnail",
@@ -240,7 +241,6 @@ const effortOption = Options.choice("effort", ["1", "2", "3"]).pipe(
 
 const copyOptions = {
   description: descriptionOption,
-  contentPlan: contentPlanOption,
   youtubeTitle: youtubeTitleOption,
   youtubeThumbnailDescription: youtubeThumbnailOption,
   newsletterTitle: newsletterTitleOption,
@@ -251,7 +251,6 @@ const copyOptions = {
 
 interface PitchFieldOpts {
   readonly description: Option.Option<string>;
-  readonly contentPlan: Option.Option<string>;
   readonly youtubeTitle: Option.Option<string>;
   readonly youtubeThumbnailDescription: Option.Option<string>;
   readonly newsletterTitle: Option.Option<string>;
@@ -269,7 +268,6 @@ const collectPitchFields = (opts: PitchFieldOpts): PitchFields => {
   const effort = Option.getOrUndefined(opts.effort);
   return {
     description: Option.getOrUndefined(opts.description),
-    contentPlan: Option.getOrUndefined(opts.contentPlan),
     youtubeTitle: Option.getOrUndefined(opts.youtubeTitle),
     youtubeThumbnailDescription: Option.getOrUndefined(
       opts.youtubeThumbnailDescription


### PR DESCRIPTION
## What

The `cvm` CLI let agents **write** `pitch.contentPlan` via `pitch create --content-plan` / `pitch update --content-plan`. Per **ADR 0015**, `pitches.contentPlan` is retired — no longer written, kept only as a read-only transitional reference. This makes the CLI honor that: the field becomes **read-only** (still surfaced in `list`/`get`/`search`) but is no longer writable.

## Changes

- Drop the `--content-plan` option from `pitch create` / `pitch update` (removed from the shared `copyOptions`, so both verbs lose it in one place).
- `contentPlan` stays fully **readable** — `list` / `get` / `search` output is unchanged.
- Help text updated to state `contentPlan` is retired / read-only.
- Tests: `--content-plan` is now rejected (exit 3) on both `create` and `update`, and `contentPlan` still appears in `get` output.

The shared service / web layer is untouched (the UI still shows the field read-only per the ADR).

## Verification

- `vitest run app/cli/cli-pitch-beat-writes.test.ts` — 20 passed (incl. new coverage).
- `tsgo` typecheck — 0 errors.

## Note

Supersedes the stale draft #1110 (same intent, but based on pre-`Beat`-rename `main` and additionally *stripped* `contentPlan` from read output, which contradicts "read-only"). Recommend closing #1110 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)