### PR TITLE
docs: mark ADR 0006 (publishing TODO lessons) as superseded

### DIFF
--- a/docs/adr/0006-publishing-todo-lessons.md
+++ b/docs/adr/0006-publishing-todo-lessons.md
@@ -1,4 +1,17 @@
+---
+status: superseded
+---
+
 # Publishing TODO lessons
+
+> **Superseded (2026-07-10).** This ADR does not reflect the code. The per-lesson
+> `TODO.md` sentinel it describes (the **TODO Marker**) was never implemented — no
+> code writes such a file (the only file write in the publish path is `course.json`),
+> and the changelog legend's reference to a `TODO.md` sentinel is stale. The one real
+> signal is the changelog itself: the `(TODO)` suffix on **New Lessons** plus the
+> **Marked Ready** / **Marked TODO** buckets. TODO lessons are otherwise mirrored to
+> Dropbox identically to `done` lessons. A replacement decision — a publish-time filter
+> to include or withhold TODO lessons — is being designed and will supersede this.
 
 A real **Lesson** whose **Lesson Authoring Status** is `todo` is published into Dropbox normally — its directory is created, and any videos, transcripts, and source files it already has are mirrored exactly as for a `done` lesson. The TODO state is communicated via two additive signals: a per-lesson `TODO.md` sentinel file written inside the lesson's dropbox folder (the **TODO Marker**), and per-section **Marked Ready** / **Marked TODO** buckets in `changelog.md` tracking status transitions across **Published Versions** via lesson lineage (`previousVersionLessonId`). New lessons that arrive in `todo` state are listed in the existing **New Lessons** bucket with a `(TODO)` suffix. The sentinel content is a fixed template — identical across every TODO lesson, no per-lesson dynamic content — so the dropbox sync stays a pure idempotent function of `authoringStatus`. **Ghost Lessons** are not published, so the marker never applies to them.
 


### PR DESCRIPTION
## Why

ADR 0006 claims TODO lessons carry **two** additive signals at publish time. Only **one** is real:

- ✅ **Changelog buckets** — `(TODO)` suffix on *New Lessons*, plus *Marked Ready* / *Marked TODO* — genuinely emitted by `changelog-service.ts`.
- ❌ **The per-lesson `TODO.md` sentinel ("TODO Marker")** — never implemented. The only file write in the entire publish path is `course.json` (`course-publish-service.ts:402`). The changelog legend (`changelog-service.ts:178`) still tells readers to "look for a `TODO.md` sentinel," pointing at a file that is never created.

TODO lessons are otherwise mirrored to Dropbox identically to `done` lessons — `course.json` ignores `authoringStatus` entirely.

## What

Adds `status: superseded` frontmatter and a dated note to the ADR. Marked superseded ahead of a replacement decision now in design: a **publish-time filter** to include or withhold TODO lessons from a publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)