### PR TITLE
Drop internal descriptions & order from course.json export

### DIFF
--- a/app/packages/course-json/lib/build-course-json.ts
+++ b/app/packages/course-json/lib/build-course-json.ts
@@ -40,7 +40,7 @@ const CourseJsonVideo = Schema.Struct({
   }),
   hash: Schema.NullOr(Schema.String).annotations({
     description:
-      "Export Hash identifying the rendered .mp4 (SHA256 of the video's clip filenames, timestamps, order, and Export Version Key); null when the video has no exportable clips.",
+      "Export Hash identifying the rendered .mp4 (SHA256 of the video's clip filenames and timestamps in sequence, plus the Export Version Key); null when the video has no exportable clips.",
   }),
   chapters: Schema.Array(CourseJsonChapter).annotations({
     description: "The video's chapters, in timeline order.",
@@ -60,9 +60,6 @@ const ExplainerLessonSchema = Schema.Struct({
   title: Schema.String.annotations({
     description: "The lesson title shown to learners.",
   }),
-  description: Schema.String.annotations({
-    description: "Short description of the lesson.",
-  }),
   explainer: CourseJsonVideo.annotations({
     description: "The explainer video that delivers this lesson.",
   }),
@@ -80,9 +77,6 @@ const ProblemLessonSchema = Schema.Struct({
   }),
   title: Schema.String.annotations({
     description: "The lesson title shown to learners.",
-  }),
-  description: Schema.String.annotations({
-    description: "Short description of the lesson.",
   }),
   problem: CourseJsonVideo.annotations({
     description: "The problem video the learner attempts.",
@@ -111,9 +105,6 @@ const CourseJsonSectionSchema = Schema.Struct({
   }),
   title: Schema.String.annotations({
     description: "The section title shown to learners.",
-  }),
-  description: Schema.String.annotations({
-    description: "Short description of the section.",
   }),
   lessons: Schema.Array(CourseJsonLessonSchema).annotations({
     description: "The lessons that ship in this section, in display order.",
@@ -221,7 +212,6 @@ function toVideoEntry(video: InputVideo): typeof CourseJsonVideo.Type {
     videoFilename: c.videoFilename,
     sourceStartTime: c.sourceStartTime,
     sourceEndTime: c.sourceEndTime,
-    order: c.order,
   }));
   return {
     id: video.lineageId,
@@ -278,7 +268,6 @@ export const buildCourseJson = (
               type: "problem",
               id: lesson.lineageId,
               title: lesson.title,
-              description: lesson.description,
               problem: toVideoEntry(problem.video),
               solution: toVideoEntry(solution.video),
             });
@@ -287,7 +276,6 @@ export const buildCourseJson = (
               type: "problem",
               id: lesson.lineageId,
               title: lesson.title,
-              description: lesson.description,
               problem: toVideoEntry(problem.video),
             });
           }
@@ -297,7 +285,6 @@ export const buildCourseJson = (
             type: "explainer",
             id: lesson.lineageId,
             title: lesson.title,
-            description: lesson.description,
             explainer: toVideoEntry(video),
           });
         }
@@ -312,7 +299,6 @@ export const buildCourseJson = (
       sections.push({
         id: section.lineageId,
         title: section.title,
-        description: section.description,
         lessons,
       });
     }

--- a/app/packages/course-json/tests/course-json.test.ts
+++ b/app/packages/course-json/tests/course-json.test.ts
@@ -172,7 +172,6 @@ describe("buildCourseJson", () => {
     expect(lesson).toMatchObject({
       type: "explainer",
       title: "Welcome",
-      description: "A welcome lesson",
       explainer: {
         body: "# Hello",
         description: "SEO text",
@@ -180,6 +179,9 @@ describe("buildCourseJson", () => {
         chapters: [],
       },
     });
+    // The lesson's own description is an author-facing internal note and is
+    // never emitted; only the video keeps its (user-facing) description.
+    expect(lesson).not.toHaveProperty("description");
     expect(lesson).not.toHaveProperty("path");
     if (lesson.type === "explainer") {
       expect(lesson.explainer).not.toHaveProperty("path");
@@ -515,9 +517,9 @@ describe("buildCourseJson", () => {
     expect(error._tag).toBe("InvalidLessonRoleComboError");
   });
 
-  // ── Section description passthrough ────────────────────────────────
+  // ── Section description withheld ───────────────────────────────────
 
-  it("includes section description", async () => {
+  it("omits the section description (an internal author-facing note)", async () => {
     const result = await run(
       makeInput([
         makeSection({
@@ -533,7 +535,7 @@ describe("buildCourseJson", () => {
       ])
     );
 
-    expect(result.sections[0]!.description).toBe("Introduction section");
+    expect(result.sections[0]!).not.toHaveProperty("description");
   });
 
   // ── Section title passthrough ──────────────────────────────────────

--- a/app/services/course-publish-service.test.ts
+++ b/app/services/course-publish-service.test.ts
@@ -145,13 +145,11 @@ const setup = async () => {
       videoFilename: "recording.mp4",
       sourceStartTime: 0,
       sourceEndTime: 10,
-      order: "a0",
     },
     {
       videoFilename: "recording.mp4",
       sourceStartTime: 15,
       sourceEndTime: 25,
-      order: "a1",
     },
   ];
   const exportHash = computeExportHash(clips)!;

--- a/app/services/course-publish-service.ts
+++ b/app/services/course-publish-service.ts
@@ -59,7 +59,6 @@ const toExportClips = (
     videoFilename: c.videoFilename,
     sourceStartTime: c.sourceStartTime,
     sourceEndTime: c.sourceEndTime,
-    order: c.order,
   }));
 
 type ExportOwner =

--- a/app/services/export-hash.test.ts
+++ b/app/services/export-hash.test.ts
@@ -16,7 +16,6 @@ const makeClip = (
   overrides: Partial<ExportClip> &
     Pick<ExportClip, "videoFilename" | "sourceStartTime" | "sourceEndTime">
 ): ExportClip => ({
-  order: "a0",
   ...overrides,
 });
 
@@ -43,13 +42,11 @@ describe("export-hash", () => {
           videoFilename: "rec.mp4",
           sourceStartTime: 0,
           sourceEndTime: 10,
-          order: "a0",
         }),
         makeClip({
           videoFilename: "rec2.mp4",
           sourceStartTime: 5,
           sourceEndTime: 15,
-          order: "a1",
         }),
       ];
       const hash1 = computeExportHash(clips);
@@ -57,36 +54,20 @@ describe("export-hash", () => {
       expect(hash1).toBe(hash2);
     });
 
-    it("sorts clips by order field before hashing", () => {
-      const clipsAB = [
-        makeClip({
-          videoFilename: "a.mp4",
-          sourceStartTime: 0,
-          sourceEndTime: 5,
-          order: "a0",
-        }),
-        makeClip({
-          videoFilename: "b.mp4",
-          sourceStartTime: 0,
-          sourceEndTime: 5,
-          order: "a1",
-        }),
-      ];
-      const clipsBA = [
-        makeClip({
-          videoFilename: "b.mp4",
-          sourceStartTime: 0,
-          sourceEndTime: 5,
-          order: "a1",
-        }),
-        makeClip({
-          videoFilename: "a.mp4",
-          sourceStartTime: 0,
-          sourceEndTime: 5,
-          order: "a0",
-        }),
-      ];
-      expect(computeExportHash(clipsAB)).toBe(computeExportHash(clipsBA));
+    it("hashes clips in the given array order, not a re-sorted one", () => {
+      const a = makeClip({
+        videoFilename: "a.mp4",
+        sourceStartTime: 0,
+        sourceEndTime: 5,
+      });
+      const b = makeClip({
+        videoFilename: "b.mp4",
+        sourceStartTime: 0,
+        sourceEndTime: 5,
+      });
+      // Clip sequence lives in the array itself — reordering the same clips is a
+      // different edit and must produce a different hash (and thus re-export).
+      expect(computeExportHash([a, b])).not.toBe(computeExportHash([b, a]));
     });
 
     it("transcript text changes do not affect the hash", () => {

--- a/app/services/export-hash.ts
+++ b/app/services/export-hash.ts
@@ -13,26 +13,24 @@ export type ExportClip = {
   videoFilename: string;
   sourceStartTime: number;
   sourceEndTime: number;
-  order: string;
 };
 
 /**
  * Compute the content-addressed export hash for a set of clips.
  * Returns null if there are no clips (not a real video).
  *
- * Hash is deterministic: clips are sorted by their `order` field,
- * and only video-affecting fields are included (not transcript text).
+ * Hash is deterministic: clip sequence is taken as given (callers pass clips
+ * already in playback order), and only video-affecting fields are included
+ * (not transcript text). Clip order therefore lives in the array itself — it is
+ * never re-derived from an `order` field, so reordering a video's clips yields a
+ * new hash and triggers a re-export.
  */
 export const computeExportHash = (clips: ExportClip[]): string | null => {
   if (clips.length === 0) return null;
 
-  const sorted = [...clips].sort((a, b) =>
-    a.order < b.order ? -1 : a.order > b.order ? 1 : 0
-  );
-
   const payload = {
     v: EXPORT_VERSION,
-    clips: sorted.map((c) => ({
+    clips: clips.map((c) => ({
       f: c.videoFilename,
       s: c.sourceStartTime,
       e: c.sourceEndTime,


### PR DESCRIPTION
## What

Two adjustments to what `course.json` (and its `course.schema.json` sidecar) emits, both requested this session.

### 1. Withhold author-facing descriptions
- **Lesson `description`** and **section `description`** are internal authoring notes — they describe the unit *for Matt*, not for learners — so they're no longer emitted (removed from the Effect schema and the builder output).
- **Video descriptions** on explainer/problem/solution are untouched: those are the user-facing copy and stay.
- `InputLesson`/`InputSection` keep `description` (the DB rows still carry it); we simply stop passing it through to the output.

### 2. Take clip sequence from the array, not an `order` field
- `computeExportHash` no longer re-sorts clips by their `order` string. Every call site already passes clips ordered by the DB (`orderBy: asc(clips.order)` across all 10 version/video queries), so the incoming array order is authoritative.
- `order` is removed from `ExportClip` entirely, so it's structurally impossible for it to influence the hash.
- **No re-exports triggered:** the hashed payload is byte-identical for already-sorted input, so existing export hashes are unchanged. Reordering a video's clips is now (correctly) a different array, hence a new hash.

## Tests
- Updated `course-json` and `export-hash` tests to assert the new behavior (lesson/section descriptions absent; hash follows array order).
- `pnpm run typecheck` clean; 86 tests across the affected suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)