### PR TITLE
fix(article-writer): persist writer-modal model selection, default to Auto

### DIFF
--- a/app/features/article-writer/write-page-reducer.ts
+++ b/app/features/article-writer/write-page-reducer.ts
@@ -190,8 +190,8 @@ export function createInitialState({
 
   const model: Model =
     typeof localStorage !== "undefined"
-      ? (localStorage.getItem(MODEL_STORAGE_KEY) as Model) || "claude-haiku-4-5"
-      : "claude-haiku-4-5";
+      ? (localStorage.getItem(MODEL_STORAGE_KEY) as Model) || "auto"
+      : "auto";
 
   const enabledFiles =
     mode === "style-guide-skill-building"

--- a/app/features/article-writer/writer-engine.tsx
+++ b/app/features/article-writer/writer-engine.tsx
@@ -21,7 +21,7 @@ import { useDocumentFlow } from "./use-document-flow";
 import { useLint } from "@/hooks/use-lint";
 import { useBannedPhrases } from "@/hooks/use-banned-phrases";
 import { useMessageQueue } from "./use-message-queue";
-import { partsToText } from "./write-utils";
+import { MODEL_STORAGE_KEY, partsToText } from "./write-utils";
 import {
   replaceChooseScreenshotWithImage,
   updateChooseScreenshotClipIndex,
@@ -120,7 +120,17 @@ export function WriterEngine({
     modes[0] ?? "article"
   );
   const [mode, setMode] = useState<Mode>(constrainedMode);
-  const [model, setModel] = useState<Model>("claude-haiku-4-5");
+  const [model, setModelState] = useState<Model>(() =>
+    typeof localStorage !== "undefined"
+      ? (localStorage.getItem(MODEL_STORAGE_KEY) as Model) || "auto"
+      : "auto"
+  );
+  const setModel = useCallback((m: Model) => {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(MODEL_STORAGE_KEY, m);
+    }
+    setModelState(m);
+  }, []);
 
   const ctxModel = useContextModel(context, pageFields);
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/mattpocock/repos/matt/course-video-manager/node_modules


### PR DESCRIPTION
## What

In the writer modal (right-hand `WriterEngine`), the model selection wasn't persisted and defaulted to Haiku.

## Fixes

- **Persist the selection.** The modal stored the model in plain `useState`, so the choice was lost on remount/reload. It now reads from and writes to `localStorage` under the shared `MODEL_STORAGE_KEY` (same key the non-modal write-page reducer uses).
- **Default to Auto.** Changed the default from `claude-haiku-4-5` to `auto`. Also aligned the write-page reducer's default to Auto for consistency, since both share the same storage key.

## Testing

- `npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)