### PR TITLE
feat: emit course.schema.json sidecar alongside course.json

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,7 +33,7 @@ An immutable CourseVersion with a name and description, created by the Publish f
 _Avoid_: Released version, Committed version
 
 **Publish**:
-The atomic operation that uploads to Dropbox, freezes the Draft Version as a Published Version (setting name/description), and clones a new Draft Version. Its structure is derived from the database (not parsed from disk); its Dropbox output is exclusively `.mp4` video files plus a single `course.json` — no sidecar files (`.transcript.md`, `.body.md`, `.meta.json`, `TODO.md`) and no `changelog.md`.
+The atomic operation that uploads to Dropbox, freezes the Draft Version as a Published Version (setting name/description), and clones a new Draft Version. Its structure is derived from the database (not parsed from disk); its Dropbox output is exclusively `.mp4` video files plus a single `course.json` and its companion `course.schema.json` (the JSON Schema describing course.json, referenced by course.json's `$schema` field) — no authoring sidecar files (`.transcript.md`, `.body.md`, `.meta.json`, `TODO.md`) and no `changelog.md`.
 _Avoid_: Commit, Deploy, Push
 
 **Export Version Key**:

--- a/app/packages/course-json/index.ts
+++ b/app/packages/course-json/index.ts
@@ -9,9 +9,14 @@
 // is also exported directly because export, validation, and the Dropbox mirror
 // read the same effective Sections — so there is exactly one notion of what a
 // publish ships.
+//
+// `buildCourseJsonSchema` derives the JSON Schema sidecar (`course.schema.json`)
+// from the same `CourseJsonDocumentSchema` that types the manifest — one source
+// of truth for both the data and the schema published beside it.
 
 export {
   buildCourseJson,
+  buildCourseJsonSchema,
   CourseJsonDocumentSchema,
   InvalidLessonRoleComboError,
   type BuildCourseJsonInput,

--- a/app/packages/course-json/lib/build-course-json.ts
+++ b/app/packages/course-json/lib/build-course-json.ts
@@ -1,4 +1,4 @@
-import { Data, Effect, Schema } from "effect";
+import { Data, Effect, JSONSchema, Schema } from "effect";
 import { computeExportHash, type ExportClip } from "@/services/export-hash";
 import { computeEffectiveSections } from "./effective-sections";
 import {
@@ -9,56 +9,149 @@ import { buildChapters } from "@/services/publish-to-dropbox";
 
 // ── Schema ──────────────────────────────────────────────────────────────
 
+// Descriptions on every field are load-bearing: `buildCourseJsonSchema` turns
+// this schema into the `course.schema.json` sidecar via `JSONSchema.make`, which
+// reads these annotations verbatim. Keep them in the domain's language (see
+// CONTEXT.md) — this is the published contract for a course.json.
+
 const CourseJsonChapter = Schema.Struct({
-  title: Schema.String,
-  startTime: Schema.Number,
+  title: Schema.String.annotations({
+    description: "The chapter name shown to viewers; maps 1:1 to a YouTube chapter.",
+  }),
+  startTime: Schema.Number.annotations({
+    description:
+      "Offset in seconds from the start of the video where this chapter begins.",
+  }),
+}).annotations({
+  description:
+    "A named marker within a video's timeline that groups related clips.",
 });
 
 const CourseJsonVideo = Schema.Struct({
-  id: Schema.String,
-  body: Schema.NullOr(Schema.String),
-  description: Schema.NullOr(Schema.String),
-  hash: Schema.NullOr(Schema.String),
-  chapters: Schema.Array(CourseJsonChapter),
+  id: Schema.String.annotations({
+    description: "Stable lineage id of the video, carried across course versions.",
+  }),
+  body: Schema.NullOr(Schema.String).annotations({
+    description:
+      "Long-form written companion to the video (its article body), or null when none was authored.",
+  }),
+  description: Schema.NullOr(Schema.String).annotations({
+    description: "Short description of the video, or null when none was authored.",
+  }),
+  hash: Schema.NullOr(Schema.String).annotations({
+    description:
+      "Export Hash identifying the rendered .mp4 (SHA256 of the video's clip filenames, timestamps, order, and Export Version Key); null when the video has no exportable clips.",
+  }),
+  chapters: Schema.Array(CourseJsonChapter).annotations({
+    description: "The video's chapters, in timeline order.",
+  }),
+}).annotations({
+  description:
+    "A single producible video output — a container of clips and chapters.",
 });
 
 const ExplainerLessonSchema = Schema.Struct({
-  type: Schema.Literal("explainer"),
-  id: Schema.String,
-  title: Schema.String,
-  description: Schema.String,
-  explainer: CourseJsonVideo,
+  type: Schema.Literal("explainer").annotations({
+    description: "Discriminant marking this lesson as a single-video explainer.",
+  }),
+  id: Schema.String.annotations({
+    description: "Stable lineage id of the lesson, carried across course versions.",
+  }),
+  title: Schema.String.annotations({
+    description: "The lesson title shown to learners.",
+  }),
+  description: Schema.String.annotations({
+    description: "Short description of the lesson.",
+  }),
+  explainer: CourseJsonVideo.annotations({
+    description: "The explainer video that delivers this lesson.",
+  }),
+}).annotations({
+  description:
+    "A lesson delivered as a single explainer video (no problem/solution split).",
 });
 
 const ProblemLessonSchema = Schema.Struct({
-  type: Schema.Literal("problem"),
-  id: Schema.String,
-  title: Schema.String,
-  description: Schema.String,
-  problem: CourseJsonVideo,
-  solution: Schema.optional(CourseJsonVideo),
+  type: Schema.Literal("problem").annotations({
+    description: "Discriminant marking this lesson as a problem/solution pair.",
+  }),
+  id: Schema.String.annotations({
+    description: "Stable lineage id of the lesson, carried across course versions.",
+  }),
+  title: Schema.String.annotations({
+    description: "The lesson title shown to learners.",
+  }),
+  description: Schema.String.annotations({
+    description: "Short description of the lesson.",
+  }),
+  problem: CourseJsonVideo.annotations({
+    description: "The problem video the learner attempts.",
+  }),
+  solution: Schema.optional(
+    CourseJsonVideo.annotations({
+      description:
+        "The worked-solution video; present only when the lesson ships a solution.",
+    })
+  ),
+}).annotations({
+  description:
+    "A lesson delivered as a problem video with an optional worked-solution video.",
 });
 
 const CourseJsonLessonSchema = Schema.Union(
   ExplainerLessonSchema,
   ProblemLessonSchema
-);
+).annotations({
+  description: "A single learning unit within a section.",
+});
 
 const CourseJsonSectionSchema = Schema.Struct({
-  id: Schema.String,
-  title: Schema.String,
-  description: Schema.String,
-  lessons: Schema.Array(CourseJsonLessonSchema),
+  id: Schema.String.annotations({
+    description: "Stable lineage id of the section, carried across course versions.",
+  }),
+  title: Schema.String.annotations({
+    description: "The section title shown to learners.",
+  }),
+  description: Schema.String.annotations({
+    description: "Short description of the section.",
+  }),
+  lessons: Schema.Array(CourseJsonLessonSchema).annotations({
+    description: "The lessons that ship in this section, in display order.",
+  }),
+}).annotations({
+  description: "A grouping of lessons within the course, in display order.",
 });
 
 export const CourseJsonDocumentSchema = Schema.Struct({
-  schemaVersion: Schema.Literal(2),
-  courseId: Schema.String,
-  courseName: Schema.String,
-  sections: Schema.Array(CourseJsonSectionSchema),
+  $schema: Schema.optional(Schema.String).annotations({
+    description:
+      "Relative path to the JSON Schema describing this document (course.schema.json).",
+  }),
+  schemaVersion: Schema.Literal(2).annotations({
+    description: "Version of the course.json manifest format.",
+  }),
+  courseId: Schema.String.annotations({
+    description: "Stable identifier of the course this manifest snapshots.",
+  }),
+  courseName: Schema.String.annotations({
+    description: "Human-readable name of the course.",
+  }),
+  sections: Schema.Array(CourseJsonSectionSchema).annotations({
+    description: "The sections that ship in this course, in display order.",
+  }),
+}).annotations({
+  title: "Course Manifest",
+  description:
+    "The published manifest of a course — an immutable snapshot of its sections, lessons, and videos, emitted alongside the exported .mp4 files at publish time.",
 });
 
 export type CourseJsonDocument = typeof CourseJsonDocumentSchema.Type;
+
+// The JSON Schema sidecar (`course.schema.json`) generated from
+// `CourseJsonDocumentSchema`. A pure function of the schema — invariant across
+// courses and publishes — so callers can write it verbatim next to course.json.
+export const buildCourseJsonSchema = (): JSONSchema.JsonSchema7Root =>
+  JSONSchema.make(CourseJsonDocumentSchema);
 
 // ── Error ───────────────────────────────────────────────────────────────
 
@@ -225,6 +318,7 @@ export const buildCourseJson = (
     }
 
     return {
+      $schema: "./course.schema.json",
       schemaVersion: 2 as const,
       courseId: input.courseId,
       courseName: input.courseName,

--- a/app/services/course-publish-service-sync.test.ts
+++ b/app/services/course-publish-service-sync.test.ts
@@ -238,7 +238,7 @@ describe("CoursePublishService.syncToDropbox", () => {
     ).toBe(true);
   });
 
-  it("writes only .mp4 and course.json — no sidecars", async () => {
+  it("writes only .mp4, course.json, and course.schema.json — no authoring sidecars", async () => {
     const { course, dropboxDir, run } = await setupSync();
 
     await run(
@@ -256,6 +256,7 @@ describe("CoursePublishService.syncToDropbox", () => {
       "01-intro/01.01-welcome/Problem.mp4",
       "01-intro/01.02-setup/Explainer.mp4",
       "course.json",
+      "course.schema.json",
     ]);
   });
 

--- a/app/services/course-publish-service.ts
+++ b/app/services/course-publish-service.ts
@@ -21,6 +21,7 @@ import {
 import { computeCourseViewLintCount } from "./lesson-warnings";
 import {
   buildCourseJson,
+  buildCourseJsonSchema,
   computeEffectiveSections,
 } from "@/packages/course-json";
 
@@ -450,6 +451,15 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
           JSON.stringify(courseJsonDoc, null, 2)
         );
         filesSupposedToBeInDropbox.add(courseJsonPath);
+
+        // Emit the JSON Schema sidecar beside course.json (referenced by its
+        // `$schema` field), so editors and validators can resolve it locally.
+        const courseSchemaPath = path.join(dropboxCourseDir, "course.schema.json");
+        yield* effectFs.writeFileString(
+          courseSchemaPath,
+          JSON.stringify(buildCourseJsonSchema(), null, 2)
+        );
+        filesSupposedToBeInDropbox.add(courseSchemaPath);
 
         const dropboxExists = yield* effectFs.exists(dropboxCourseDir);
         if (dropboxExists) {


### PR DESCRIPTION
## What

Every publish now writes a JSON Schema sidecar — `course.schema.json` — next to `course.json` in the Dropbox course dir, derived from `CourseJsonDocumentSchema` via Effect's built-in `JSONSchema.make`. **No new dependency.**

## Changes

- **Descriptions on every field** of `CourseJsonDocumentSchema` and its sub-structs (`CourseJsonChapter`, `CourseJsonVideo`, lesson/section structs), plus role-specific descriptions on the `explainer`/`problem`/`solution`/`sections`/`lessons` slots and a top-level `title`/`description`. Wording is drawn from `CONTEXT.md`'s ubiquitous language (e.g. `hash` cites the Export Hash / Export Version Key). These annotations are load-bearing — `JSONSchema.make` reads them verbatim into the emitted schema.
- **Self-reference** — `course.json` now carries `"$schema": "./course.schema.json"`, and `CourseJsonDocumentSchema` gains an **optional** `$schema` field so the document still validates against its own schema (which emits `additionalProperties: false`). Verified at runtime with a round-trip `ajv` validation.
- **New seam** — `buildCourseJsonSchema()` exported from the `course-json` package, keeping the schema owned by the package that owns `CourseJsonDocumentSchema`.
- **Publish service** writes the sidecar pretty-printed and registers it in `filesSupposedToBeInDropbox` so the cleanup pass keeps it.
- **Docs/tests** — updated the "no sidecars" publish test (relabelled "no *authoring* sidecars") and `CONTEXT.md`'s `Publish` definition to reflect the intended companion file.

## Verification

- Typecheck clean on all changed files.
- `course-publish-service-sync.test.ts` (13 tests) and the `course-json` package tests (39 tests) pass.
- One-off round-trip: a built `course.json` (including its `$schema` field) validates against the generated schema via `ajv`.

## Not in this PR

Refactoring `course-publish-service.ts` into a deep module — agreed to be tracked separately, as it touches ~10 importers and is a design question in its own right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)