### PR TITLE
feat(course-json): add relativePath to each video

### DIFF
--- a/app/packages/course-json/lib/build-course-json.ts
+++ b/app/packages/course-json/lib/build-course-json.ts
@@ -31,6 +31,10 @@ const CourseJsonVideo = Schema.Struct({
   id: Schema.String.annotations({
     description: "Stable lineage id of the video, carried across course versions.",
   }),
+  relativePath: Schema.NullOr(Schema.String).annotations({
+    description:
+      "Path to the exported .mp4 relative to this course.json (section-dir/lesson-dir/VideoTitle.mp4); null when the video has no exportable clips and so ships no file.",
+  }),
   body: Schema.NullOr(Schema.String).annotations({
     description:
       "Long-form written companion to the video (its article body), or null when none was authored.",
@@ -207,17 +211,29 @@ export type BuildCourseJsonInput = {
 
 // ── Builder ─────────────────────────────────────────────────────────────
 
-function toVideoEntry(video: InputVideo): typeof CourseJsonVideo.Type {
+// The published .mp4 lands beside course.json under section-dir/lesson-dir at
+// the video's title (see syncToDropbox's copyFileToDropbox). The relative path
+// only points at a file that actually ships, so it is null exactly when the
+// export hash is — i.e. when the video has no exportable clips.
+function toVideoEntry(
+  video: InputVideo,
+  sectionPath: string,
+  lessonPath: string
+): typeof CourseJsonVideo.Type {
   const exportClips: ExportClip[] = video.clips.map((c) => ({
     videoFilename: c.videoFilename,
     sourceStartTime: c.sourceStartTime,
     sourceEndTime: c.sourceEndTime,
   }));
+  const hash = computeExportHash(exportClips);
   return {
     id: video.lineageId,
+    relativePath: hash
+      ? `${sectionPath}/${lessonPath}/${video.title}.mp4`
+      : null,
     body: video.body,
     description: video.description,
-    hash: computeExportHash(exportClips),
+    hash,
     chapters: buildChapters(video.clips, video.chapters) ?? [],
   };
 }
@@ -268,15 +284,15 @@ export const buildCourseJson = (
               type: "problem",
               id: lesson.lineageId,
               title: lesson.title,
-              problem: toVideoEntry(problem.video),
-              solution: toVideoEntry(solution.video),
+              problem: toVideoEntry(problem.video, section.path, lesson.path),
+              solution: toVideoEntry(solution.video, section.path, lesson.path),
             });
           } else {
             lessons.push({
               type: "problem",
               id: lesson.lineageId,
               title: lesson.title,
-              problem: toVideoEntry(problem.video),
+              problem: toVideoEntry(problem.video, section.path, lesson.path),
             });
           }
         } else {
@@ -285,7 +301,7 @@ export const buildCourseJson = (
             type: "explainer",
             id: lesson.lineageId,
             title: lesson.title,
-            explainer: toVideoEntry(video),
+            explainer: toVideoEntry(video, section.path, lesson.path),
           });
         }
       }

--- a/app/packages/course-json/tests/course-json.test.ts
+++ b/app/packages/course-json/tests/course-json.test.ts
@@ -313,6 +313,81 @@ describe("buildCourseJson", () => {
     }
   });
 
+  // ── Relative path per video ────────────────────────────────────────
+
+  it("sets relativePath to section-dir/lesson-dir/title.mp4 for an exportable video", async () => {
+    const result = await run(
+      makeInput([
+        makeSection({
+          path: "03-concepts",
+          lessons: [
+            makeLesson({
+              path: "03.01-models-harnesses-agents-environments",
+              videos: [makeVideo({ title: "Explainer", clips: CLIPS })],
+            }),
+          ],
+        }),
+      ])
+    );
+
+    const lesson = result.sections[0]!.lessons[0]!;
+    if (lesson.type === "explainer") {
+      expect(lesson.explainer.relativePath).toBe(
+        "03-concepts/03.01-models-harnesses-agents-environments/Explainer.mp4"
+      );
+    }
+  });
+
+  it("sets relativePath to null when video has no clips", async () => {
+    const result = await run(
+      makeInput([
+        makeSection({
+          path: "01-intro",
+          lessons: [
+            makeLesson({
+              path: "01.01-welcome",
+              videos: [makeVideo({ title: "Explainer", clips: [] })],
+            }),
+          ],
+        }),
+      ])
+    );
+
+    const lesson = result.sections[0]!.lessons[0]!;
+    if (lesson.type === "explainer") {
+      expect(lesson.explainer.relativePath).toBeNull();
+    }
+  });
+
+  it("uses each video's own title for the relativePath in a problem/solution pair", async () => {
+    const result = await run(
+      makeInput([
+        makeSection({
+          path: "02-exercises",
+          lessons: [
+            makeLesson({
+              path: "02.01-exercise",
+              videos: [
+                makeVideo({ title: "Problem", clips: CLIPS }),
+                makeVideo({ title: "Solution", clips: CLIPS }),
+              ],
+            }),
+          ],
+        }),
+      ])
+    );
+
+    const lesson = result.sections[0]!.lessons[0]!;
+    if (lesson.type === "problem") {
+      expect(lesson.problem.relativePath).toBe(
+        "02-exercises/02.01-exercise/Problem.mp4"
+      );
+      expect(lesson.solution!.relativePath).toBe(
+        "02-exercises/02.01-exercise/Solution.mp4"
+      );
+    }
+  });
+
   // ── Inline chapters ────────────────────────────────────────────────
 
   it("includes inline chapters from clips and chapter markers", async () => {


### PR DESCRIPTION
## What

Adds a `relativePath` field to every video in the `course.json` manifest (and its generated `course.schema.json` sidecar).

```json
{
  "id": "769fdf86-…",
  "relativePath": "03-concepts/03.01-models-harnesses-agents-environments/Explainer.mp4",
  "hash": "dbef8207…"
}
```

## Why

The manifest identified videos only by content-addressed `hash`, leaving consumers to re-derive where the `.mp4` actually sits. `relativePath` makes that explicit — the path to the exported file relative to `course.json`.

## How

- New `relativePath: Schema.NullOr(Schema.String)` on `CourseJsonVideo`, with a description that flows into `course.schema.json` via `JSONSchema.make`.
- `toVideoEntry` now takes `sectionPath` + `lessonPath` and emits `` `${sectionPath}/${lessonPath}/${video.title}.mp4` `` — the exact location `syncToDropbox` copies each file to.
- Null exactly when `hash` is null (no exportable clips → no file ships), so the manifest only points at files that exist.

## Tests

- 3 new unit tests (exportable path, null-when-no-clips, per-video titles in a Problem/Solution pair).
- Full `course-json` + sync/beats/effective-sections suites green; `typecheck` (typegen + tsgo) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)