### PR TITLE
feat(lesson): set authoring status (todo/done) from CLI + two-way UI toggle

### DIFF
--- a/app/cli/cli-lesson-video-writes.test.ts
+++ b/app/cli/cli-lesson-video-writes.test.ts
@@ -188,6 +188,128 @@ describe("lesson create", () => {
   });
 });
 
+describe("lesson update", () => {
+  interface Lesson {
+    id: string;
+    title: string;
+    authoringStatus: string | null;
+  }
+  const lobj = (stdout: string): Lesson => one<Lesson>(stdout);
+
+  it("--authoring-status done marks the lesson done, echoing the row", async () => {
+    // The seed lesson starts as "done"; flip it to todo first so we can prove
+    // the write, then back to done.
+    await run(["lesson", "update", "--authoring-status", "todo", s.lessonId]);
+    const updated = lobj(
+      (
+        await run([
+          "lesson",
+          "update",
+          "--authoring-status",
+          "done",
+          s.lessonId,
+        ])
+      ).stdout
+    );
+    expect(updated.id).toBe(s.lessonId);
+    expect(updated.authoringStatus).toBe("done");
+  });
+
+  it("--authoring-status todo marks a done lesson back to todo", async () => {
+    const updated = lobj(
+      (
+        await run([
+          "lesson",
+          "update",
+          "--authoring-status",
+          "todo",
+          s.lessonId,
+        ])
+      ).stdout
+    );
+    expect(updated.authoringStatus).toBe("todo");
+  });
+
+  it("patches title and authoring status together, leaving the slug", async () => {
+    const updated = lobj(
+      (
+        await run([
+          "lesson",
+          "update",
+          "--title",
+          "A Clearer Title",
+          "--authoring-status",
+          "todo",
+          s.lessonId,
+        ])
+      ).stdout
+    );
+    expect(updated.title).toBe("A Clearer Title");
+    expect(updated.authoringStatus).toBe("todo");
+  });
+
+  it("--title only leaves the authoring status untouched", async () => {
+    // Seed lesson is "done"; renaming must not reset it to todo.
+    const updated = lobj(
+      (await run(["lesson", "update", "--title", "Renamed Only", s.lessonId]))
+        .stdout
+    );
+    expect(updated.title).toBe("Renamed Only");
+    expect(updated.authoringStatus).toBe("done");
+  });
+
+  it("with neither --title nor --authoring-status => invalid input, exit 3", async () => {
+    const { exitCode, stdout, stderr } = await run([
+      "lesson",
+      "update",
+      s.lessonId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+    expect((JSON.parse(stderr.trim()) as { _tag: string })._tag).toBe(
+      "ParseError"
+    );
+  });
+
+  it("an unknown --authoring-status value => invalid input, exit 3", async () => {
+    const { exitCode, stdout } = await run([
+      "lesson",
+      "update",
+      "--authoring-status",
+      "in-progress",
+      s.lessonId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("an empty --title => invalid input, exit 3", async () => {
+    const { exitCode, stdout } = await run([
+      "lesson",
+      "update",
+      "--title",
+      "  ",
+      s.lessonId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("update an unknown lesson => NotFoundError(lesson), exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "lesson",
+      "update",
+      "--authoring-status",
+      "todo",
+      "les_missing",
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "lesson"
+    );
+  });
+});
+
 describe("video create / move / update", () => {
   interface Video {
     id: string;

--- a/app/cli/commands/lesson.help.ts
+++ b/app/cli/commands/lesson.help.ts
@@ -33,8 +33,9 @@ VERBS
   tree <id> [--depth N] Skeleton tree lesson -> videos -> clips.
   create --section <id> --title <t> [--before|--after <lessonId>]
                         Create a lesson in a Section (WRITE).
-  update <id> --title <t>
-                        Rename a lesson's display title (WRITE; slug unchanged).
+  update <id> [--title <t>] [--authoring-status todo|done]
+                        Rename a lesson and/or set its authoring status (WRITE;
+                        slug unchanged).
   move <id> [--section <id>] [--before|--after <lessonId>]
                         Reorder within a section, or re-home to another (WRITE).
   search <id> <query>   Substring search down this lesson's subtree
@@ -121,17 +122,28 @@ Examples:
   cvm lesson create --section sec_123 --title "Intro to Effect"
   cvm lesson create --section sec_123 --title "Setup" --before les_abc`;
 
-export const UPDATE_HELP = `Rename a lesson's display TITLE by id. Requires --title <t> (an update with an
-empty title is invalid input, exit 3).
+export const UPDATE_HELP = `Update a lesson by id. Change its display TITLE and/or its AUTHORING STATUS.
 
-This changes the human-readable 'title' only — the lesson's 'path' (its slug) is
-deliberately left untouched, so renaming never moves a URL. Editing a lesson in a
-published (frozen) version is refused (exit 3); edits go to the Draft.
+Flags (pass at least one — an update with neither is invalid input, exit 3):
+  --title <text>              new display title. The lesson's 'path' (its slug)
+                              is deliberately left untouched, so renaming never
+                              moves a URL. An empty title is invalid (exit 3).
+  --authoring-status <state>  set where the lesson sits in the authoring
+                              workflow: "todo" (still needs work — the default
+                              for newly created lessons) or "done" (marked
+                              ready). Any other value is invalid input (exit 3).
+
+This is a partial patch: only the flags you pass are changed; the rest are left
+as-is. Editing a lesson in a published (frozen) version is refused (exit 3);
+edits go to the Draft.
 
 Echoes the updated lesson with its Section/Version/Repo hierarchy (as 'get').
 
 Examples:
-  cvm lesson update les_abc --title "A clearer title"`;
+  cvm lesson update les_abc --title "A clearer title"
+  cvm lesson update les_abc --authoring-status done
+  cvm lesson update les_abc --authoring-status todo
+  cvm lesson update les_abc --title "Setup" --authoring-status todo`;
 
 export const MOVE_HELP = `Reposition a lesson: reorder it within its Section, or re-home it to another.
 

--- a/app/cli/commands/lesson.ts
+++ b/app/cli/commands/lesson.ts
@@ -2,6 +2,7 @@ import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
 import { lessonSearchCmd } from "./search";
 import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
+import { AUTHORING_STATUSES } from "@/services/lesson-authoring-status";
 import { VersionOperationsService } from "@/services/db-version-operations.server";
 import { VideoOperationsService } from "@/services/db-video-operations.server";
 import { CourseWriteService } from "@/services/course-write-service";
@@ -274,8 +275,7 @@ const updateTitle = Options.text("title").pipe(
   Options.optional
 );
 const updateAuthoringStatus = Options.choice("authoring-status", [
-  "todo",
-  "done",
+  ...AUTHORING_STATUSES,
 ]).pipe(
   Options.withDescription(
     'Set the authoring status: "todo" (still needs work — the default for new ' +

--- a/app/cli/commands/lesson.ts
+++ b/app/cli/commands/lesson.ts
@@ -270,16 +270,36 @@ const updateId = Args.text({ name: "id" });
 const updateTitle = Options.text("title").pipe(
   Options.withDescription(
     "The lesson's new display title (the slug/path is left unchanged)."
-  )
+  ),
+  Options.optional
+);
+const updateAuthoringStatus = Options.choice("authoring-status", [
+  "todo",
+  "done",
+]).pipe(
+  Options.withDescription(
+    'Set the authoring status: "todo" (still needs work — the default for new ' +
+      'lessons) or "done" (marked ready).'
+  ),
+  Options.optional
 );
 
 const updateCmd = Command.make(
   "update",
-  { id: updateId, title: updateTitle },
-  ({ id, title }) =>
+  { id: updateId, title: updateTitle, authoringStatus: updateAuthoringStatus },
+  ({ id, title, authoringStatus }) =>
     withBackupCoordination(
       Effect.gen(function* () {
-        if (title.trim().length === 0) {
+        const titleValue = Option.getOrUndefined(title);
+        const statusValue = Option.getOrUndefined(authoringStatus);
+
+        if (titleValue === undefined && statusValue === undefined) {
+          return yield* parseError(
+            "update needs at least one of --title or --authoring-status",
+            "lesson"
+          );
+        }
+        if (titleValue !== undefined && titleValue.trim().length === 0) {
           return yield* parseError(
             "update needs a non-empty --title",
             "lesson"
@@ -295,7 +315,12 @@ const updateCmd = Command.make(
 
         yield* assertDraftLesson(lesson);
 
-        yield* svc.updateLesson(id, { title });
+        yield* svc.updateLesson(id, {
+          ...(titleValue !== undefined ? { title: titleValue } : {}),
+          ...(statusValue !== undefined
+            ? { authoringStatus: statusValue }
+            : {}),
+        });
 
         const updated = yield* svc.getLessonWithHierarchyById(id);
         yield* emitObject(updated);

--- a/app/features/course-view/lesson-context-menu.tsx
+++ b/app/features/course-view/lesson-context-menu.tsx
@@ -12,6 +12,7 @@ import type { Lesson, Section } from "./course-view-types";
 import type { useNavigate } from "react-router";
 import {
   ArrowRightLeft,
+  CheckCircle2,
   FileText,
   FileVideo,
   ListTodo,
@@ -82,22 +83,33 @@ export function LessonContextMenuContent({
               Edit Description
             </ContextMenuItem>
           )}
-          {lesson.authoringStatus === "done" && (
-            <>
-              <ContextMenuSeparator />
-              <ContextMenuItem
-                onSelect={() =>
-                  submitEvent({
-                    type: "set-lesson-authoring-status",
-                    lessonId: lesson.id,
-                    status: "todo",
-                  })
-                }
-              >
-                <ListTodo className="w-4 h-4" />
-                Mark as TODO
-              </ContextMenuItem>
-            </>
+          <ContextMenuSeparator />
+          {lesson.authoringStatus === "done" ? (
+            <ContextMenuItem
+              onSelect={() =>
+                submitEvent({
+                  type: "set-lesson-authoring-status",
+                  lessonId: lesson.id,
+                  status: "todo",
+                })
+              }
+            >
+              <ListTodo className="w-4 h-4" />
+              Mark as TODO
+            </ContextMenuItem>
+          ) : (
+            <ContextMenuItem
+              onSelect={() =>
+                submitEvent({
+                  type: "set-lesson-authoring-status",
+                  lessonId: lesson.id,
+                  status: "done",
+                })
+              }
+            >
+              <CheckCircle2 className="w-4 h-4" />
+              Mark as Done
+            </ContextMenuItem>
           )}
           <ContextMenuSeparator />
           <ContextMenuItem

--- a/app/services/lesson-authoring-status.ts
+++ b/app/services/lesson-authoring-status.ts
@@ -1,1 +1,3 @@
-export type AuthoringStatus = "todo" | "done";
+export const AUTHORING_STATUSES = ["todo", "done"] as const;
+
+export type AuthoringStatus = (typeof AUTHORING_STATUSES)[number];


### PR DESCRIPTION
## Why

The lesson **authoring status** (`todo` / `done`) was hard to manage and impossible to script:

- **CLI**: `cvm lesson update` only supported `--title` — there was no way to set the status at all, so bulk-marking a course's lessons back to `todo` was impossible.
- **UI**: the only controls were a small "todo" badge (marks a lesson *done*) and a context-menu "Mark as TODO" that **only appeared once a lesson was already `done`** — so from a fresh `todo` lesson there was no obvious status control, and the toggle wasn't discoverable in both directions.

This came from wanting to mark every lesson in a course back to TO&nbsp;DO.

## What changed

**CLI** (`app/cli/commands/lesson.ts`, `lesson.help.ts`)
- `cvm lesson update` now accepts `--authoring-status <todo|done>`.
- `--title` is now optional; you must pass **at least one** of `--title` / `--authoring-status` (neither → invalid input, exit 3).
- Partial patch: setting the status leaves the title/slug untouched and vice-versa.
- Invalid status values are rejected (exit 3). Help text updated with examples.

```
cvm lesson update les_abc --authoring-status todo
cvm lesson update les_abc --authoring-status done
cvm lesson update les_abc --title "Setup" --authoring-status todo
```

**UI** (`app/features/course-view/lesson-context-menu.tsx`)
- The lesson context menu now always shows a clear two-way toggle: **"Mark as Done"** when a lesson is `todo`, **"Mark as TODO"** when it's `done`.

**New lessons** keep defaulting to `todo` (unchanged), so they still surface the TO&nbsp;DO badge on creation.

## Notes
- The service layer (`updateLesson`) already accepted `authoringStatus`; this just plumbs it through the CLI and improves UI discoverability. No schema/migration changes.

## Testing
- 8 new CLI tests in `cli-lesson-video-writes.test.ts` (set done, set todo, combined title+status patch, title-only leaves status untouched, empty update / bad status / empty title → exit 3, unknown lesson → exit 2). Full file: 42/42 pass.
- `pnpm run typecheck` clean; Prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)