### PR TITLE
Publish-time toggle to include/exclude lessons marked to-do (#1250)

### DIFF
--- a/app/features/upload-manager/sse-batch-export-client.ts
+++ b/app/features/upload-manager/sse-batch-export-client.ts
@@ -3,6 +3,7 @@ import type { uploadReducer } from "./upload-reducer";
 
 export interface SSEBatchExportParams {
   versionId: string;
+  includeTodoLessons: boolean;
 }
 
 export interface SSEBatchExportCallbacks {
@@ -18,7 +19,7 @@ export const startSSEBatchExport = (
 ): AbortController =>
   consumeSSEStream({
     url: `/api/courseVersions/${params.versionId}/batch-export-sse`,
-    body: {},
+    body: { includeTodoLessons: params.includeTodoLessons },
     events: {
       videos: (data: { videos: Array<{ id: string; title: string }> }) =>
         callbacks.onVideos(data.videos),

--- a/app/features/upload-manager/sse-publish-client.ts
+++ b/app/features/upload-manager/sse-publish-client.ts
@@ -5,6 +5,7 @@ export interface SSEPublishParams {
   courseId: string;
   name: string;
   description: string;
+  includeTodoLessons: boolean;
 }
 
 export interface SSEPublishCallbacks {
@@ -22,7 +23,11 @@ export const startSSEPublish = (
 ): AbortController =>
   consumeSSEStream({
     url: `/api/courses/${params.courseId}/publish-sse`,
-    body: { name: params.name, description: params.description },
+    body: {
+      name: params.name,
+      description: params.description,
+      includeTodoLessons: params.includeTodoLessons,
+    },
     events: {
       progress: (data: { stage: uploadReducer.PublishStage }) =>
         callbacks.onStageChange(data.stage),

--- a/app/features/upload-manager/upload-context.tsx
+++ b/app/features/upload-manager/upload-context.tsx
@@ -45,13 +45,17 @@ export interface UploadContextType {
     dependsOn?: string
   ) => string;
   startExportUpload: (videoId: string, title: string) => string;
-  startBatchExportUpload: (versionId: string) => void;
+  startBatchExportUpload: (
+    versionId: string,
+    includeTodoLessons: boolean
+  ) => void;
   startDropboxPublish: (repoId: string, repoName: string) => string;
   startPublish: (
     courseId: string,
     courseName: string,
     name: string,
-    description: string
+    description: string,
+    includeTodoLessons: boolean
   ) => string;
   dismissUpload: (uploadId: string) => void;
 }
@@ -281,73 +285,76 @@ export function UploadProvider({ children }: { children: React.ReactNode }) {
     return uploadId;
   }, []);
 
-  const startBatchExportUpload = useCallback((versionId: string) => {
-    const abortController = startSSEBatchExport(
-      { versionId },
-      {
-        onVideos: (videos) => {
-          for (const video of videos) {
-            const uploadId = generateUploadId();
-            batchVideoIdToUploadIdRef.current.set(video.id, uploadId);
-            dispatch({
-              type: "START_UPLOAD",
-              uploadId,
-              videoId: video.id,
-              title: video.title,
-              uploadType: "export",
-              isBatchEntry: true,
-            });
-          }
-        },
-        onStageChange: (videoId, stage) => {
-          const uploadId = batchVideoIdToUploadIdRef.current.get(videoId);
-          if (uploadId) {
-            dispatch({
-              type: "UPDATE_EXPORT_STAGE",
-              uploadId,
-              stage,
-            });
-          }
-        },
-        onComplete: (videoId) => {
-          const uploadId = batchVideoIdToUploadIdRef.current.get(videoId);
-          if (uploadId) {
-            dispatch({
-              type: "UPLOAD_SUCCESS",
-              uploadId,
-            });
-            batchVideoIdToUploadIdRef.current.delete(videoId);
-          }
-        },
-        onError: (videoId, message) => {
-          if (videoId === null) {
-            // Connection-level error — mark all remaining batch entries as errored
-            for (const [, uid] of batchVideoIdToUploadIdRef.current) {
+  const startBatchExportUpload = useCallback(
+    (versionId: string, includeTodoLessons: boolean) => {
+      const abortController = startSSEBatchExport(
+        { versionId, includeTodoLessons },
+        {
+          onVideos: (videos) => {
+            for (const video of videos) {
+              const uploadId = generateUploadId();
+              batchVideoIdToUploadIdRef.current.set(video.id, uploadId);
               dispatch({
-                type: "UPLOAD_ERROR",
-                uploadId: uid,
-                errorMessage: message,
+                type: "START_UPLOAD",
+                uploadId,
+                videoId: video.id,
+                title: video.title,
+                uploadType: "export",
+                isBatchEntry: true,
               });
             }
-            batchVideoIdToUploadIdRef.current.clear();
-          } else {
+          },
+          onStageChange: (videoId, stage) => {
             const uploadId = batchVideoIdToUploadIdRef.current.get(videoId);
             if (uploadId) {
               dispatch({
-                type: "UPLOAD_ERROR",
+                type: "UPDATE_EXPORT_STAGE",
                 uploadId,
-                errorMessage: message,
+                stage,
+              });
+            }
+          },
+          onComplete: (videoId) => {
+            const uploadId = batchVideoIdToUploadIdRef.current.get(videoId);
+            if (uploadId) {
+              dispatch({
+                type: "UPLOAD_SUCCESS",
+                uploadId,
               });
               batchVideoIdToUploadIdRef.current.delete(videoId);
             }
-          }
-        },
-      }
-    );
+          },
+          onError: (videoId, message) => {
+            if (videoId === null) {
+              // Connection-level error — mark all remaining batch entries as errored
+              for (const [, uid] of batchVideoIdToUploadIdRef.current) {
+                dispatch({
+                  type: "UPLOAD_ERROR",
+                  uploadId: uid,
+                  errorMessage: message,
+                });
+              }
+              batchVideoIdToUploadIdRef.current.clear();
+            } else {
+              const uploadId = batchVideoIdToUploadIdRef.current.get(videoId);
+              if (uploadId) {
+                dispatch({
+                  type: "UPLOAD_ERROR",
+                  uploadId,
+                  errorMessage: message,
+                });
+                batchVideoIdToUploadIdRef.current.delete(videoId);
+              }
+            }
+          },
+        }
+      );
 
-    // Store with a synthetic key so it can be cleaned up on unmount
-    abortControllersRef.current.set(`batch-${versionId}`, abortController);
-  }, []);
+      // Store with a synthetic key so it can be cleaned up on unmount
+      abortControllersRef.current.set(`batch-${versionId}`, abortController);
+    },
+    []
+  );
 
   const startDropboxPublish = useCallback(
     (repoId: string, repoName: string) => {
@@ -386,11 +393,12 @@ export function UploadProvider({ children }: { children: React.ReactNode }) {
       courseId: string,
       courseName: string,
       name: string,
-      description: string
+      description: string,
+      includeTodoLessons: boolean
     ) => {
       const uploadId = generateUploadId();
 
-      const params = { courseId, name, description };
+      const params = { courseId, name, description, includeTodoLessons };
       paramsMapRef.current.set(uploadId, { type: "publish", params });
 
       const action = {

--- a/app/features/upload-manager/upload-type-registry.ts
+++ b/app/features/upload-manager/upload-type-registry.ts
@@ -456,6 +456,7 @@ export interface PublishParams {
   courseId: string;
   name: string;
   description: string;
+  includeTodoLessons: boolean;
 }
 
 const publishConfig: UploadTypeConfig<
@@ -495,6 +496,7 @@ const publishConfig: UploadTypeConfig<
           courseId: params.courseId,
           name: params.name,
           description: params.description,
+          includeTodoLessons: params.includeTodoLessons,
         },
         {
           onStageChange: (stage) => {

--- a/app/packages/course-json/index.ts
+++ b/app/packages/course-json/index.ts
@@ -1,0 +1,25 @@
+// Entry point (public) for the course-json package — a single seam.
+//
+// A deep module: this small surface hides the whole production of a course.json
+// manifest — the effective-output filter (which to-do Lessons ship), role
+// derivation, chapter building, content-addressed export hashing, and
+// empty-Section elision. Import THIS from outside the package — never `./lib/*`.
+//
+// `buildCourseJson` consumes the effective-output filter internally; the filter
+// is also exported directly because export, validation, and the Dropbox mirror
+// read the same effective Sections — so there is exactly one notion of what a
+// publish ships.
+
+export {
+  buildCourseJson,
+  CourseJsonDocumentSchema,
+  InvalidLessonRoleComboError,
+  type BuildCourseJsonInput,
+  type CourseJsonDocument,
+} from "./lib/build-course-json";
+
+export {
+  computeEffectiveSections,
+  isLessonEffective,
+  isLessonWithheld,
+} from "./lib/effective-sections";

--- a/app/packages/course-json/lib/build-course-json.ts
+++ b/app/packages/course-json/lib/build-course-json.ts
@@ -1,7 +1,11 @@
 import { Data, Effect, Schema } from "effect";
-import { computeExportHash, type ExportClip } from "./export-hash";
-import { computeLessonWarnings, deriveVideoRole } from "./lesson-warnings";
-import { buildChapters } from "./publish-to-dropbox";
+import { computeExportHash, type ExportClip } from "@/services/export-hash";
+import { computeEffectiveSections } from "./effective-sections";
+import {
+  computeLessonWarnings,
+  deriveVideoRole,
+} from "@/services/lesson-warnings";
+import { buildChapters } from "@/services/publish-to-dropbox";
 
 // ── Schema ──────────────────────────────────────────────────────────────
 
@@ -95,6 +99,7 @@ type InputLesson = {
   path: string;
   title: string;
   description: string;
+  authoringStatus: string | null;
   videos: InputVideo[];
 };
 
@@ -110,6 +115,10 @@ export type BuildCourseJsonInput = {
   courseId: string;
   courseName: string;
   sections: InputSection[];
+  // Whether Lessons still marked to-do ship in this manifest. When false, every
+  // to-do Lesson is withheld — omitted from course.json entirely, and Sections
+  // left with no shippable Lessons disappear.
+  includeTodoLessons: boolean;
 };
 
 // ── Builder ─────────────────────────────────────────────────────────────
@@ -136,12 +145,16 @@ export const buildCourseJson = (
   Effect.gen(function* () {
     const sections: Array<typeof CourseJsonSectionSchema.Type> = [];
 
-    for (const section of input.sections) {
-      // Empty sections derive no path — skip them rather than emit a section
-      // with an undefined path. (A real section with no active lessons still
-      // has a derived path and is emitted with an empty lessons array.)
-      if (!section.path) continue;
+    // The effective-output filter is the single home of "what this publish
+    // ships": it drops to-do Lessons when they are withheld, Lessons with no
+    // active Videos, and Sections left with no shippable Lessons. Everything
+    // below then models only what actually ships.
+    const effectiveSections = computeEffectiveSections(
+      input.sections,
+      input.includeTodoLessons
+    );
 
+    for (const section of effectiveSections) {
       const lessons: Array<typeof CourseJsonLessonSchema.Type> = [];
 
       for (const lesson of section.lessons) {
@@ -196,6 +209,12 @@ export const buildCourseJson = (
           });
         }
       }
+
+      // Emit a Section only when it actually ships Lessons. Sections are
+      // decided by their shippable Lessons, not by a derived path — an empty
+      // Section (whether it never had Lessons or had them all withheld/archived
+      // upstream) produces no course.json entry, never an empty lessons array.
+      if (lessons.length === 0) continue;
 
       sections.push({
         id: section.lineageId,

--- a/app/packages/course-json/lib/effective-sections.ts
+++ b/app/packages/course-json/lib/effective-sections.ts
@@ -1,0 +1,51 @@
+// The single home of "what this publish ships". Export, validation, the
+// Dropbox mirror, and buildCourseJson all read effective Sections from here so
+// there is exactly one notion of the effective output.
+//
+// A Lesson is *effective* iff it has at least one active (non-archived) Video
+// AND it is not withheld. It is *withheld* only when to-do Lessons are excluded
+// (`includeTodoLessons` is false) and the Lesson's authoring status is `todo`.
+// A Section is *effective* iff it retains at least one effective Lesson.
+//
+// The toggle never touches the frozen Published Version snapshot — this filter
+// affects only what reaches Dropbox and course.json, so withholding is fully
+// reversible: flip the toggle back on (or mark the Lesson done) and republish.
+
+type EffectiveVideo = { archived: boolean };
+
+type EffectiveLesson = {
+  authoringStatus: string | null;
+  videos: readonly EffectiveVideo[];
+};
+
+type EffectiveSection<L extends EffectiveLesson> = {
+  lessons: readonly L[];
+};
+
+export const isLessonWithheld = (
+  authoringStatus: string | null,
+  includeTodoLessons: boolean
+): boolean => !includeTodoLessons && authoringStatus === "todo";
+
+export const isLessonEffective = (
+  lesson: EffectiveLesson,
+  includeTodoLessons: boolean
+): boolean =>
+  lesson.videos.some((video) => !video.archived) &&
+  !isLessonWithheld(lesson.authoringStatus, includeTodoLessons);
+
+export const computeEffectiveSections = <
+  L extends EffectiveLesson,
+  S extends EffectiveSection<L>,
+>(
+  sections: readonly S[],
+  includeTodoLessons: boolean
+): S[] =>
+  sections
+    .map((section) => ({
+      ...section,
+      lessons: section.lessons.filter((lesson) =>
+        isLessonEffective(lesson, includeTodoLessons)
+      ),
+    }))
+    .filter((section) => section.lessons.length > 0) as S[];

--- a/app/packages/course-json/tests/course-json.test.ts
+++ b/app/packages/course-json/tests/course-json.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Effect } from "effect";
-import { buildCourseJson, type BuildCourseJsonInput } from "./course-json";
-import { computeExportHash } from "./export-hash";
+import { buildCourseJson, type BuildCourseJsonInput } from "../index";
+import { computeExportHash } from "@/services/export-hash";
 
 const makeVideo = (
   overrides: Partial<
@@ -28,6 +28,7 @@ const makeLesson = (
   lineageId: `lesson-lineage-${overrides.path}`,
   title: overrides.path,
   description: "",
+  authoringStatus: null as string | null,
   ...overrides,
 });
 
@@ -44,11 +45,13 @@ const makeSection = (
 });
 
 const makeInput = (
-  sections: BuildCourseJsonInput["sections"]
+  sections: BuildCourseJsonInput["sections"],
+  includeTodoLessons = true
 ): BuildCourseJsonInput => ({
   courseId: "course-1",
   courseName: "Test Course",
   sections,
+  includeTodoLessons,
 });
 
 const run = (input: BuildCourseJsonInput) =>
@@ -89,7 +92,12 @@ describe("buildCourseJson", () => {
         makeSection({
           path: "01-intro",
           lineageId: "sec-abc",
-          lessons: [],
+          lessons: [
+            makeLesson({
+              path: "01.01-welcome",
+              videos: [makeVideo({ title: "Explainer" })],
+            }),
+          ],
         }),
       ])
     );
@@ -393,7 +401,7 @@ describe("buildCourseJson", () => {
     expect(lesson.type).toBe("problem");
   });
 
-  it("skips lessons where all videos are archived", async () => {
+  it("drops a section whose only lesson has all videos archived", async () => {
     const result = await run(
       makeInput([
         makeSection({
@@ -408,7 +416,7 @@ describe("buildCourseJson", () => {
       ])
     );
 
-    expect(result.sections[0]!.lessons).toEqual([]);
+    expect(result.sections).toEqual([]);
   });
 
   // ── Invalid combos fail loudly ─────────────────────────────────────
@@ -515,7 +523,12 @@ describe("buildCourseJson", () => {
         makeSection({
           path: "01-intro",
           description: "Introduction section",
-          lessons: [],
+          lessons: [
+            makeLesson({
+              path: "01.01-welcome",
+              videos: [makeVideo({ title: "Explainer" })],
+            }),
+          ],
         }),
       ])
     );
@@ -551,12 +564,22 @@ describe("buildCourseJson", () => {
         makeSection({
           path: "01-intro",
           title: "Introduction",
-          lessons: [],
+          lessons: [
+            makeLesson({
+              path: "01.01-welcome",
+              videos: [makeVideo({ title: "Explainer" })],
+            }),
+          ],
         }),
         makeSection({
           path: "02-advanced",
           title: "Advanced Topics",
-          lessons: [],
+          lessons: [
+            makeLesson({
+              path: "02.01-deep",
+              videos: [makeVideo({ title: "Explainer" })],
+            }),
+          ],
         }),
       ])
     );
@@ -633,6 +656,114 @@ describe("buildCourseJson", () => {
     if (lesson.type === "explainer") {
       expect(lesson.explainer.body).toBeNull();
       expect(lesson.explainer.description).toBeNull();
+    }
+  });
+
+  // ── Effective-output filter (includeTodoLessons) ───────────────────
+
+  it("includes to-do lessons when includeTodoLessons is true", async () => {
+    const result = await run(
+      makeInput(
+        [
+          makeSection({
+            path: "01-intro",
+            lessons: [
+              makeLesson({
+                path: "01.01-todo",
+                authoringStatus: "todo",
+                videos: [makeVideo({ title: "Explainer" })],
+              }),
+              makeLesson({
+                path: "01.02-done",
+                authoringStatus: "done",
+                videos: [makeVideo({ title: "Explainer" })],
+              }),
+            ],
+          }),
+        ],
+        true
+      )
+    );
+    expect(result.sections[0]!.lessons).toHaveLength(2);
+  });
+
+  it("withholds to-do lessons when includeTodoLessons is false", async () => {
+    const result = await run(
+      makeInput(
+        [
+          makeSection({
+            path: "01-intro",
+            title: "Intro",
+            lessons: [
+              makeLesson({
+                path: "01.01-todo",
+                title: "Todo",
+                authoringStatus: "todo",
+                videos: [makeVideo({ title: "Explainer" })],
+              }),
+              makeLesson({
+                path: "01.02-done",
+                title: "Done",
+                authoringStatus: "done",
+                videos: [makeVideo({ title: "Explainer" })],
+              }),
+            ],
+          }),
+        ],
+        false
+      )
+    );
+    expect(result.sections[0]!.lessons.map((l) => l.title)).toEqual(["Done"]);
+  });
+
+  it("drops a section whose only lessons are withheld to-do lessons", async () => {
+    const result = await run(
+      makeInput(
+        [
+          makeSection({
+            path: "01-intro",
+            lessons: [
+              makeLesson({
+                path: "01.01-todo",
+                authoringStatus: "todo",
+                videos: [makeVideo({ title: "Explainer" })],
+              }),
+            ],
+          }),
+        ],
+        false
+      )
+    );
+    expect(result.sections).toEqual([]);
+  });
+
+  it("never emits a section with an empty lessons array", async () => {
+    const result = await run(
+      makeInput([
+        makeSection({ path: "01-empty", title: "Empty", lessons: [] }),
+        makeSection({
+          path: "02-archived",
+          lessons: [
+            makeLesson({
+              path: "02.01-x",
+              videos: [makeVideo({ title: "Explainer", archived: true })],
+            }),
+          ],
+        }),
+        makeSection({
+          path: "03-real",
+          lessons: [
+            makeLesson({
+              path: "03.01-x",
+              videos: [makeVideo({ title: "Explainer" })],
+            }),
+          ],
+        }),
+      ])
+    );
+    expect(result.sections.map((s) => s.title)).toEqual(["03-real"]);
+    for (const section of result.sections) {
+      expect(section.lessons.length).toBeGreaterThan(0);
     }
   });
 });

--- a/app/packages/course-json/tests/effective-sections.test.ts
+++ b/app/packages/course-json/tests/effective-sections.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeEffectiveSections,
+  isLessonEffective,
+  isLessonWithheld,
+} from "../index";
+
+const video = (archived = false) => ({ archived });
+
+const lesson = (
+  authoringStatus: string | null,
+  videos: Array<{ archived: boolean }> = [video()]
+) => ({ authoringStatus, videos });
+
+const section = (lessons: ReturnType<typeof lesson>[]) => ({ lessons });
+
+describe("isLessonWithheld", () => {
+  it("withholds only a todo lesson when todo lessons are excluded", () => {
+    expect(isLessonWithheld("todo", false)).toBe(true);
+    expect(isLessonWithheld("done", false)).toBe(false);
+    expect(isLessonWithheld(null, false)).toBe(false);
+  });
+
+  it("never withholds when todo lessons are included", () => {
+    expect(isLessonWithheld("todo", true)).toBe(false);
+    expect(isLessonWithheld("done", true)).toBe(false);
+    expect(isLessonWithheld(null, true)).toBe(false);
+  });
+});
+
+describe("isLessonEffective", () => {
+  it("requires at least one active (non-archived) video", () => {
+    expect(isLessonEffective(lesson("done", [video()]), true)).toBe(true);
+    expect(isLessonEffective(lesson("done", []), true)).toBe(false);
+    expect(isLessonEffective(lesson("done", [video(true)]), true)).toBe(false);
+  });
+
+  it("excludes withheld todo lessons even with active videos", () => {
+    expect(isLessonEffective(lesson("todo", [video()]), false)).toBe(false);
+    expect(isLessonEffective(lesson("todo", [video()]), true)).toBe(true);
+  });
+});
+
+describe("computeEffectiveSections", () => {
+  it("passes every lesson through when todo lessons are included", () => {
+    const sections = [section([lesson("todo"), lesson("done"), lesson(null)])];
+    const result = computeEffectiveSections(sections, true);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.lessons).toHaveLength(3);
+  });
+
+  it("withholds todo lessons and keeps done/null lessons when excluded", () => {
+    const sections = [section([lesson("todo"), lesson("done"), lesson(null)])];
+    const result = computeEffectiveSections(sections, false);
+    expect(result[0]!.lessons.map((l) => l.authoringStatus)).toEqual([
+      "done",
+      null,
+    ]);
+  });
+
+  it("excludes lessons with no active videos regardless of toggle", () => {
+    const noActive = lesson("done", [video(true)]);
+    for (const include of [true, false]) {
+      const result = computeEffectiveSections([section([noActive])], include);
+      expect(result).toEqual([]);
+    }
+  });
+
+  it("drops a section whose only lessons are withheld", () => {
+    const sections = [section([lesson("todo"), lesson("todo")])];
+    expect(computeEffectiveSections(sections, false)).toEqual([]);
+  });
+
+  it("drops a section whose only lessons have no active videos", () => {
+    const sections = [section([lesson("done", [video(true)])])];
+    expect(computeEffectiveSections(sections, true)).toEqual([]);
+  });
+
+  it("keeps a section that retains at least one effective lesson", () => {
+    const sections = [section([lesson("todo"), lesson("done")])];
+    const result = computeEffectiveSections(sections, false);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.lessons).toHaveLength(1);
+    expect(result[0]!.lessons[0]!.authoringStatus).toBe("done");
+  });
+
+  it("preserves non-filtered fields on sections and lessons", () => {
+    const sections = [
+      {
+        id: "sec-1",
+        path: "01-intro",
+        lessons: [
+          { id: "l-1", authoringStatus: "done", videos: [video()] },
+          { id: "l-2", authoringStatus: "todo", videos: [video()] },
+        ],
+      },
+    ];
+    const result = computeEffectiveSections(sections, false);
+    expect(result[0]!.id).toBe("sec-1");
+    expect(result[0]!.path).toBe("01-intro");
+    expect(result[0]!.lessons).toEqual([
+      { id: "l-1", authoringStatus: "done", videos: [video()] },
+    ]);
+  });
+});

--- a/app/routes/_app.courses.$courseId._index.tsx
+++ b/app/routes/_app.courses.$courseId._index.tsx
@@ -251,7 +251,8 @@ export default function Component(props: Route.ComponentProps) {
 
   const handleBatchExport = () => {
     if (!loaderData.selectedVersion) return;
-    startBatchExportUpload(loaderData.selectedVersion.id);
+    // Course-view Export All ships the whole version — include every lesson.
+    startBatchExportUpload(loaderData.selectedVersion.id, true);
   };
 
   const lessonSelectionRef = useRef(lessonSelection);

--- a/app/routes/_app.courses.$courseId.publish.tsx
+++ b/app/routes/_app.courses.$courseId.publish.tsx
@@ -1,11 +1,11 @@
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useFocusRevalidate } from "@/hooks/use-focus-revalidate";
 import { UploadContext } from "@/features/upload-manager/upload-context";
 import { hasActiveExportUploads } from "@/features/upload-manager/export-status";
-import { generateChangelog } from "@/services/changelog-service";
 import { CoursePublishService } from "@/services/course-publish-service";
 import { CourseOperationsService } from "@/services/db-course-operations.server";
 import { VersionOperationsService } from "@/services/db-version-operations.server";
@@ -19,8 +19,6 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
-import Markdown from "react-markdown";
-import rehypeRaw from "rehype-raw";
 import { data, Link, useNavigate, useRevalidator } from "react-router";
 import type { Route } from "./+types/_app.courses.$courseId.publish";
 
@@ -44,19 +42,14 @@ export const loader = makeLoader({
         return yield* Effect.die(data("No version found", { status: 404 }));
       }
 
-      // Get changelog preview (treat draft as if it were published with a placeholder name)
-      const changelogVersions = allVersions.map((v) =>
-        v.id === latestVersion.id
-          ? { ...v, name: "(Draft — pending publish)" }
-          : v
-      );
-      const changelog = generateChangelog(changelogVersions);
-
       // Get previous published version name (allVersions is sorted newest first)
       const previousVersion = allVersions.length > 1 ? allVersions[1] : null;
 
-      // Get unexported videos and course-view lint count
-      const { unexportedVideoIds, courseViewLintCount } =
+      // Validation is computed for BOTH toggle positions in a single pass so the
+      // publish page can flip instantly with no server round-trip. `withTodo` is
+      // the default (everything ships); `withoutTodo` is what ships when to-do
+      // Lessons are withheld.
+      const { withTodo, withoutTodo } =
         yield* publishService.validatePublishability(latestVersion.id);
 
       const { sections: _, ...latestVersionMeta } = latestVersion;
@@ -64,22 +57,21 @@ export const loader = makeLoader({
         course,
         latestVersion: latestVersionMeta,
         previousVersionName: previousVersion?.name ?? null,
-        changelog,
-        unexportedVideoCount: unexportedVideoIds.length,
-        courseViewLintCount,
+        withTodo: {
+          unexportedVideoCount: withTodo.unexportedVideoIds.length,
+          courseViewLintCount: withTodo.courseViewLintCount,
+        },
+        withoutTodo: {
+          unexportedVideoCount: withoutTodo.unexportedVideoIds.length,
+          courseViewLintCount: withoutTodo.courseViewLintCount,
+        },
       };
     }),
 });
 
 export default function Component(props: Route.ComponentProps) {
-  const {
-    course,
-    latestVersion,
-    previousVersionName,
-    changelog,
-    unexportedVideoCount,
-    courseViewLintCount,
-  } = props.loaderData;
+  const { course, latestVersion, previousVersionName, withTodo, withoutTodo } =
+    props.loaderData;
   const navigate = useNavigate();
   const revalidator = useRevalidator();
   const { uploads, startBatchExportUpload, startPublish } =
@@ -87,6 +79,7 @@ export default function Component(props: Route.ComponentProps) {
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  const [includeTodoLessons, setIncludeTodoLessons] = useState(true);
   const [publishStarted, setPublishStarted] = useState(false);
 
   const hasActiveExport = hasActiveExportUploads(uploads);
@@ -109,6 +102,13 @@ export default function Component(props: Route.ComponentProps) {
     prevHadActiveExportRef.current = hasActiveExport;
   }, [hasActiveExport, revalidator]);
 
+  // The warnings and the publish button reflect whichever toggle position is
+  // currently selected — flipping the toggle switches them instantly, with no
+  // server round-trip.
+  const effective = includeTodoLessons ? withTodo : withoutTodo;
+  const unexportedVideoCount = effective.unexportedVideoCount;
+  const courseViewLintCount = effective.courseViewLintCount;
+
   const hasUnexportedVideos = unexportedVideoCount > 0;
   const hasCourseViewLints = courseViewLintCount > 0;
   const canPublish =
@@ -119,15 +119,29 @@ export default function Component(props: Route.ComponentProps) {
     !isOperationInProgress;
 
   const handleExportAll = useCallback(() => {
-    startBatchExportUpload(latestVersion.id);
-  }, [latestVersion.id, startBatchExportUpload]);
+    startBatchExportUpload(latestVersion.id, includeTodoLessons);
+  }, [latestVersion.id, includeTodoLessons, startBatchExportUpload]);
 
   const handlePublish = useCallback(() => {
     setPublishStarted(true);
-    startPublish(course.id, course.name, name.trim(), description.trim());
+    startPublish(
+      course.id,
+      course.name,
+      name.trim(),
+      description.trim(),
+      includeTodoLessons
+    );
     // Navigate back to course — progress shows in GlobalUploadProgress
     navigate(`/courses/${course.id}`);
-  }, [course.id, course.name, name, description, startPublish, navigate]);
+  }, [
+    course.id,
+    course.name,
+    name,
+    description,
+    includeTodoLessons,
+    startPublish,
+    navigate,
+  ]);
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -171,6 +185,31 @@ export default function Component(props: Route.ComponentProps) {
               disabled={publishStarted}
               rows={3}
             />
+          </div>
+        </div>
+
+        {/* Include to-do lessons toggle */}
+        <div className="mb-8 rounded-lg border border-border p-4">
+          <div className="flex items-start gap-3">
+            <Checkbox
+              id="include-todo"
+              checked={includeTodoLessons}
+              onCheckedChange={(checked) =>
+                setIncludeTodoLessons(checked === true)
+              }
+              disabled={publishStarted}
+              className="mt-0.5"
+            />
+            <div className="space-y-1">
+              <Label htmlFor="include-todo" className="font-medium">
+                Include lessons marked to-do
+              </Label>
+              <p className="text-sm text-muted-foreground">
+                {includeTodoLessons
+                  ? "Every lesson will publish — including lessons still marked to-do, which may be unreviewed. They are exported, mirrored to the team's Dropbox, and listed in course.json exactly like finished lessons."
+                  : "Lessons still marked to-do are withheld from this publish: omitted from course.json, not exported, and not mirrored to Dropbox. Any to-do lesson already in the team's Dropbox is removed, and sections left with no remaining lessons disappear. Nothing is lost — every lesson stays saved in full in the Published Version, and turning this back on and republishing restores it."}
+              </p>
+            </div>
           </div>
         </div>
 
@@ -225,14 +264,6 @@ export default function Component(props: Route.ComponentProps) {
                 ? "Export in progress..."
                 : "Publish"}
           </Button>
-        </div>
-
-        {/* Changelog Preview */}
-        <div className="border-t border-border pt-6">
-          <h2 className="text-lg font-semibold mb-4">Changelog Preview</h2>
-          <div className="prose dark:prose-invert max-w-none">
-            <Markdown rehypePlugins={[rehypeRaw]}>{changelog}</Markdown>
-          </div>
         </div>
       </div>
     </div>

--- a/app/routes/api.courseVersions.$versionId.batch-export-sse.ts
+++ b/app/routes/api.courseVersions.$versionId.batch-export-sse.ts
@@ -1,18 +1,31 @@
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { runtimeLive } from "@/services/layer.server";
 import { CoursePublishService } from "@/services/course-publish-service";
 import { createSSEResponse } from "@/lib/create-sse-response.server";
 import type { Route } from "./+types/api.courseVersions.$versionId.batch-export-sse";
 
+const batchExportSchema = Schema.Struct({
+  includeTodoLessons: Schema.optional(Schema.Boolean),
+});
+
 export const action = async (args: Route.ActionArgs) => {
   const { versionId } = args.params;
+  const body = await args.request.json().catch(() => ({}));
+  const parsed = Schema.decodeUnknownSync(batchExportSchema)(body);
+  // Default to include — Export All ships everything unless to-do Lessons are
+  // being withheld on the publish page.
+  const includeTodoLessons = parsed.includeTodoLessons ?? true;
 
   return createSSEResponse({
     runtime: runtimeLive,
     program: (sendEvent) =>
       Effect.gen(function* () {
         const publishService = yield* CoursePublishService;
-        yield* publishService.batchExport(versionId, sendEvent);
+        yield* publishService.batchExport(
+          versionId,
+          includeTodoLessons,
+          sendEvent
+        );
       }),
     errorHandlers: [
       {

--- a/app/routes/api.courseVersions.$versionId.unexported-videos.ts
+++ b/app/routes/api.courseVersions.$versionId.unexported-videos.ts
@@ -11,8 +11,12 @@ export const action = makeAction({
       const publishService = yield* CoursePublishService;
       const versionOps = yield* VersionOperationsService;
 
-      const { unexportedVideoIds } =
-        yield* publishService.validatePublishability(params.versionId!);
+      // This list backs the "unexported videos" detail view; it reflects the
+      // full course (include to-do Lessons), matching the default publish.
+      const { withTodo } = yield* publishService.validatePublishability(
+        params.versionId!
+      );
+      const { unexportedVideoIds } = withTodo;
 
       const version = yield* versionOps.getVersionWithSections(
         params.versionId!

--- a/app/routes/api.courses.$courseId.publish-sse.ts
+++ b/app/routes/api.courses.$courseId.publish-sse.ts
@@ -7,6 +7,7 @@ import { createSSEResponse } from "@/lib/create-sse-response.server";
 const publishSchema = Schema.Struct({
   name: Schema.String,
   description: Schema.optional(Schema.String),
+  includeTodoLessons: Schema.optional(Schema.Boolean),
 });
 
 export const action = async (args: Route.ActionArgs) => {
@@ -24,6 +25,7 @@ export const action = async (args: Route.ActionArgs) => {
           courseId,
           parsed.name,
           parsed.description ?? "",
+          parsed.includeTodoLessons ?? true,
           (stage) => {
             sendEvent("progress", { stage });
           }

--- a/app/routes/api.courses.publish-to-dropbox-sse.ts
+++ b/app/routes/api.courses.publish-to-dropbox-sse.ts
@@ -18,8 +18,11 @@ export const action = async ({ request }: Route.ActionArgs) => {
         const result = yield* Schema.decodeUnknown(publishRepoSchema)(body);
 
         const publishService = yield* CoursePublishService;
+        // Standalone Dropbox mirror (no publish-page toggle) — include every
+        // Lesson, matching the default publish behaviour.
         const { missingVideos } = yield* publishService.syncToDropbox(
           result.repoId,
+          true,
           sendEvent
         );
 

--- a/app/routes/api.courses.publish-to-dropbox.ts
+++ b/app/routes/api.courses.publish-to-dropbox.ts
@@ -18,6 +18,8 @@ export const action = makeAction({
       const result = yield* Schema.decodeUnknown(publishRepoSchema)(payload);
 
       const publishService = yield* CoursePublishService;
-      return yield* publishService.syncToDropbox(result.repoId);
+      // Standalone Dropbox mirror (no publish-page toggle) — include every
+      // Lesson, matching the default publish behaviour.
+      return yield* publishService.syncToDropbox(result.repoId, true);
     }),
 });

--- a/app/services/course-publish-service-sync.test.ts
+++ b/app/services/course-publish-service-sync.test.ts
@@ -198,7 +198,7 @@ describe("CoursePublishService.syncToDropbox", () => {
     await run(
       Effect.gen(function* () {
         const svc = yield* CoursePublishService;
-        yield* svc.syncToDropbox(course.id);
+        yield* svc.syncToDropbox(course.id, true);
       })
     );
 
@@ -221,7 +221,7 @@ describe("CoursePublishService.syncToDropbox", () => {
     await run(
       Effect.gen(function* () {
         const svc = yield* CoursePublishService;
-        yield* svc.syncToDropbox(course.id);
+        yield* svc.syncToDropbox(course.id, true);
       })
     );
 
@@ -244,7 +244,7 @@ describe("CoursePublishService.syncToDropbox", () => {
     await run(
       Effect.gen(function* () {
         const svc = yield* CoursePublishService;
-        yield* svc.syncToDropbox(course.id);
+        yield* svc.syncToDropbox(course.id, true);
       })
     );
 
@@ -270,7 +270,7 @@ describe("CoursePublishService.syncToDropbox", () => {
     await run(
       Effect.gen(function* () {
         const svc = yield* CoursePublishService;
-        yield* svc.syncToDropbox(course.id);
+        yield* svc.syncToDropbox(course.id, true);
       })
     );
 
@@ -314,7 +314,7 @@ describe("CoursePublishService.syncToDropbox", () => {
     await run(
       Effect.gen(function* () {
         const svc = yield* CoursePublishService;
-        yield* svc.syncToDropbox(course.id);
+        yield* svc.syncToDropbox(course.id, true);
       })
     );
 
@@ -337,7 +337,7 @@ describe("CoursePublishService.syncToDropbox", () => {
     await run(
       Effect.gen(function* () {
         const svc = yield* CoursePublishService;
-        yield* svc.syncToDropbox(course.id, (event, data) => {
+        yield* svc.syncToDropbox(course.id, true, (event, data) => {
           events.push({ event, data });
         });
       })
@@ -360,7 +360,7 @@ describe("CoursePublishService.syncToDropbox", () => {
     const result = await run(
       Effect.gen(function* () {
         const svc = yield* CoursePublishService;
-        return yield* svc.syncToDropbox(course.id);
+        return yield* svc.syncToDropbox(course.id, true);
       })
     );
 
@@ -373,7 +373,7 @@ describe("CoursePublishService.syncToDropbox", () => {
     await run(
       Effect.gen(function* () {
         const svc = yield* CoursePublishService;
-        yield* svc.syncToDropbox(course.id);
+        yield* svc.syncToDropbox(course.id, true);
       })
     );
 
@@ -394,7 +394,7 @@ describe("CoursePublishService.syncToDropbox", () => {
     await run(
       Effect.gen(function* () {
         const svc = yield* CoursePublishService;
-        yield* svc.syncToDropbox(course.id);
+        yield* svc.syncToDropbox(course.id, true);
       })
     );
 
@@ -417,7 +417,7 @@ describe("CoursePublishService.syncToDropbox", () => {
     await run(
       Effect.gen(function* () {
         const svc = yield* CoursePublishService;
-        yield* svc.syncToDropbox(course.id);
+        yield* svc.syncToDropbox(course.id, true);
       })
     );
 
@@ -439,7 +439,7 @@ describe("CoursePublishService.syncToDropbox", () => {
     await run(
       Effect.gen(function* () {
         const svc = yield* CoursePublishService;
-        yield* svc.syncToDropbox(course.id);
+        yield* svc.syncToDropbox(course.id, true);
       })
     );
 
@@ -453,6 +453,76 @@ describe("CoursePublishService.syncToDropbox", () => {
     const video = lesson.problem ?? lesson.explainer;
     expect(video.hash).not.toBeNull();
     expect(typeof video.hash).toBe("string");
+  });
+
+  // ── Withholding to-do lessons (includeTodoLessons = false) ──────────
+
+  it("withholds a to-do lesson's folder and omits it from course.json", async () => {
+    const { course, dropboxDir, run } = await setupSync();
+
+    await run(
+      Effect.gen(function* () {
+        const svc = yield* CoursePublishService;
+        yield* svc.syncToDropbox(course.id, false);
+      })
+    );
+
+    const courseDir = path.join(dropboxDir, "test-course");
+    // The "done" lesson ships…
+    expect(
+      fs.existsSync(
+        path.join(courseDir, "01-intro", "01.01-welcome", "Problem.mp4")
+      )
+    ).toBe(true);
+    // …the "todo" lesson does not.
+    expect(fs.existsSync(path.join(courseDir, "01-intro", "01.02-setup"))).toBe(
+      false
+    );
+
+    const doc = JSON.parse(
+      fs.readFileSync(path.join(courseDir, "course.json"), "utf-8")
+    );
+    expect(doc.sections).toHaveLength(1);
+    expect(doc.sections[0].lessons).toHaveLength(1);
+  });
+
+  it("removes a previously-published to-do lesson when it is later withheld", async () => {
+    const { course, dropboxDir, run } = await setupSync();
+
+    // First publish includes the to-do lesson…
+    await run(
+      Effect.gen(function* () {
+        const svc = yield* CoursePublishService;
+        yield* svc.syncToDropbox(course.id, true);
+      })
+    );
+    const todoDir = path.join(
+      dropboxDir,
+      "test-course",
+      "01-intro",
+      "01.02-setup"
+    );
+    expect(fs.existsSync(path.join(todoDir, "Explainer.mp4"))).toBe(true);
+
+    // …a later publish withholds it, and the stale-file cleanup deletes it.
+    await run(
+      Effect.gen(function* () {
+        const svc = yield* CoursePublishService;
+        yield* svc.syncToDropbox(course.id, false);
+      })
+    );
+    expect(fs.existsSync(todoDir)).toBe(false);
+    expect(
+      fs.existsSync(
+        path.join(
+          dropboxDir,
+          "test-course",
+          "01-intro",
+          "01.01-welcome",
+          "Problem.mp4"
+        )
+      )
+    ).toBe(true);
   });
 });
 

--- a/app/services/course-publish-service.test.ts
+++ b/app/services/course-publish-service.test.ts
@@ -340,7 +340,7 @@ describe("CoursePublishService", () => {
       const result = await run(
         Effect.gen(function* () {
           const svc = yield* CoursePublishService;
-          return yield* svc.validatePublishability(version.id);
+          return (yield* svc.validatePublishability(version.id)).withTodo;
         })
       );
 
@@ -359,7 +359,7 @@ describe("CoursePublishService", () => {
       const result = await run(
         Effect.gen(function* () {
           const svc = yield* CoursePublishService;
-          return yield* svc.validatePublishability(version.id);
+          return (yield* svc.validatePublishability(version.id)).withTodo;
         })
       );
 
@@ -375,7 +375,7 @@ describe("CoursePublishService", () => {
       await run(
         Effect.gen(function* () {
           const svc = yield* CoursePublishService;
-          yield* svc.batchExport(version.id, (event, data) => {
+          yield* svc.batchExport(version.id, true, (event, data) => {
             events.push({ event, data });
           });
         })
@@ -408,7 +408,7 @@ describe("CoursePublishService", () => {
       await run(
         Effect.gen(function* () {
           const svc = yield* CoursePublishService;
-          yield* svc.batchExport(version.id, (event, data) => {
+          yield* svc.batchExport(version.id, true, (event, data) => {
             events.push({ event, data });
           });
         })
@@ -460,7 +460,7 @@ describe("CoursePublishService", () => {
       const before = await run(
         Effect.gen(function* () {
           const svc = yield* CoursePublishService;
-          return yield* svc.validatePublishability(version.id);
+          return (yield* svc.validatePublishability(version.id)).withTodo;
         })
       );
       expect(before.unexportedVideoIds).toContain(video.id);
@@ -477,7 +477,7 @@ describe("CoursePublishService", () => {
       const after = await run(
         Effect.gen(function* () {
           const svc = yield* CoursePublishService;
-          return yield* svc.validatePublishability(version.id);
+          return (yield* svc.validatePublishability(version.id)).withTodo;
         })
       );
       expect(after.unexportedVideoIds).toEqual([]);
@@ -491,7 +491,7 @@ describe("CoursePublishService", () => {
       const result = await run(
         Effect.gen(function* () {
           const svc = yield* CoursePublishService;
-          return yield* svc.validatePublishability(version.id);
+          return (yield* svc.validatePublishability(version.id)).withTodo;
         })
       );
 
@@ -585,7 +585,7 @@ describe("CoursePublishService", () => {
       const result = await run(
         Effect.gen(function* () {
           const svc = yield* CoursePublishService;
-          return yield* svc.validatePublishability(version.id);
+          return (yield* svc.validatePublishability(version.id)).withTodo;
         })
       );
 
@@ -601,14 +601,16 @@ describe("CoursePublishService", () => {
       const result = await run(
         Effect.gen(function* () {
           const svc = yield* CoursePublishService;
-          return yield* svc.publish(course.id, "v1.0", "First release").pipe(
-            Effect.catchTag("PublishValidationError", (e) =>
-              Effect.succeed({
-                error: true,
-                unexportedVideoIds: e.unexportedVideoIds,
-              })
-            )
-          );
+          return yield* svc
+            .publish(course.id, "v1.0", "First release", true)
+            .pipe(
+              Effect.catchTag("PublishValidationError", (e) =>
+                Effect.succeed({
+                  error: true,
+                  unexportedVideoIds: e.unexportedVideoIds,
+                })
+              )
+            );
         })
       );
 

--- a/app/services/course-publish-service.ts
+++ b/app/services/course-publish-service.ts
@@ -19,7 +19,10 @@ import {
   resolveSectionsWithVideos,
 } from "./publish-to-dropbox";
 import { computeCourseViewLintCount } from "./lesson-warnings";
-import { buildCourseJson } from "./course-json";
+import {
+  buildCourseJson,
+  computeEffectiveSections,
+} from "@/packages/course-json";
 
 export class PublishValidationError extends Data.TaggedError(
   "PublishValidationError"
@@ -178,10 +181,18 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
 
       const batchExport = Effect.fn("batchExport")(function* (
         versionId: string,
+        includeTodoLessons: boolean,
         sendEvent?: (event: string, data: unknown) => void
       ) {
         const version = yield* versionOps.getVersionWithSections(versionId);
         const courseId = version.repo.id;
+
+        // Export only what this publish will ship — the effective Sections for
+        // the current toggle. Withheld to-do Lessons' Videos are not exported.
+        const effectiveSections = computeEffectiveSections(
+          version.sections,
+          includeTodoLessons
+        );
 
         // Find unexported videos
         const unexportedVideos: Array<{
@@ -189,7 +200,7 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
           title: string;
         }> = [];
 
-        for (const section of version.sections) {
+        for (const section of effectiveSections) {
           for (const lesson of section.lessons) {
             for (const video of lesson.videos) {
               if (video.clips.length === 0) continue;
@@ -252,12 +263,17 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
         yield* garbageCollect(courseId);
       });
 
+      // Validation gates on the effective output — the set of Lessons this
+      // publish actually ships. Because the toggle can flip on the publish page
+      // with no round-trip, both positions are computed in a single pass: the
+      // expensive per-Video existence checks run once, then the pure counters
+      // run against the effective Sections for each toggle state.
       const validatePublishability = Effect.fn("validatePublishability")(
         function* (versionId: string) {
           const version = yield* versionOps.getVersionWithSections(versionId);
           const courseId = version.repo.id;
 
-          const unexportedVideoIds: string[] = [];
+          const exportedById = new Map<string, boolean>();
           for (const section of version.sections) {
             for (const lesson of section.lessons) {
               for (const video of lesson.videos) {
@@ -269,22 +285,41 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
                   courseId,
                   hash
                 );
-                if (!(yield* effectFs.exists(filePath))) {
-                  unexportedVideoIds.push(video.id);
-                }
+                exportedById.set(video.id, yield* effectFs.exists(filePath));
               }
             }
           }
 
-          const courseViewLintCount = computeCourseViewLintCount(
-            version.sections
-          );
-          return { unexportedVideoIds, courseViewLintCount };
+          const evaluate = (includeTodoLessons: boolean) => {
+            const effectiveSections = computeEffectiveSections(
+              version.sections,
+              includeTodoLessons
+            );
+            const unexportedVideoIds: string[] = [];
+            for (const section of effectiveSections) {
+              for (const lesson of section.lessons) {
+                for (const video of lesson.videos) {
+                  if (exportedById.get(video.id) === false) {
+                    unexportedVideoIds.push(video.id);
+                  }
+                }
+              }
+            }
+            const courseViewLintCount =
+              computeCourseViewLintCount(effectiveSections);
+            return { unexportedVideoIds, courseViewLintCount };
+          };
+
+          return {
+            withTodo: evaluate(true),
+            withoutTodo: evaluate(false),
+          };
         }
       );
 
       const syncToDropbox = Effect.fn("syncToDropbox")(function* (
         courseId: string,
+        includeTodoLessons: boolean,
         onProgress?: (event: string, data: unknown) => void
       ) {
         const latestVersion =
@@ -305,8 +340,18 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
             versionId: latestVersion.id,
           });
 
+        // The effective Sections are the single source of "what this publish
+        // ships". The Dropbox mirror and course.json both read from it, so they
+        // can never disagree. Withheld to-do Lessons are absent here; the
+        // stale-file cleanup below removes any of their previously-published
+        // folders. Sections left with no shippable Lessons disappear entirely.
+        const effectiveSections = computeEffectiveSections(
+          repoWithSections.sections,
+          includeTodoLessons
+        );
+
         const videoPathOverrides = new Map<string, string>();
-        for (const section of repoWithSections.sections) {
+        for (const section of effectiveSections) {
           for (const lesson of section.lessons) {
             for (const video of lesson.videos) {
               if (video.clips.length > 0) {
@@ -327,7 +372,7 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
         }
 
         const { sections, missingVideos } = yield* resolveSectionsWithVideos({
-          sectionsInDb: repoWithSections.sections,
+          sectionsInDb: effectiveSections,
           finishedVideosDirectory: FINISHED_VIDEOS_DIRECTORY,
           videoPathOverrides,
         });
@@ -396,6 +441,7 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
           courseId,
           courseName: repoWithSections.name,
           sections: repoWithSections.sections,
+          includeTodoLessons,
         });
         const courseJsonPath = path.join(dropboxCourseDir, "course.json");
         yield* effectFs.makeDirectory(dropboxCourseDir, { recursive: true });
@@ -443,6 +489,7 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
         courseId: string,
         versionName: string,
         versionDescription: string,
+        includeTodoLessons: boolean,
         onProgress?: (
           stage:
             | "validating"
@@ -460,8 +507,13 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
           return yield* Effect.die(new Error("No version found for course"));
         }
 
-        const { unexportedVideoIds, courseViewLintCount } =
-          yield* validatePublishability(latestVersion.id);
+        // Gate on the effective output for the chosen toggle: an unfinished
+        // to-do Lesson that is being withheld must not block a publish that is
+        // not shipping it.
+        const validation = yield* validatePublishability(latestVersion.id);
+        const { unexportedVideoIds, courseViewLintCount } = includeTodoLessons
+          ? validation.withTodo
+          : validation.withoutTodo;
         if (unexportedVideoIds.length > 0 || courseViewLintCount > 0) {
           return yield* new PublishValidationError({
             unexportedVideoIds,
@@ -470,7 +522,7 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
         }
 
         onProgress?.("uploading");
-        yield* syncToDropbox(courseId);
+        yield* syncToDropbox(courseId, includeTodoLessons);
 
         onProgress?.("freezing");
         yield* versionOps.updateCourseVersion({


### PR DESCRIPTION
Closes #1250.

## What

Adds a single course-wide **"Include lessons marked to-do"** toggle to the publish page, defaulting **on** (today's behaviour). When **off**, every Lesson still marked to-do is **withheld** from that publish: not exported, not mirrored to Dropbox, and omitted from `course.json`. Sections left with no shippable Lessons disappear, and a previously-published to-do Lesson is removed from the team's Dropbox by the existing stale-file cleanup. The frozen Published Version snapshot is untouched, so withholding is fully reversible — flip the toggle back on (or mark the Lesson done) and republish.

## How

- **One pure effective-output selector** (`computeEffectiveSections`) is the single home of "what this publish ships": export, validation, the Dropbox mirror, and `buildCourseJson` all consume it. A Lesson is effective iff it has ≥1 active (non-archived) Video **and** is not withheld (withheld = toggle off **and** `authoringStatus === "todo"`); a Section is effective iff it retains ≥1 effective Lesson.
- **Fixes the brittle Section-skip bug**: Sections are now emitted on whether they contain shippable Lessons, not on a derived path — no empty `lessons` arrays, and real Sections never wrongly vanish.
- **Deep-module package**: the selector and the course.json builder live in `app/packages/course-json` behind a single entry-point seam (`index.ts`); `lib/` + `tests/` are private. Conforms to the boundary rules from #1249 (linter passes, 0 violations).
- **Publish page**: validation is computed for **both** toggle states in a single filesystem pass, so warnings and the publish button react instantly on flip with no server round-trip. State-dependent copy explains the consequence of the current position. The deprecated changelog live preview is removed (changelog service left intact).
- **Plumbing**: `includeTodoLessons` threads through the publish/export triggers → SSE request schemas → publish service (validate/sync/export). Standalone Dropbox mirror and course-view "Export All" hardcode `true` to preserve current behaviour.

## Testing

- New pure unit tests for the selector (`effective-sections.test.ts`).
- Extended `course-json` tests: no Section emitted with an empty `lessons` array; to-do Lessons withheld when excluded.
- Extended sync integration tests: with the toggle off a withheld Lesson's folder is absent, and a previously-published now-withheld Lesson's folder is deleted by the cleanup.
- Typecheck, boundary linter, and file-token checks pass (all re-run in the pre-commit hook). All touched suites green.

## Out of scope

No changelog rework or toggle-awareness, no per-Lesson selection, no per-version persistence of the toggle, no change to the frozen snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)