### PR TITLE
Edit lesson body & generate SEO description from context menus

### DIFF
--- a/app/features/article-writer/use-writer-context.ts
+++ b/app/features/article-writer/use-writer-context.ts
@@ -4,6 +4,32 @@ import { useState, useEffect } from "react";
 import type { WriterContextData } from "@/services/video-posting-context.server";
 import type { WriterContext } from "./writer-engine";
 
+/**
+ * Project the server-loaded {@link WriterContextData} down to the client
+ * {@link WriterContext} the writer engine consumes. Shared between the deferred
+ * hook and callers that fetch the context on demand.
+ */
+export function toWriterContext(data: WriterContextData): WriterContext {
+  return {
+    files: data.files,
+    transcript: data.transcript,
+    transcriptWordCount: data.transcriptWordCount,
+    chapters: data.chapters,
+    indexedClips: data.indexedClips,
+    links: data.links.map((l) => ({
+      id: l.id,
+      url: l.url,
+      title: l.title,
+    })),
+    courseStructure: data.courseStructure,
+    memory: data.memory,
+    repoId: data.repoId,
+    fullPath: data.fullPath,
+    isStandalone: data.isStandalone,
+    beats: data.beats,
+  };
+}
+
 export function useWriterContext(
   writerContextPromise: Promise<WriterContextData> | undefined
 ): WriterContext | null {
@@ -15,24 +41,7 @@ export function useWriterContext(
     writerContextPromise
       .then((data) => {
         if (!cancelled) {
-          setCtx({
-            files: data.files,
-            transcript: data.transcript,
-            transcriptWordCount: data.transcriptWordCount,
-            chapters: data.chapters,
-            indexedClips: data.indexedClips,
-            links: data.links.map((l) => ({
-              id: l.id,
-              url: l.url,
-              title: l.title,
-            })),
-            courseStructure: data.courseStructure,
-            memory: data.memory,
-            repoId: data.repoId,
-            fullPath: data.fullPath,
-            isStandalone: data.isStandalone,
-            beats: data.beats,
-          });
+          setCtx(toWriterContext(data));
         }
       })
       .catch(console.error);

--- a/app/features/article-writer/writable-field.tsx
+++ b/app/features/article-writer/writable-field.tsx
@@ -3,21 +3,16 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import { AIResponse } from "components/ui/kibo-ui/ai/response";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { MarkdownMonacoEditor } from "@/components/markdown-monaco-editor";
 import { cn } from "@/lib/utils";
 import { PencilIcon, EyeIcon, Maximize2Icon } from "lucide-react";
 import type { OnMount } from "@monaco-editor/react";
-import { WriterEngine, type WriterContext } from "./writer-engine";
+import type { WriterContext } from "./writer-engine";
 import type { Mode } from "./types";
 import type { WriterFieldId } from "./writer-engine-utils";
-import {
-  FIELD_LABELS,
-  FIELD_MODES,
-  saveFieldMessages,
-  loadFieldMessages,
-} from "./writer-engine-utils";
+import { FIELD_MODES } from "./writer-engine-utils";
+import { WriterModal } from "./writer-modal";
 
 export interface WritableFieldProps {
   videoId: string;
@@ -56,7 +51,6 @@ export function WritableField({
   pageFields,
 }: WritableFieldProps) {
   const resolvedModes = modes ?? FIELD_MODES[fieldId] ?? [];
-  const resolvedLabel = label ?? FIELD_LABELS[fieldId] ?? fieldId;
 
   const [searchParams, setSearchParams] = useSearchParams();
   const isOpen = searchParams.get("writer") === fieldId;
@@ -68,11 +62,6 @@ export function WritableField({
       | "settings"
       | null) ?? "writer";
   const ctxTab = searchParams.get("writerTab") ?? undefined;
-
-  const workingValueRef = useRef(value);
-  const snapshotMessagesRef = useRef<Map<string, unknown[]>>(new Map());
-  const [isDirty, setIsDirty] = useState(false);
-  const [showConfirmClose, setShowConfirmClose] = useState(false);
 
   // Inline editor state: a local draft drives Monaco so persisting through the
   // host (which round-trips the value back down) never yanks the cursor.
@@ -158,54 +147,6 @@ export function WritableField({
     [setSearchParams]
   );
 
-  const handleOpen = useCallback(() => {
-    workingValueRef.current = value;
-    setIsDirty(false);
-    setShowConfirmClose(false);
-    const snap = new Map<string, unknown[]>();
-    for (const m of resolvedModes) {
-      snap.set(m, loadFieldMessages(videoId, fieldId, m));
-    }
-    snapshotMessagesRef.current = snap;
-    setOpen(true);
-  }, [value, resolvedModes, videoId, fieldId, setOpen]);
-
-  const handleApply = useCallback(
-    (finalValue: string) => {
-      onApply(finalValue);
-      workingValueRef.current = finalValue;
-      setIsDirty(false);
-      setOpen(false);
-    },
-    [onApply, setOpen]
-  );
-
-  const handleCancel = useCallback(() => {
-    for (const [m, msgs] of snapshotMessagesRef.current) {
-      saveFieldMessages(videoId, fieldId, m as Mode, msgs);
-    }
-    workingValueRef.current = value;
-    setIsDirty(false);
-    setShowConfirmClose(false);
-    setOpen(false);
-  }, [videoId, fieldId, value, setOpen]);
-
-  const handleRequestClose = useCallback(() => {
-    if (isDirty) {
-      setShowConfirmClose(true);
-    } else {
-      handleCancel();
-    }
-  }, [isDirty, handleCancel]);
-
-  const handleDocumentChange = useCallback(
-    (doc: string) => {
-      workingValueRef.current = doc;
-      setIsDirty(doc !== value);
-    },
-    [value]
-  );
-
   return (
     <>
       <div
@@ -235,7 +176,7 @@ export function WritableField({
             variant="secondary"
             size="sm"
             className="h-7 shadow-sm"
-            onClick={handleOpen}
+            onClick={() => setOpen(true)}
           >
             <Maximize2Icon className="mr-1 size-3.5" /> Open in writer
           </Button>
@@ -271,71 +212,23 @@ export function WritableField({
         </div>
       </div>
 
-      <Dialog
+      <WriterModal
         open={isOpen}
-        onOpenChange={(open) => {
-          if (!open) handleRequestClose();
-        }}
-      >
-        <DialogContent
-          className="flex h-[96vh] w-[97vw] max-w-none flex-col gap-0 overflow-hidden p-0 sm:max-w-none"
-          showCloseButton={false}
-        >
-          <DialogTitle className="sr-only">{resolvedLabel}</DialogTitle>
-          <div className="flex items-center px-4 py-2 border-b">
-            <h2 className="text-sm font-semibold">{resolvedLabel}</h2>
-          </div>
-          <div className="relative flex-1 overflow-hidden">
-            {isOpen && (
-              <WriterEngine
-                videoId={videoId}
-                fieldId={fieldId}
-                modes={resolvedModes}
-                initialDocument={value}
-                layout="modal"
-                context={context}
-                onDocumentChange={handleDocumentChange}
-                view={view}
-                onViewChange={handleViewChange}
-                ctxTab={ctxTab}
-                onCtxTabChange={handleCtxTabChange}
-                onCancel={handleRequestClose}
-                onApply={handleApply}
-                onAddFileFromClipboard={onAddFileFromClipboard}
-                pageFields={pageFields}
-              />
-            )}
-
-            {/* Unsaved-changes confirmation */}
-            {showConfirmClose && (
-              <div className="absolute inset-0 z-20 flex items-center justify-center bg-background/80 backdrop-blur-sm">
-                <div className="max-w-sm rounded-lg border bg-background p-6 shadow-lg">
-                  <h3 className="text-base font-semibold">Unsaved changes</h3>
-                  <p className="mt-2 text-sm text-muted-foreground">
-                    You have unsaved edits. Discard them?
-                  </p>
-                  <div className="mt-4 flex justify-end gap-2">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setShowConfirmClose(false)}
-                    >
-                      Keep editing
-                    </Button>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={handleCancel}
-                    >
-                      Discard
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-        </DialogContent>
-      </Dialog>
+        onOpenChange={setOpen}
+        videoId={videoId}
+        fieldId={fieldId}
+        modes={resolvedModes}
+        value={value}
+        context={context}
+        label={label}
+        onApply={onApply}
+        onAddFileFromClipboard={onAddFileFromClipboard}
+        pageFields={pageFields}
+        view={view}
+        onViewChange={handleViewChange}
+        ctxTab={ctxTab}
+        onCtxTabChange={handleCtxTabChange}
+      />
     </>
   );
 }

--- a/app/features/article-writer/writer-modal.tsx
+++ b/app/features/article-writer/writer-modal.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2Icon } from "lucide-react";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { WriterEngine, type WriterContext } from "./writer-engine";
+import type { Mode } from "./types";
+import type { WriterFieldId } from "./writer-engine-utils";
+import {
+  FIELD_LABELS,
+  saveFieldMessages,
+  loadFieldMessages,
+} from "./writer-engine-utils";
+
+export interface WriterModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  videoId: string;
+  fieldId: WriterFieldId;
+  modes: Mode[];
+  /** Current persisted value; seeds the writer document. */
+  value: string;
+  /**
+   * The writer context. `null` renders a loading state so callers can open the
+   * modal before the (possibly on-demand fetched) context has resolved.
+   */
+  context: WriterContext | null;
+  label?: string;
+  /** Receives the final (image-uploaded) document to persist. */
+  onApply: (finalValue: string) => void;
+  /** When set, the modal's Repo Files tab shows an "add from clipboard" button. */
+  onAddFileFromClipboard?: () => void;
+  /** Other fields on the same page, offered as toggleable AI context. */
+  pageFields?: Array<{ id: string; label: string; value: string }>;
+  // Optional controlled sub-view. When omitted the modal manages it internally;
+  // WritableField drives these through URL search params so a reload restores
+  // the open writer's tab.
+  view?: "writer" | "context" | "settings";
+  onViewChange?: (view: "writer" | "context" | "settings") => void;
+  ctxTab?: string;
+  onCtxTabChange?: (tab: string) => void;
+}
+
+/**
+ * The fullscreen AI Writer, wrapped in a dialog. Extracted from WritableField
+ * so it can be opened both by the inline field and directly from elsewhere
+ * (e.g. a course-view context menu) once the writer context is available.
+ */
+export function WriterModal({
+  open,
+  onOpenChange,
+  videoId,
+  fieldId,
+  modes,
+  value,
+  context,
+  label,
+  onApply,
+  onAddFileFromClipboard,
+  pageFields,
+  view: viewProp,
+  onViewChange,
+  ctxTab: ctxTabProp,
+  onCtxTabChange,
+}: WriterModalProps) {
+  const resolvedLabel = label ?? FIELD_LABELS[fieldId] ?? fieldId;
+
+  const [viewInternal, setViewInternal] = useState<
+    "writer" | "context" | "settings"
+  >("writer");
+  const view = viewProp ?? viewInternal;
+  const handleViewChange = onViewChange ?? setViewInternal;
+
+  const [ctxTabInternal, setCtxTabInternal] = useState<string | undefined>(
+    undefined
+  );
+  const ctxTab = ctxTabProp ?? ctxTabInternal;
+  const handleCtxTabChange = onCtxTabChange ?? setCtxTabInternal;
+
+  const workingValueRef = useRef(value);
+  const snapshotMessagesRef = useRef<Map<string, unknown[]>>(new Map());
+  const [isDirty, setIsDirty] = useState(false);
+  const [showConfirmClose, setShowConfirmClose] = useState(false);
+
+  // Snapshot the per-mode chat messages on the rising edge of `open` (once the
+  // context is ready) so a Cancel can restore them. Mirrors the old
+  // WritableField.handleOpen behaviour.
+  const initedRef = useRef(false);
+  useEffect(() => {
+    if (open && context && !initedRef.current) {
+      initedRef.current = true;
+      workingValueRef.current = value;
+      setIsDirty(false);
+      setShowConfirmClose(false);
+      const snap = new Map<string, unknown[]>();
+      for (const m of modes) {
+        snap.set(m, loadFieldMessages(videoId, fieldId, m));
+      }
+      snapshotMessagesRef.current = snap;
+    }
+    if (!open) initedRef.current = false;
+  }, [open, context, value, modes, videoId, fieldId]);
+
+  const handleApply = useCallback(
+    (finalValue: string) => {
+      onApply(finalValue);
+      workingValueRef.current = finalValue;
+      setIsDirty(false);
+      onOpenChange(false);
+    },
+    [onApply, onOpenChange]
+  );
+
+  const handleCancel = useCallback(() => {
+    for (const [m, msgs] of snapshotMessagesRef.current) {
+      saveFieldMessages(videoId, fieldId, m as Mode, msgs);
+    }
+    workingValueRef.current = value;
+    setIsDirty(false);
+    setShowConfirmClose(false);
+    onOpenChange(false);
+  }, [videoId, fieldId, value, onOpenChange]);
+
+  const handleRequestClose = useCallback(() => {
+    if (isDirty) {
+      setShowConfirmClose(true);
+    } else {
+      handleCancel();
+    }
+  }, [isDirty, handleCancel]);
+
+  const handleDocumentChange = useCallback(
+    (doc: string) => {
+      workingValueRef.current = doc;
+      setIsDirty(doc !== value);
+    },
+    [value]
+  );
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) handleRequestClose();
+      }}
+    >
+      <DialogContent
+        className="flex h-[96vh] w-[97vw] max-w-none flex-col gap-0 overflow-hidden p-0 sm:max-w-none"
+        showCloseButton={false}
+      >
+        <DialogTitle className="sr-only">{resolvedLabel}</DialogTitle>
+        <div className="flex items-center px-4 py-2 border-b">
+          <h2 className="text-sm font-semibold">{resolvedLabel}</h2>
+        </div>
+        <div className="relative flex-1 overflow-hidden">
+          {context ? (
+            <WriterEngine
+              videoId={videoId}
+              fieldId={fieldId}
+              modes={modes}
+              initialDocument={value}
+              layout="modal"
+              context={context}
+              onDocumentChange={handleDocumentChange}
+              view={view}
+              onViewChange={handleViewChange}
+              ctxTab={ctxTab}
+              onCtxTabChange={handleCtxTabChange}
+              onCancel={handleRequestClose}
+              onApply={handleApply}
+              onAddFileFromClipboard={onAddFileFromClipboard}
+              pageFields={pageFields}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
+              <Loader2Icon className="size-4 animate-spin" />
+              Loading writer context…
+            </div>
+          )}
+
+          {/* Unsaved-changes confirmation */}
+          {showConfirmClose && (
+            <div className="absolute inset-0 z-20 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+              <div className="max-w-sm rounded-lg border bg-background p-6 shadow-lg">
+                <h3 className="text-base font-semibold">Unsaved changes</h3>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  You have unsaved edits. Discard them?
+                </p>
+                <div className="mt-4 flex justify-end gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowConfirmClose(false)}
+                  >
+                    Keep editing
+                  </Button>
+                  <Button variant="destructive" size="sm" onClick={handleCancel}>
+                    Discard
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/features/course-view/course-view-components.tsx
+++ b/app/features/course-view/course-view-components.tsx
@@ -6,6 +6,8 @@ import { MoveVideoModal } from "@/components/move-video-modal";
 import { RenameCourseModal } from "@/components/rename-course-modal";
 import { RenameVideoModal } from "@/components/rename-video-modal";
 import { VersionSelectorModal } from "@/components/version-selector-modal";
+import { LessonBodyWriterModal } from "@/features/lesson-writer/lesson-body-writer-modal";
+import { GenerateSeoDescriptionModal } from "@/features/lesson-writer/generate-seo-description-modal";
 import { computeCourseStats } from "@/features/course-view/course-editor-helpers";
 import { courseViewReducer } from "@/features/course-view/course-view-reducer";
 
@@ -323,6 +325,8 @@ export function RouteModals({
       clipCount: number;
       beatCount: number;
     } | null;
+    lessonBodyWriterVideoId: string | null;
+    seoDescriptionVideoId: string | null;
     priorityFilter: number[];
     iconFilter: string[];
     todoFilter: boolean;
@@ -475,6 +479,26 @@ export function RouteModals({
           }}
           onCopy={() => {
             dispatch({ type: "close-copy-video" });
+          }}
+        />
+      )}
+
+      {viewState.lessonBodyWriterVideoId && (
+        <LessonBodyWriterModal
+          videoId={viewState.lessonBodyWriterVideoId}
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) dispatch({ type: "close-lesson-body-writer" });
+          }}
+        />
+      )}
+
+      {viewState.seoDescriptionVideoId && (
+        <GenerateSeoDescriptionModal
+          videoId={viewState.seoDescriptionVideoId}
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) dispatch({ type: "close-seo-description" });
           }}
         />
       )}

--- a/app/features/course-view/course-view-reducer.ts
+++ b/app/features/course-view/course-view-reducer.ts
@@ -64,6 +64,8 @@ export namespace courseViewReducer {
     deleteLessonId: string | null;
     archiveSectionId: string | null;
     editDescriptionLessonId: string | null;
+    lessonBodyWriterVideoId: string | null;
+    seoDescriptionVideoId: string | null;
 
     // Complex object states
     videoPlayerState: VideoPlayerState;
@@ -118,6 +120,10 @@ export namespace courseViewReducer {
     | { type: "set-delete-lesson-id"; lessonId: string | null }
     | { type: "set-archive-section-id"; sectionId: string | null }
     | { type: "set-edit-description-lesson-id"; lessonId: string | null }
+    | { type: "open-lesson-body-writer"; videoId: string }
+    | { type: "close-lesson-body-writer" }
+    | { type: "open-seo-description"; videoId: string }
+    | { type: "close-seo-description" }
     // Video player
     | {
         type: "open-video-player";
@@ -203,6 +209,8 @@ export function createInitialCourseViewState(): courseViewReducer.State {
     deleteLessonId: null,
     archiveSectionId: null,
     editDescriptionLessonId: null,
+    lessonBodyWriterVideoId: null,
+    seoDescriptionVideoId: null,
     videoPlayerState: { isOpen: false, videoId: "", videoTitle: "" },
     moveVideoState: null,
     moveLessonState: null,
@@ -290,6 +298,14 @@ export const courseViewReducer: EffectReducer<
       return { ...state, archiveSectionId: action.sectionId };
     case "set-edit-description-lesson-id":
       return { ...state, editDescriptionLessonId: action.lessonId };
+    case "open-lesson-body-writer":
+      return { ...state, lessonBodyWriterVideoId: action.videoId };
+    case "close-lesson-body-writer":
+      return { ...state, lessonBodyWriterVideoId: null };
+    case "open-seo-description":
+      return { ...state, seoDescriptionVideoId: action.videoId };
+    case "close-seo-description":
+      return { ...state, seoDescriptionVideoId: null };
 
     // Video player
     case "open-video-player":

--- a/app/features/course-view/video-context-menu.tsx
+++ b/app/features/course-view/video-context-menu.tsx
@@ -1,6 +1,7 @@
 import {
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
 } from "@/components/ui/context-menu";
 import { courseViewReducer } from "@/features/course-view/course-view-reducer";
 import {
@@ -8,10 +9,11 @@ import {
   Combine,
   Copy,
   Download,
+  FileText,
   FolderOpen,
   Link2,
+  ListTree,
   PencilIcon,
-  Play,
   Sparkles,
   Trash2,
 } from "lucide-react";
@@ -29,6 +31,9 @@ import { useRequestCreateBeat } from "@/features/beats/create-beat-dialog";
  * thumbnail grid and the compact beat tree so right-clicking a Video offers
  * the same actions in both views. Wrap in a `<ContextMenu>`/`<ContextMenuTrigger>`
  * at the call site.
+ *
+ * Grouped into sections divided by separators: deep link, lesson content,
+ * beats, organize, video files, and (destructively) delete.
  */
 export function VideoContextMenuItems({
   courseId,
@@ -63,64 +68,6 @@ export function VideoContextMenuItems({
   return (
     <ContextMenuContent>
       <ContextMenuItem
-        onSelect={() => {
-          dispatch({
-            type: "open-video-player",
-            videoId: video.id,
-            videoTitle: `${section.title}/${lesson.path}/${video.title}`,
-          });
-        }}
-      >
-        <Play className="w-4 h-4" />
-        Play Video
-      </ContextMenuItem>
-      <ContextMenuItem
-        onSelect={() => {
-          startExportUpload(
-            video.id,
-            `${section.title}/${lesson.path}/${video.title}`
-          );
-        }}
-      >
-        <Download className="w-4 h-4" />
-        Export
-      </ContextMenuItem>
-      <ContextMenuItem
-        onSelect={() => {
-          navigate(`/videos/concatenate?initial=${video.id}`);
-        }}
-      >
-        <Combine className="w-4 h-4" />
-        Create Concatenated Video
-      </ContextMenuItem>
-      {canGenerateChapters && (
-        <ContextMenuItem
-          onSelect={() => {
-            openGenerateChapters({
-              videoId: video.id,
-              videoLabel: `${section.title}/${lesson.path}/${video.title}`,
-            });
-          }}
-        >
-          <Sparkles className="w-4 h-4" />
-          Generate Chapters
-        </ContextMenuItem>
-      )}
-      <ContextMenuItem
-        onSelect={() => {
-          revealVideoFetcher.submit(
-            {},
-            {
-              method: "post",
-              action: `/api/videos/${video.id}/reveal`,
-            }
-          );
-        }}
-      >
-        <FolderOpen className="w-4 h-4" />
-        Reveal in File System
-      </ContextMenuItem>
-      <ContextMenuItem
         onSelect={() =>
           copyDeepLink({
             courseId,
@@ -132,8 +79,47 @@ export function VideoContextMenuItems({
         <Link2 className="w-4 h-4" />
         Copy Deep Link
       </ContextMenuItem>
+
       {!isReadOnly && (
         <>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            onSelect={() => {
+              dispatch({
+                type: "open-lesson-body-writer",
+                videoId: video.id,
+              });
+            }}
+          >
+            <FileText className="w-4 h-4" />
+            Edit Lesson Body
+          </ContextMenuItem>
+          <ContextMenuItem
+            onSelect={() => {
+              dispatch({
+                type: "open-seo-description",
+                videoId: video.id,
+              });
+            }}
+          >
+            <Sparkles className="w-4 h-4" />
+            Generate SEO Description
+          </ContextMenuItem>
+          {canGenerateChapters && (
+            <ContextMenuItem
+              onSelect={() => {
+                openGenerateChapters({
+                  videoId: video.id,
+                  videoLabel: `${section.title}/${lesson.path}/${video.title}`,
+                });
+              }}
+            >
+              <ListTree className="w-4 h-4" />
+              Generate Chapters
+            </ContextMenuItem>
+          )}
+
+          <ContextMenuSeparator />
           <AddBeatSubMenu
             onAdd={(kind) =>
               requestCreateBeat({
@@ -143,6 +129,8 @@ export function VideoContextMenuItems({
               })
             }
           />
+
+          <ContextMenuSeparator />
           <ContextMenuItem
             onSelect={() => {
               dispatch({
@@ -182,13 +170,56 @@ export function VideoContextMenuItems({
             <ArrowRightLeft className="w-4 h-4" />
             Move to Lesson
           </ContextMenuItem>
-          <Suspense>
-            <PurgeExportMenuItem
-              videoId={video.id}
-              hasExportedVideoMap={data.hasExportedVideoMap}
-              deleteVideoFileFetcher={deleteVideoFileFetcher}
-            />
-          </Suspense>
+          <ContextMenuItem
+            onSelect={() => {
+              navigate(`/videos/concatenate?initial=${video.id}`);
+            }}
+          >
+            <Combine className="w-4 h-4" />
+            Create Concatenated Video
+          </ContextMenuItem>
+        </>
+      )}
+
+      <ContextMenuSeparator />
+      <ContextMenuItem
+        onSelect={() => {
+          startExportUpload(
+            video.id,
+            `${section.title}/${lesson.path}/${video.title}`
+          );
+        }}
+      >
+        <Download className="w-4 h-4" />
+        Export
+      </ContextMenuItem>
+      <ContextMenuItem
+        onSelect={() => {
+          revealVideoFetcher.submit(
+            {},
+            {
+              method: "post",
+              action: `/api/videos/${video.id}/reveal`,
+            }
+          );
+        }}
+      >
+        <FolderOpen className="w-4 h-4" />
+        Reveal in File System
+      </ContextMenuItem>
+      {!isReadOnly && (
+        <Suspense>
+          <PurgeExportMenuItem
+            videoId={video.id}
+            hasExportedVideoMap={data.hasExportedVideoMap}
+            deleteVideoFileFetcher={deleteVideoFileFetcher}
+          />
+        </Suspense>
+      )}
+
+      {!isReadOnly && (
+        <>
+          <ContextMenuSeparator />
           <ContextMenuItem
             variant="destructive"
             onSelect={() => {

--- a/app/features/lesson-writer/generate-seo-description-modal.tsx
+++ b/app/features/lesson-writer/generate-seo-description-modal.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useFetcher } from "react-router";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { Loader2Icon, SparklesIcon } from "lucide-react";
+
+type LessonWriterData = {
+  body: string | null;
+  description: string | null;
+};
+
+/**
+ * A focused modal for the video's SEO description: shows the current value, a
+ * Generate button (driven by the lesson body only), and Save. Mount
+ * conditionally so each open starts from a fresh fetch.
+ */
+export function GenerateSeoDescriptionModal({
+  videoId,
+  open,
+  onOpenChange,
+}: {
+  videoId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const dataFetcher = useFetcher<LessonWriterData>();
+  const genFetcher = useFetcher<{ text?: string; error?: string }>();
+  const saveFetcher = useFetcher();
+
+  const [value, setValue] = useState("");
+  const [seeded, setSeeded] = useState(false);
+
+  useEffect(() => {
+    if (open && dataFetcher.state === "idle" && !dataFetcher.data) {
+      dataFetcher.load(`/api/videos/${videoId}/lesson-writer`);
+    }
+  }, [open, videoId, dataFetcher]);
+
+  // Seed the textarea from the persisted description once, when data lands.
+  useEffect(() => {
+    if (dataFetcher.data && !seeded) {
+      setValue(dataFetcher.data.description ?? "");
+      setSeeded(true);
+    }
+  }, [dataFetcher.data, seeded]);
+
+  // A completed generation always replaces the textarea contents.
+  useEffect(() => {
+    if (genFetcher.data?.text != null) {
+      setValue(genFetcher.data.text);
+    }
+  }, [genFetcher.data]);
+
+  const isLoading = !dataFetcher.data;
+  const isGenerating = genFetcher.state !== "idle";
+  const bodyIsEmpty = dataFetcher.data
+    ? !(dataFetcher.data.body ?? "").trim()
+    : false;
+
+  const handleGenerate = () => {
+    genFetcher.submit(
+      {},
+      {
+        method: "post",
+        action: `/api/videos/${videoId}/generate-seo-from-body`,
+        encType: "application/json",
+      }
+    );
+  };
+
+  const handleSave = () => {
+    saveFetcher.submit(
+      { intent: "updateDescription", description: value },
+      { method: "post", action: `/api/videos/${videoId}/lesson-writer` }
+    );
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>SEO Description</DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+            <Loader2Icon className="size-4 animate-spin" />
+            Loading…
+          </div>
+        ) : (
+          <div className="space-y-3 py-2">
+            <Textarea
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder="A short, compelling SEO description…"
+              className="min-h-[120px] text-sm"
+              disabled={isGenerating}
+              autoFocus
+            />
+            <div className="flex items-center justify-between text-xs">
+              <span
+                className={cn(
+                  "text-muted-foreground",
+                  value.length > 160 && "text-destructive"
+                )}
+              >
+                {value.length}/160 characters
+              </span>
+            </div>
+
+            {bodyIsEmpty && (
+              <p className="text-sm text-destructive">
+                The lesson body is empty. Write a lesson body before generating.
+              </p>
+            )}
+            {genFetcher.data?.error && (
+              <p className="text-sm text-destructive">
+                {genFetcher.data.error}
+              </p>
+            )}
+
+            <div className="flex items-center justify-between">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={handleGenerate}
+                disabled={bodyIsEmpty || isGenerating}
+              >
+                {isGenerating ? (
+                  <Loader2Icon className="mr-1 size-4 animate-spin" />
+                ) : (
+                  <SparklesIcon className="mr-1 size-4" />
+                )}
+                Generate
+              </Button>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={isGenerating}
+                >
+                  Save
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/features/lesson-writer/lesson-body-writer-modal.tsx
+++ b/app/features/lesson-writer/lesson-body-writer-modal.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { useFetcher } from "react-router";
+import { WriterModal } from "@/features/article-writer/writer-modal";
+import { toWriterContext } from "@/features/article-writer/use-writer-context";
+import type { Mode } from "@/features/article-writer/types";
+import type { WriterContextData } from "@/services/video-posting-context.server";
+
+type LessonWriterData = {
+  body: string | null;
+  description: string | null;
+  writerContext: WriterContextData;
+};
+
+// Matches the modes the Lesson tab uses for the video body.
+const BODY_MODES: Mode[] = ["article", "skill-building"];
+
+/**
+ * Opens the full AI Writer on a video's lesson body from anywhere (course-view
+ * context menu, video-editor actions), fetching the writer context on demand.
+ * Mount conditionally so each open starts from a fresh fetch.
+ */
+export function LessonBodyWriterModal({
+  videoId,
+  open,
+  onOpenChange,
+}: {
+  videoId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const dataFetcher = useFetcher<LessonWriterData>();
+  const saveFetcher = useFetcher();
+
+  useEffect(() => {
+    if (open && dataFetcher.state === "idle" && !dataFetcher.data) {
+      dataFetcher.load(`/api/videos/${videoId}/lesson-writer`);
+    }
+  }, [open, videoId, dataFetcher]);
+
+  const context = useMemo(
+    () =>
+      dataFetcher.data
+        ? toWriterContext(dataFetcher.data.writerContext)
+        : null,
+    [dataFetcher.data]
+  );
+
+  const persistBody = (newValue: string) => {
+    saveFetcher.submit(
+      { intent: "updateBody", body: newValue },
+      { method: "post", action: `/api/videos/${videoId}/lesson-writer` }
+    );
+  };
+
+  return (
+    <WriterModal
+      open={open}
+      onOpenChange={onOpenChange}
+      videoId={videoId}
+      fieldId="video-body"
+      modes={BODY_MODES}
+      value={dataFetcher.data?.body ?? ""}
+      context={context}
+      onApply={persistBody}
+    />
+  );
+}

--- a/app/features/video-editor/components/actions-dropdown.tsx
+++ b/app/features/video-editor/components/actions-dropdown.tsx
@@ -22,6 +22,7 @@ import {
   Combine,
   CopyIcon,
   DownloadIcon,
+  FileText,
   FilmIcon,
   FolderOpen,
   ListTree,
@@ -89,6 +90,10 @@ export const ActionsDropdown = (props: {
   onGenerateChaptersClick: () => void;
   /** Open diagram playground resolved for the current video context */
   onOpenDiagramPlayground: () => void;
+  /** Open the AI Writer on the lesson body (only when lesson-bound) */
+  onEditLessonBodyClick: () => void;
+  /** Open the Generate SEO Description modal (only when lesson-bound) */
+  onGenerateSeoDescriptionClick: () => void;
 }) => {
   const navigate = useNavigate();
 
@@ -132,6 +137,29 @@ export const ActionsDropdown = (props: {
             </span>
           </div>
         </DropdownMenuItem>
+
+        {props.lessonId && (
+          <>
+            <DropdownMenuItem onSelect={props.onEditLessonBodyClick}>
+              <FileText className="w-4 h-4 mr-2" />
+              <div className="flex flex-col">
+                <span className="font-medium">Edit Lesson Body</span>
+                <span className="text-xs text-muted-foreground">
+                  Open the AI Writer on the lesson body
+                </span>
+              </div>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={props.onGenerateSeoDescriptionClick}>
+              <Sparkles className="w-4 h-4 mr-2" />
+              <div className="flex flex-col">
+                <span className="font-medium">Generate SEO Description</span>
+                <span className="text-xs text-muted-foreground">
+                  AI-generate an SEO description from the body
+                </span>
+              </div>
+            </DropdownMenuItem>
+          </>
+        )}
 
         {props.referenceVideoId !== null &&
         props.referenceCandidates.some(

--- a/app/features/video-editor/components/video-player-panel.tsx
+++ b/app/features/video-editor/components/video-player-panel.tsx
@@ -11,6 +11,8 @@ import {
   type SuggestionsPanelProps,
 } from "./suggestions-panel";
 import { ActionsDropdown } from "./actions-dropdown";
+import { LessonBodyWriterModal } from "@/features/lesson-writer/lesson-body-writer-modal";
+import { GenerateSeoDescriptionModal } from "@/features/lesson-writer/generate-seo-description-modal";
 import { VideoPlayerLinksTab } from "./video-player-links-tab";
 import { PreloadableClipManager } from "../preloadable-clip";
 import {
@@ -72,6 +74,8 @@ export const VideoPlayerPanel = () => {
     VideoEditorContext,
     (ctx) => ctx.lessonId
   );
+  const [isLessonBodyWriterOpen, setIsLessonBodyWriterOpen] = useState(false);
+  const [isSeoDescriptionOpen, setIsSeoDescriptionOpen] = useState(false);
   const liveMediaStream = useContextSelector(
     VideoEditorContext,
     (ctx) => ctx.liveMediaStream
@@ -498,6 +502,10 @@ export const VideoPlayerPanel = () => {
               onShowBeatPanel={onShowBeatPanel}
               onGenerateChaptersClick={onOpenGenerateChaptersModal}
               onOpenDiagramPlayground={handleOpenDiagramPlayground}
+              onEditLessonBodyClick={() => setIsLessonBodyWriterOpen(true)}
+              onGenerateSeoDescriptionClick={() =>
+                setIsSeoDescriptionOpen(true)
+              }
             />
             <Button variant="secondary" onClick={onAddNoteFromClipboard}>
               <ClipboardIcon className="w-4 h-4 mr-1" />
@@ -581,6 +589,22 @@ export const VideoPlayerPanel = () => {
           onOpenChange={setIsAddVideoModalOpen}
         />
       </Suspense>
+
+      {lessonId && isLessonBodyWriterOpen && (
+        <LessonBodyWriterModal
+          videoId={videoId}
+          open={isLessonBodyWriterOpen}
+          onOpenChange={setIsLessonBodyWriterOpen}
+        />
+      )}
+
+      {lessonId && isSeoDescriptionOpen && (
+        <GenerateSeoDescriptionModal
+          videoId={videoId}
+          open={isSeoDescriptionOpen}
+          onOpenChange={setIsSeoDescriptionOpen}
+        />
+      )}
     </>
   );
 };

--- a/app/prompts/generate-seo-description-from-body.ts
+++ b/app/prompts/generate-seo-description-from-body.ts
@@ -1,0 +1,49 @@
+import { getLinkInstructions, type GlobalLink } from "./link-instructions";
+
+/**
+ * SEO description generated purely from the lesson body (the written lesson
+ * markdown), ignoring the transcript. Used by the "Generate SEO Description"
+ * modal, which is driven by the body only.
+ */
+export const generateSeoDescriptionFromBodyPrompt = (opts: {
+  body: string;
+  links: GlobalLink[];
+}) => {
+  return `
+<role-context>
+You are a helpful assistant being asked to generate an SEO description for a coding lesson.
+
+SEO descriptions appear in search engine results and should be compelling, accurate, and optimized for discovery.
+</role-context>
+
+<documents>
+Here is the written lesson body (Markdown):
+
+<lesson-body>
+${opts.body}
+</lesson-body>
+</documents>
+
+<the-ask>
+Generate a concise SEO description (meta description) for this coding lesson, based solely on the lesson body above.
+
+The description should:
+- Accurately summarize what the viewer will learn
+- Be compelling and encourage clicks from search results
+- Include relevant keywords naturally
+- Be no more than 160 characters
+
+CRITICAL: The description MUST be 160 characters or fewer. This is a hard limit.
+
+${getLinkInstructions(opts.links)}
+</the-ask>
+
+<output-format>
+Do not enter into conversation with the user. Always assume that their messages to you are instructions for editing the description.
+
+Respond ONLY with the SEO description text. Do not include any other text, explanations, or formatting.
+
+The response should be a single line of plain text, 160 characters or fewer.
+</output-format>
+`.trim();
+};

--- a/app/routes/api.videos.$videoId.generate-seo-from-body.ts
+++ b/app/routes/api.videos.$videoId.generate-seo-from-body.ts
@@ -1,0 +1,45 @@
+import { LinkAuthOperationsService } from "@/services/db-link-auth-operations.server";
+import { VideoOperationsService } from "@/services/db-video-operations.server";
+import { generateSeoDescriptionFromBodyPrompt } from "@/prompts/generate-seo-description-from-body";
+import { Effect } from "effect";
+import { makeAction } from "@/services/route-action.server";
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateText } from "ai";
+
+/**
+ * Generate an SEO description from the lesson body only (ignoring the
+ * transcript). Returns `{ error }` when the body is empty so the modal can
+ * surface it without hitting the model.
+ */
+export const action = makeAction({
+  input: "json",
+  dump: false,
+  effect: ({ params }) =>
+    Effect.gen(function* () {
+      const videoId = params.videoId!;
+      const videoOps = yield* VideoOperationsService;
+      const video = yield* videoOps.getVideoWithLessonById(videoId);
+      const body = (video.body ?? "").trim();
+
+      if (!body) {
+        return {
+          error: "The lesson body is empty. Write a lesson body first.",
+        } as const;
+      }
+
+      const linkAuthOps = yield* LinkAuthOperationsService;
+      const links = yield* linkAuthOps.getLinks();
+
+      const systemPrompt = generateSeoDescriptionFromBodyPrompt({ body, links });
+
+      const result = yield* Effect.tryPromise(() =>
+        generateText({
+          model: anthropic("claude-haiku-4-5-20251001"),
+          system: systemPrompt,
+          messages: [{ role: "user", content: "Go" }],
+        })
+      );
+
+      return { text: result.text } as const;
+    }),
+});

--- a/app/routes/api.videos.$videoId.lesson-writer.ts
+++ b/app/routes/api.videos.$videoId.lesson-writer.ts
@@ -1,0 +1,52 @@
+import { loadWriterContext } from "@/services/video-posting-context.server";
+import { VideoOperationsService } from "@/services/db-video-operations.server";
+import { makeLoader, makeAction } from "@/services/route-action.server";
+import { Effect } from "effect";
+
+/**
+ * On-demand data for opening the lesson writer / SEO modals from anywhere
+ * (course view, video editor) without being on the Lesson tab. Returns the
+ * current body/description plus the resolved writer context.
+ */
+export const loader = makeLoader({
+  effect: ({ params }) =>
+    Effect.gen(function* () {
+      const videoId = params.videoId!;
+      const videoOps = yield* VideoOperationsService;
+      const video = yield* videoOps.getVideoWithLessonById(videoId);
+      const writerContext = yield* loadWriterContext(videoId);
+      return {
+        body: video.body,
+        description: video.description,
+        writerContext,
+      };
+    }),
+});
+
+export const action = makeAction({
+  input: "formData",
+  effect: ({ params, payload }) =>
+    Effect.gen(function* () {
+      const videoId = params.videoId!;
+      const videoOps = yield* VideoOperationsService;
+      const data = payload as Record<string, string>;
+
+      if (data.intent === "updateBody") {
+        yield* videoOps.updateVideoBody({
+          videoId,
+          body: data.body || null,
+        });
+        return { ok: true };
+      }
+
+      if (data.intent === "updateDescription") {
+        yield* videoOps.updateVideoDescription({
+          videoId,
+          description: data.description || null,
+        });
+        return { ok: true };
+      }
+
+      return { ok: false };
+    }),
+});


### PR DESCRIPTION
## What

Adds two lesson-content actions, reachable from **both** the course-view right-click menu **and** the video editor's **Actions** dropdown:

- **Edit Lesson Body** — opens the full AI Writer directly (no page navigation), loading the writer context on demand.
- **Generate SEO Description** — opens a dedicated modal (current value + **Generate** + **Save**). Generation is driven by the **lesson body only** and errors when the body is empty; **Generate** always replaces the text.

Also **regroups the video context menu** into separator-divided sections (Copy Deep Link · Lesson · Beats · Organize · Video · Delete) and removes the unused **Play Video** item. Editing items stay hidden in read-only course versions.

## How

- `WriterModal` is extracted from `WritableField` so the AI Writer can be opened from anywhere without duplicating its dirty-tracking / confirm-close logic. The Lesson tab renders it unchanged.
- New resource route `api.videos.$videoId.lesson-writer` — loader returns `{ body, description, writerContext }`; action persists body/description.
- New route `api.videos.$videoId.generate-seo-from-body` + `generateSeoDescriptionFromBodyPrompt` — one-shot SEO generation from the body, returning `{ error }` when the body is empty.
- New `LessonBodyWriterModal` and `GenerateSeoDescriptionModal` (both fetch on open, mounted conditionally). Wired via new course-view reducer actions and local state in the video editor.

## Testing

- `pnpm typecheck` — passes.
- `pnpm vitest run` (article-writer + course-view) — 417 tests pass, including the existing `writable-field.test.ts` over the refactored component.
- Not yet manually click-tested in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)