### PR TITLE
Remove downstream nulls from course.json + surface publish blockers on the publish page

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,7 +33,7 @@ An immutable CourseVersion with a name and description, created by the Publish f
 _Avoid_: Released version, Committed version
 
 **Publish**:
-The atomic operation that uploads to Dropbox, freezes the Draft Version as a Published Version (setting name/description), and clones a new Draft Version. Its structure is derived from the database (not parsed from disk); its Dropbox output is exclusively `.mp4` video files plus a single `course.json` and its companion `course.schema.json` (the JSON Schema describing course.json, referenced by course.json's `$schema` field) — no authoring sidecar files (`.transcript.md`, `.body.md`, `.meta.json`, `TODO.md`) and no `changelog.md`.
+The atomic operation that uploads to Dropbox, freezes the Draft Version as a Published Version (setting name/description), and clones a new Draft Version. Its structure is derived from the database (not parsed from disk); its Dropbox output is exclusively `.mp4` video files plus a single `course.json` and its companion `course.schema.json` (the JSON Schema describing course.json, referenced by course.json's `$schema` field) — no authoring sidecar files (`.transcript.md`, `.body.md`, `.meta.json`, `TODO.md`) and no `changelog.md`. Every shipping **Video** must be complete — it has exportable **Clips** (hence an `.mp4` and an **Export Hash**), a `body`, and a `description` — so every field in `course.json` is present, never null; an incomplete Video fails the Publish (see ADR 0019).
 _Avoid_: Commit, Deploy, Push
 
 **Export Version Key**:

--- a/app/packages/course-json/index.ts
+++ b/app/packages/course-json/index.ts
@@ -17,10 +17,15 @@
 export {
   buildCourseJson,
   buildCourseJsonSchema,
+  collectPublishBlockers,
   CourseJsonDocumentSchema,
   InvalidLessonRoleComboError,
+  IncompleteVideosError,
   type BuildCourseJsonInput,
   type CourseJsonDocument,
+  type IncompleteVideo,
+  type InvalidLessonCombo,
+  type PublishBlockers,
 } from "./lib/build-course-json";
 
 export {

--- a/app/packages/course-json/lib/build-course-json.ts
+++ b/app/packages/course-json/lib/build-course-json.ts
@@ -33,21 +33,19 @@ const CourseJsonVideo = Schema.Struct({
     description:
       "Stable lineage id of the video, carried across course versions.",
   }),
-  relativePath: Schema.NullOr(Schema.String).annotations({
+  relativePath: Schema.String.annotations({
     description:
-      "Path to the exported .mp4 relative to this course.json (section-dir/lesson-dir/VideoTitle.mp4); null when the video has no exportable clips and so ships no file.",
+      "Path to the exported .mp4 relative to this course.json (section-dir/lesson-dir/VideoTitle.mp4).",
   }),
-  body: Schema.NullOr(Schema.String).annotations({
-    description:
-      "Long-form written companion to the video (its article body), or null when none was authored.",
+  body: Schema.String.annotations({
+    description: "Long-form written companion to the video (its article body).",
   }),
-  description: Schema.NullOr(Schema.String).annotations({
-    description:
-      "Short description of the video, or null when none was authored.",
+  description: Schema.String.annotations({
+    description: "Short description of the video.",
   }),
-  hash: Schema.NullOr(Schema.String).annotations({
+  hash: Schema.String.annotations({
     description:
-      "Export Hash identifying the rendered .mp4 (SHA256 of the video's clip filenames and timestamps in sequence, plus the Export Version Key); null when the video has no exportable clips.",
+      "Export Hash identifying the rendered .mp4 (SHA256 of the video's clip filenames and timestamps in sequence, plus the Export Version Key).",
   }),
   chapters: Schema.Array(CourseJsonChapter).annotations({
     description: "The video's chapters, in timeline order.",
@@ -125,7 +123,7 @@ const CourseJsonSectionSchema = Schema.Struct({
 });
 
 export const CourseJsonDocumentSchema = Schema.Struct({
-  $schema: Schema.optional(Schema.String).annotations({
+  $schema: Schema.String.annotations({
     description:
       "Relative path to the JSON Schema describing this document (course.schema.json).",
   }),
@@ -155,14 +153,51 @@ export type CourseJsonDocument = typeof CourseJsonDocumentSchema.Type;
 export const buildCourseJsonSchema = (): JSONSchema.JsonSchema7Root =>
   JSONSchema.make(CourseJsonDocumentSchema);
 
-// ── Error ───────────────────────────────────────────────────────────────
+// ── Publish blockers ──────────────────────────────────────────────────────
 
-export class InvalidLessonRoleComboError extends Data.TaggedError(
-  "InvalidLessonRoleComboError"
-)<{
+// A Lesson whose active Videos don't form a valid role combo (a lone solution,
+// an explainer beside a problem, duplicate roles, 3+ videos, …). We can't tell
+// which Video is the problem vs solution, so the whole Lesson is flagged.
+export type InvalidLessonCombo = {
   sectionPath: string;
   lessonPath: string;
   videoTitles: string[];
+};
+
+// What a shipping Video is missing to be publishable. A Video that reaches
+// course.json must carry exportable clips (so it produces an .mp4 and an Export
+// Hash) and both a body and a description — each is required, never nullable.
+// Any absence is a gap on our side, not real optionality.
+export type IncompleteVideo = {
+  sectionPath: string;
+  lessonPath: string;
+  videoTitle: string;
+  missing: Array<"clips" | "body" | "description">;
+};
+
+// Everything that would make a Publish fail, enumerated in full. The pre-publish
+// page reads this to warn (and block) before a doomed publish is ever started;
+// `buildCourseJson` reads the same result as its backstop — so the thing that
+// warns you is literally the thing that would fail.
+export type PublishBlockers = {
+  invalidLessonCombos: InvalidLessonCombo[];
+  incompleteVideos: IncompleteVideo[];
+};
+
+// ── Errors ──────────────────────────────────────────────────────────────
+
+export class InvalidLessonRoleComboError extends Data.TaggedError(
+  "InvalidLessonRoleComboError"
+)<InvalidLessonCombo> {}
+
+// Raised when one or more shipping Videos are incomplete. Publish scans the
+// whole course and collects every gap, then fails with the full list — so the
+// author fixes all of them in one pass rather than re-running publish per gap,
+// and course.json never ships a null for these fields.
+export class IncompleteVideosError extends Data.TaggedError(
+  "IncompleteVideosError"
+)<{
+  videos: IncompleteVideo[];
 }> {}
 
 // ── Input types ─────────────────────────────────────────────────────────
@@ -216,12 +251,112 @@ export type BuildCourseJsonInput = {
   includeTodoLessons: boolean;
 };
 
+// ── Publish-blocker detection ─────────────────────────────────────────────
+
+// The gaps that make a Video unshippable — no exportable clips, no body, or no
+// description. An empty result means the Video is complete and may be emitted.
+// This is the single gate that lets `toVideoEntry` treat every field as present.
+function videoGaps(video: InputVideo): IncompleteVideo["missing"] {
+  const missing: IncompleteVideo["missing"] = [];
+  if (video.clips.length === 0) missing.push("clips");
+  if (video.body === null) missing.push("body");
+  if (video.description === null) missing.push("description");
+  return missing;
+}
+
+// Which Video plays which role in a Lesson. Assumes the active Videos already
+// form a valid combo (i.e. `computeLessonWarnings` returned nothing) — the same
+// selection the builder and the blocker collector both rely on, so they agree.
+type SelectedLessonVideos =
+  | { type: "explainer"; video: InputVideo }
+  | { type: "problem"; problem: InputVideo; solution?: InputVideo };
+
+function selectLessonVideos(
+  activeVideos: readonly InputVideo[]
+): SelectedLessonVideos {
+  const roleMap = activeVideos.map((v) => ({
+    video: v,
+    role: deriveVideoRole(v.title),
+  }));
+  const problem = roleMap.find((r) => r.role === "problem");
+  const solution = roleMap.find((r) => r.role === "solution");
+  const explainer = roleMap.find((r) => r.role === "explainer");
+
+  if (problem) {
+    return {
+      type: "problem",
+      problem: problem.video,
+      solution: solution?.video,
+    };
+  }
+  return { type: "explainer", video: explainer?.video ?? activeVideos[0]! };
+}
+
+// The Videos a Lesson actually ships, in course.json order.
+function shippingVideos(selected: SelectedLessonVideos): InputVideo[] {
+  return selected.type === "problem"
+    ? [selected.problem, ...(selected.solution ? [selected.solution] : [])]
+    : [selected.video];
+}
+
+// The single source of truth for "why can't this publish?". Walks the effective
+// output — the exact Lessons and Videos this publish would ship — and returns
+// every blocker: Lessons with an invalid role combo, and shipping Videos missing
+// a required field. `buildCourseJson` fails on a non-empty result; the publish
+// page shows it as pre-publish warnings and blocks the button. One walk, so the
+// warning and the failure can never disagree.
+export const collectPublishBlockers = (
+  sections: readonly InputSection[],
+  includeTodoLessons: boolean
+): PublishBlockers => {
+  const invalidLessonCombos: InvalidLessonCombo[] = [];
+  const incompleteVideos: IncompleteVideo[] = [];
+
+  const effectiveSections = computeEffectiveSections(
+    sections,
+    includeTodoLessons
+  );
+
+  for (const section of effectiveSections) {
+    for (const lesson of section.lessons) {
+      const activeVideos = lesson.videos.filter((v) => !v.archived);
+      if (activeVideos.length === 0) continue;
+
+      // An invalid combo makes roles ambiguous, so we can't meaningfully gap-check
+      // the individual Videos — flag the Lesson and move on.
+      if (computeLessonWarnings({ videos: activeVideos }).length > 0) {
+        invalidLessonCombos.push({
+          sectionPath: section.path,
+          lessonPath: lesson.path,
+          videoTitles: activeVideos.map((v) => v.title),
+        });
+        continue;
+      }
+
+      for (const video of shippingVideos(selectLessonVideos(activeVideos))) {
+        const missing = videoGaps(video);
+        if (missing.length > 0) {
+          incompleteVideos.push({
+            sectionPath: section.path,
+            lessonPath: lesson.path,
+            videoTitle: video.title,
+            missing,
+          });
+        }
+      }
+    }
+  }
+
+  return { invalidLessonCombos, incompleteVideos };
+};
+
 // ── Builder ─────────────────────────────────────────────────────────────
 
 // The published .mp4 lands beside course.json under section-dir/lesson-dir at
-// the video's title (see syncToDropbox's copyFileToDropbox). The relative path
-// only points at a file that actually ships, so it is null exactly when the
-// export hash is — i.e. when the video has no exportable clips.
+// the video's title (see syncToDropbox's copyFileToDropbox). Only complete
+// Videos reach here — `videoGaps` has already been checked and found empty — so
+// the clips (hence hash), body, and description are all guaranteed present, and
+// every emitted field is non-null.
 function toVideoEntry(
   video: InputVideo,
   sectionPath: string,
@@ -232,29 +367,50 @@ function toVideoEntry(
     sourceStartTime: c.sourceStartTime,
     sourceEndTime: c.sourceEndTime,
   }));
-  const hash = computeExportHash(exportClips);
   return {
     id: video.lineageId,
-    relativePath: hash
-      ? `${sectionPath}/${lessonPath}/${video.title}.mp4`
-      : null,
-    body: video.body,
-    description: video.description,
-    hash,
+    relativePath: `${sectionPath}/${lessonPath}/${video.title}.mp4`,
+    body: video.body!,
+    description: video.description!,
+    hash: computeExportHash(exportClips)!,
     chapters: buildChapters(video.clips, video.chapters) ?? [],
   };
 }
 
 export const buildCourseJson = (
   input: BuildCourseJsonInput
-): Effect.Effect<CourseJsonDocument, InvalidLessonRoleComboError> =>
+): Effect.Effect<
+  CourseJsonDocument,
+  InvalidLessonRoleComboError | IncompleteVideosError
+> =>
   Effect.gen(function* () {
+    // The pre-publish gate and this backstop read the exact same blockers, so a
+    // manifest can never ship with a hole in it. Invalid role combos come first
+    // (they make roles ambiguous); we fail on the first, matching the page, which
+    // blocks publish until it's fixed. Incomplete Videos are reported all at once
+    // so the author fixes every gap in a single pass.
+    const blockers = collectPublishBlockers(
+      input.sections,
+      input.includeTodoLessons
+    );
+    if (blockers.invalidLessonCombos.length > 0) {
+      return yield* new InvalidLessonRoleComboError(
+        blockers.invalidLessonCombos[0]!
+      );
+    }
+    if (blockers.incompleteVideos.length > 0) {
+      return yield* new IncompleteVideosError({
+        videos: blockers.incompleteVideos,
+      });
+    }
+
     const sections: Array<typeof CourseJsonSectionSchema.Type> = [];
 
     // The effective-output filter is the single home of "what this publish
     // ships": it drops to-do Lessons when they are withheld, Lessons with no
     // active Videos, and Sections left with no shippable Lessons. Everything
-    // below then models only what actually ships.
+    // below then models only what actually ships. Every Lesson here is now a
+    // valid combo and every shipping Video complete (checked above).
     const effectiveSections = computeEffectiveSections(
       input.sections,
       input.includeTodoLessons
@@ -267,48 +423,42 @@ export const buildCourseJson = (
         const activeVideos = lesson.videos.filter((v) => !v.archived);
         if (activeVideos.length === 0) continue;
 
-        const warnings = computeLessonWarnings({ videos: activeVideos });
-        if (warnings.length > 0) {
-          return yield* new InvalidLessonRoleComboError({
-            sectionPath: section.path,
-            lessonPath: lesson.path,
-            videoTitles: activeVideos.map((v) => v.title),
-          });
-        }
-
-        const roleMap = activeVideos.map((v) => ({
-          video: v,
-          role: deriveVideoRole(v.title),
-        }));
-
-        const problem = roleMap.find((r) => r.role === "problem");
-        const solution = roleMap.find((r) => r.role === "solution");
-        const explainer = roleMap.find((r) => r.role === "explainer");
-
-        if (problem) {
-          if (solution) {
+        const selected = selectLessonVideos(activeVideos);
+        if (selected.type === "problem") {
+          if (selected.solution) {
             lessons.push({
               type: "problem",
               id: lesson.lineageId,
               title: lesson.title,
-              problem: toVideoEntry(problem.video, section.path, lesson.path),
-              solution: toVideoEntry(solution.video, section.path, lesson.path),
+              problem: toVideoEntry(
+                selected.problem,
+                section.path,
+                lesson.path
+              ),
+              solution: toVideoEntry(
+                selected.solution,
+                section.path,
+                lesson.path
+              ),
             });
           } else {
             lessons.push({
               type: "problem",
               id: lesson.lineageId,
               title: lesson.title,
-              problem: toVideoEntry(problem.video, section.path, lesson.path),
+              problem: toVideoEntry(
+                selected.problem,
+                section.path,
+                lesson.path
+              ),
             });
           }
         } else {
-          const video = explainer?.video ?? activeVideos[0]!;
           lessons.push({
             type: "explainer",
             id: lesson.lineageId,
             title: lesson.title,
-            explainer: toVideoEntry(video, section.path, lesson.path),
+            explainer: toVideoEntry(selected.video, section.path, lesson.path),
           });
         }
       }

--- a/app/packages/course-json/tests/course-json-validation.test.ts
+++ b/app/packages/course-json/tests/course-json-validation.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { Effect } from "effect";
-import { buildCourseJson, type BuildCourseJsonInput } from "../index";
+import {
+  buildCourseJson,
+  collectPublishBlockers,
+  type BuildCourseJsonInput,
+} from "../index";
 
+// A complete, shippable Video by default: every field course.json requires is
+// present (clips → hash + relativePath, a body, and a description). Tests that
+// exercise incompleteness override these to null / [] explicitly.
 const makeVideo = (
   overrides: Partial<
     BuildCourseJsonInput["sections"][0]["lessons"][0]["videos"][0]
@@ -10,10 +17,10 @@ const makeVideo = (
   }
 ) => ({
   lineageId: `vid-lineage-${overrides.title}`,
-  body: null,
-  description: null,
+  body: "Video body",
+  description: "Video description",
   archived: false,
-  clips: [],
+  clips: CLIPS,
   chapters: [],
   ...overrides,
 });
@@ -55,6 +62,24 @@ const makeInput = (
 
 const run = (input: BuildCourseJsonInput) =>
   Effect.runPromise(buildCourseJson(input));
+
+const runFlip = (input: BuildCourseJsonInput) =>
+  Effect.runPromise(buildCourseJson(input).pipe(Effect.flip));
+
+const CLIPS = [
+  {
+    videoFilename: "rec.mp4",
+    sourceStartTime: 0,
+    sourceEndTime: 10,
+    order: "a0",
+  },
+  {
+    videoFilename: "rec.mp4",
+    sourceStartTime: 15,
+    sourceEndTime: 25,
+    order: "a1",
+  },
+];
 
 describe("buildCourseJson – validation and filtering", () => {
   // ── Archived videos filtered ───────────────────────────────────────
@@ -309,10 +334,77 @@ describe("buildCourseJson – validation and filtering", () => {
     expect(result.sections[1]!.lessons[1]!.type).toBe("problem");
   });
 
-  // ── Body and description nullable ──────────────────────────────────
+  // ── Incomplete videos fail loudly ──────────────────────────────────
 
-  it("preserves null body and description on videos", async () => {
-    const result = await run(
+  it("fails when a shipping video has no exportable clips", async () => {
+    const error = await runFlip(
+      makeInput([
+        makeSection({
+          path: "01-intro",
+          lessons: [
+            makeLesson({
+              path: "01.01-welcome",
+              videos: [makeVideo({ title: "Explainer", clips: [] })],
+            }),
+          ],
+        }),
+      ])
+    );
+    expect(error).toMatchObject({
+      _tag: "IncompleteVideosError",
+      videos: [
+        {
+          sectionPath: "01-intro",
+          lessonPath: "01.01-welcome",
+          videoTitle: "Explainer",
+          missing: ["clips"],
+        },
+      ],
+    });
+  });
+
+  it("fails when a shipping video has no body", async () => {
+    const error = await runFlip(
+      makeInput([
+        makeSection({
+          path: "01-intro",
+          lessons: [
+            makeLesson({
+              path: "01.01-welcome",
+              videos: [makeVideo({ title: "Explainer", body: null })],
+            }),
+          ],
+        }),
+      ])
+    );
+    expect(error).toMatchObject({
+      _tag: "IncompleteVideosError",
+      videos: [{ videoTitle: "Explainer", missing: ["body"] }],
+    });
+  });
+
+  it("fails when a shipping video has no description", async () => {
+    const error = await runFlip(
+      makeInput([
+        makeSection({
+          path: "01-intro",
+          lessons: [
+            makeLesson({
+              path: "01.01-welcome",
+              videos: [makeVideo({ title: "Explainer", description: null })],
+            }),
+          ],
+        }),
+      ])
+    );
+    expect(error).toMatchObject({
+      _tag: "IncompleteVideosError",
+      videos: [{ videoTitle: "Explainer", missing: ["description"] }],
+    });
+  });
+
+  it("reports every missing field on a single video", async () => {
+    const error = await runFlip(
       makeInput([
         makeSection({
           path: "01-intro",
@@ -322,6 +414,7 @@ describe("buildCourseJson – validation and filtering", () => {
               videos: [
                 makeVideo({
                   title: "Explainer",
+                  clips: [],
                   body: null,
                   description: null,
                 }),
@@ -331,11 +424,41 @@ describe("buildCourseJson – validation and filtering", () => {
         }),
       ])
     );
+    expect(error).toMatchObject({
+      _tag: "IncompleteVideosError",
+      videos: [{ missing: ["clips", "body", "description"] }],
+    });
+  });
 
-    const lesson = result.sections[0]!.lessons[0]!;
-    if (lesson.type === "explainer") {
-      expect(lesson.explainer.body).toBeNull();
-      expect(lesson.explainer.description).toBeNull();
+  it("collects every incomplete video across the whole course before failing", async () => {
+    const error = await runFlip(
+      makeInput([
+        makeSection({
+          path: "01-intro",
+          lessons: [
+            makeLesson({
+              path: "01.01-welcome",
+              videos: [makeVideo({ title: "Explainer", clips: [] })],
+            }),
+          ],
+        }),
+        makeSection({
+          path: "02-exercises",
+          lessons: [
+            makeLesson({
+              path: "02.01-exercise",
+              videos: [makeVideo({ title: "Problem", body: null })],
+            }),
+          ],
+        }),
+      ])
+    );
+    expect(error).toMatchObject({ _tag: "IncompleteVideosError" });
+    if (error._tag === "IncompleteVideosError") {
+      expect(error.videos.map((v) => v.videoTitle)).toEqual([
+        "Explainer",
+        "Problem",
+      ]);
     }
   });
 
@@ -445,5 +568,175 @@ describe("buildCourseJson – validation and filtering", () => {
     for (const section of result.sections) {
       expect(section.lessons.length).toBeGreaterThan(0);
     }
+  });
+});
+
+// The pre-publish page reads collectPublishBlockers to warn and block before a
+// doomed publish; buildCourseJson reads the same result as its backstop. These
+// cover the collector's enumeration directly.
+describe("collectPublishBlockers", () => {
+  it("returns no blockers for a complete course", () => {
+    const blockers = collectPublishBlockers(
+      [
+        makeSection({
+          path: "01-intro",
+          lessons: [
+            makeLesson({
+              path: "01.01-welcome",
+              videos: [makeVideo({ title: "Explainer" })],
+            }),
+          ],
+        }),
+      ],
+      true
+    );
+    expect(blockers).toEqual({
+      invalidLessonCombos: [],
+      incompleteVideos: [],
+    });
+  });
+
+  it("collects every incomplete shipping video across the course", () => {
+    const blockers = collectPublishBlockers(
+      [
+        makeSection({
+          path: "01-intro",
+          lessons: [
+            makeLesson({
+              path: "01.01-welcome",
+              videos: [makeVideo({ title: "Explainer", clips: [] })],
+            }),
+          ],
+        }),
+        makeSection({
+          path: "02-exercises",
+          lessons: [
+            makeLesson({
+              path: "02.01-exercise",
+              videos: [makeVideo({ title: "Problem", body: null })],
+            }),
+          ],
+        }),
+      ],
+      true
+    );
+    expect(blockers.invalidLessonCombos).toEqual([]);
+    expect(blockers.incompleteVideos).toEqual([
+      {
+        sectionPath: "01-intro",
+        lessonPath: "01.01-welcome",
+        videoTitle: "Explainer",
+        missing: ["clips"],
+      },
+      {
+        sectionPath: "02-exercises",
+        lessonPath: "02.01-exercise",
+        videoTitle: "Problem",
+        missing: ["body"],
+      },
+    ]);
+  });
+
+  it("collects every invalid lesson combo", () => {
+    const blockers = collectPublishBlockers(
+      [
+        makeSection({
+          path: "01-intro",
+          lessons: [
+            makeLesson({
+              path: "01.01-exercise",
+              videos: [makeVideo({ title: "Solution" })],
+            }),
+            makeLesson({
+              path: "01.02-exercise",
+              videos: [
+                makeVideo({ title: "Explainer" }),
+                makeVideo({ title: "Problem" }),
+              ],
+            }),
+          ],
+        }),
+      ],
+      true
+    );
+    expect(blockers.incompleteVideos).toEqual([]);
+    expect(blockers.invalidLessonCombos).toMatchObject([
+      { lessonPath: "01.01-exercise", videoTitles: ["Solution"] },
+      {
+        lessonPath: "01.02-exercise",
+        videoTitles: ["Explainer", "Problem"],
+      },
+    ]);
+  });
+
+  it("does not gap-check a lesson with an invalid combo (roles are ambiguous)", () => {
+    const blockers = collectPublishBlockers(
+      [
+        makeSection({
+          path: "01-intro",
+          lessons: [
+            makeLesson({
+              path: "01.01-exercise",
+              // Invalid combo AND both videos incomplete — only the combo is
+              // reported, since we can't say which video plays which role.
+              videos: [
+                makeVideo({ title: "Explainer", clips: [] }),
+                makeVideo({ title: "Problem", clips: [] }),
+              ],
+            }),
+          ],
+        }),
+      ],
+      true
+    );
+    expect(blockers.incompleteVideos).toEqual([]);
+    expect(blockers.invalidLessonCombos).toHaveLength(1);
+  });
+
+  it("ignores withheld to-do lessons", () => {
+    const sections = [
+      makeSection({
+        path: "01-intro",
+        lessons: [
+          makeLesson({
+            path: "01.01-todo",
+            authoringStatus: "todo",
+            videos: [makeVideo({ title: "Explainer", clips: [] })],
+          }),
+        ],
+      }),
+    ];
+    // Included → the incomplete to-do video is a blocker.
+    expect(
+      collectPublishBlockers(sections, true).incompleteVideos
+    ).toHaveLength(1);
+    // Withheld → it doesn't ship, so it isn't a blocker.
+    expect(
+      collectPublishBlockers(sections, false).incompleteVideos
+    ).toHaveLength(0);
+  });
+
+  it("ignores archived videos", () => {
+    const blockers = collectPublishBlockers(
+      [
+        makeSection({
+          path: "01-intro",
+          lessons: [
+            makeLesson({
+              path: "01.01-welcome",
+              videos: [
+                makeVideo({ title: "Old", archived: true, clips: [] }),
+                makeVideo({ title: "Explainer" }),
+              ],
+            }),
+          ],
+        }),
+      ],
+      true
+    );
+    expect(blockers).toEqual({
+      invalidLessonCombos: [],
+      incompleteVideos: [],
+    });
   });
 });

--- a/app/packages/course-json/tests/course-json.test.ts
+++ b/app/packages/course-json/tests/course-json.test.ts
@@ -3,6 +3,9 @@ import { Effect } from "effect";
 import { buildCourseJson, type BuildCourseJsonInput } from "../index";
 import { computeExportHash } from "@/services/export-hash";
 
+// A complete, shippable Video by default: every field course.json requires is
+// present (clips → hash + relativePath, a body, and a description). Tests that
+// exercise incompleteness override these to null / [] explicitly.
 const makeVideo = (
   overrides: Partial<
     BuildCourseJsonInput["sections"][0]["lessons"][0]["videos"][0]
@@ -11,10 +14,10 @@ const makeVideo = (
   }
 ) => ({
   lineageId: `vid-lineage-${overrides.title}`,
-  body: null,
-  description: null,
+  body: "Video body",
+  description: "Video description",
   archived: false,
-  clips: [],
+  clips: CLIPS,
   chapters: [],
   ...overrides,
 });
@@ -175,7 +178,6 @@ describe("buildCourseJson", () => {
       explainer: {
         body: "# Hello",
         description: "SEO text",
-        hash: null,
         chapters: [],
       },
     });
@@ -292,27 +294,6 @@ describe("buildCourseJson", () => {
     }
   });
 
-  it("sets hash to null when video has no clips", async () => {
-    const result = await run(
-      makeInput([
-        makeSection({
-          path: "01-intro",
-          lessons: [
-            makeLesson({
-              path: "01.01-welcome",
-              videos: [makeVideo({ title: "Explainer", clips: [] })],
-            }),
-          ],
-        }),
-      ])
-    );
-
-    const lesson = result.sections[0]!.lessons[0]!;
-    if (lesson.type === "explainer") {
-      expect(lesson.explainer.hash).toBeNull();
-    }
-  });
-
   // ── Relative path per video ────────────────────────────────────────
 
   it("sets relativePath to section-dir/lesson-dir/title.mp4 for an exportable video", async () => {
@@ -335,27 +316,6 @@ describe("buildCourseJson", () => {
       expect(lesson.explainer.relativePath).toBe(
         "03-concepts/03.01-models-harnesses-agents-environments/Explainer.mp4"
       );
-    }
-  });
-
-  it("sets relativePath to null when video has no clips", async () => {
-    const result = await run(
-      makeInput([
-        makeSection({
-          path: "01-intro",
-          lessons: [
-            makeLesson({
-              path: "01.01-welcome",
-              videos: [makeVideo({ title: "Explainer", clips: [] })],
-            }),
-          ],
-        }),
-      ])
-    );
-
-    const lesson = result.sections[0]!.lessons[0]!;
-    if (lesson.type === "explainer") {
-      expect(lesson.explainer.relativePath).toBeNull();
     }
   });
 

--- a/app/routes/_app.courses.$courseId.publish.tsx
+++ b/app/routes/_app.courses.$courseId.publish.tsx
@@ -60,10 +60,14 @@ export const loader = makeLoader({
         withTodo: {
           unexportedVideoCount: withTodo.unexportedVideoIds.length,
           courseViewLintCount: withTodo.courseViewLintCount,
+          invalidLessonCombos: withTodo.invalidLessonCombos,
+          incompleteVideos: withTodo.incompleteVideos,
         },
         withoutTodo: {
           unexportedVideoCount: withoutTodo.unexportedVideoIds.length,
           courseViewLintCount: withoutTodo.courseViewLintCount,
+          invalidLessonCombos: withoutTodo.invalidLessonCombos,
+          incompleteVideos: withoutTodo.incompleteVideos,
         },
       };
     }),
@@ -108,13 +112,19 @@ export default function Component(props: Route.ComponentProps) {
   const effective = includeTodoLessons ? withTodo : withoutTodo;
   const unexportedVideoCount = effective.unexportedVideoCount;
   const courseViewLintCount = effective.courseViewLintCount;
+  const invalidLessonCombos = effective.invalidLessonCombos;
+  const incompleteVideos = effective.incompleteVideos;
 
   const hasUnexportedVideos = unexportedVideoCount > 0;
   const hasCourseViewLints = courseViewLintCount > 0;
+  const hasInvalidLessonCombos = invalidLessonCombos.length > 0;
+  const hasIncompleteVideos = incompleteVideos.length > 0;
   const canPublish =
     name.trim().length > 0 &&
     !hasUnexportedVideos &&
     !hasCourseViewLints &&
+    !hasInvalidLessonCombos &&
+    !hasIncompleteVideos &&
     !publishStarted &&
     !isOperationInProgress;
 
@@ -247,6 +257,75 @@ export default function Component(props: Route.ComponentProps) {
                 before publishing
               </span>
             </div>
+          </div>
+        )}
+
+        {/* Incomplete Videos — a shipping video missing clips, body, or
+            description. Every field in course.json is required, so publishing
+            one would fail the build; block it here (see ADR 0019). */}
+        {hasIncompleteVideos && (
+          <div className="mb-8 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4">
+            <div className="flex items-center gap-2 mb-3">
+              <AlertTriangle className="w-5 h-5 text-amber-500" />
+              <span className="text-sm font-medium text-amber-500">
+                {incompleteVideos.length} incomplete video
+                {incompleteVideos.length !== 1 ? "s" : ""} — finish{" "}
+                {incompleteVideos.length !== 1 ? "these" : "this"} before
+                publishing
+              </span>
+            </div>
+            <ul className="space-y-1.5">
+              {incompleteVideos.map((video) => (
+                <li
+                  key={`${video.sectionPath}/${video.lessonPath}/${video.videoTitle}`}
+                  className="text-xs text-muted-foreground"
+                >
+                  <span className="font-medium text-foreground">
+                    {video.videoTitle}
+                  </span>{" "}
+                  <span className="text-amber-500">
+                    (missing {video.missing.join(", ")})
+                  </span>
+                  <span className="block text-muted-foreground/70">
+                    {video.sectionPath} / {video.lessonPath}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Invalid Lesson Role Combos — a lesson whose videos don't form a valid
+            explainer / problem / solution combo. buildCourseJson can't resolve
+            it, so block publish until the roles are fixed in the course view. */}
+        {hasInvalidLessonCombos && (
+          <div className="mb-8 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4">
+            <div className="flex items-center gap-2 mb-3">
+              <AlertTriangle className="w-5 h-5 text-amber-500" />
+              <span className="text-sm font-medium text-amber-500">
+                {invalidLessonCombos.length} lesson
+                {invalidLessonCombos.length !== 1 ? "s" : ""} with an invalid
+                video combo — fix in the course view before publishing
+              </span>
+            </div>
+            <ul className="space-y-1.5">
+              {invalidLessonCombos.map((lesson) => (
+                <li
+                  key={`${lesson.sectionPath}/${lesson.lessonPath}`}
+                  className="text-xs text-muted-foreground"
+                >
+                  <span className="font-medium text-foreground">
+                    {lesson.lessonPath}
+                  </span>{" "}
+                  <span className="text-amber-500">
+                    ({lesson.videoTitles.join(", ")})
+                  </span>
+                  <span className="block text-muted-foreground/70">
+                    {lesson.sectionPath}
+                  </span>
+                </li>
+              ))}
+            </ul>
           </div>
         )}
 

--- a/app/services/course-publish-service-sync.test.ts
+++ b/app/services/course-publish-service-sync.test.ts
@@ -122,6 +122,16 @@ const setupSync = async () => {
     });
   }).pipe(Effect.provide(dbLayer), Effect.runPromise);
 
+  // Every shipping Video needs a body and description to publish (see ADR 0019).
+  await testDb
+    .update(videosTable)
+    .set({ body: "Video body", description: "Video description" })
+    .where(eq(videosTable.id, video1.id));
+  await testDb
+    .update(videosTable)
+    .set({ body: "Video body", description: "Video description" })
+    .where(eq(videosTable.id, video2.id));
+
   const clipData = [
     {
       videoFilename: "recording.mp4",

--- a/app/services/course-publish-service.test.ts
+++ b/app/services/course-publish-service.test.ts
@@ -363,6 +363,27 @@ describe("CoursePublishService", () => {
 
       expect(result.unexportedVideoIds).toEqual([]);
     });
+
+    it("surfaces incomplete shipping videos (the seed video has no body/description)", async () => {
+      const { version, run } = await setup();
+
+      const result = await run(
+        Effect.gen(function* () {
+          const svc = yield* CoursePublishService;
+          return (yield* svc.validatePublishability(version.id)).withTodo;
+        })
+      );
+
+      expect(result.incompleteVideos).toMatchObject([
+        {
+          sectionPath: "01-intro",
+          lessonPath: "01.01-welcome",
+          videoTitle: "Problem",
+          missing: ["body", "description"],
+        },
+      ]);
+      expect(result.invalidLessonCombos).toEqual([]);
+    });
   });
 
   describe("batchExport", () => {

--- a/app/services/course-publish-service.ts
+++ b/app/services/course-publish-service.ts
@@ -22,6 +22,7 @@ import { computeCourseViewLintCount } from "./lesson-warnings";
 import {
   buildCourseJson,
   buildCourseJsonSchema,
+  collectPublishBlockers,
   computeEffectiveSections,
 } from "@/packages/course-json";
 
@@ -307,7 +308,19 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
             }
             const courseViewLintCount =
               computeCourseViewLintCount(effectiveSections);
-            return { unexportedVideoIds, courseViewLintCount };
+
+            // Publish blockers computed from the exact same walk buildCourseJson
+            // uses (its backstop), so the pre-publish warnings and the build
+            // failure can never disagree — see collectPublishBlockers.
+            const { invalidLessonCombos, incompleteVideos } =
+              collectPublishBlockers(version.sections, includeTodoLessons);
+
+            return {
+              unexportedVideoIds,
+              courseViewLintCount,
+              invalidLessonCombos,
+              incompleteVideos,
+            };
           };
 
           return {

--- a/docs/adr/0019-course-json-fields-are-required.md
+++ b/docs/adr/0019-course-json-fields-are-required.md
@@ -1,0 +1,41 @@
+# course.json fields are required, and incomplete Videos fail the Publish
+
+Every field on a **Video** in `course.json` — `relativePath`, `hash`, `body`, and `description` — is **required and non-nullable**. A Video reaches the manifest only if it is complete: it has exportable **Clips** (which produce its `.mp4` and its **Export Hash**) and both an authored `body` and `description`. When a shipping Video is missing any of these, **Publish fails** with the full list of gaps rather than emitting a `null`.
+
+## Why this shape
+
+- **A `null` here was fake optionality, not real optionality.** These fields were previously `NullOr(String)`, but a null never meant "this Video legitimately has no path/hash/body/description" — it meant the Video was unfinished. `relativePath` and `hash` were null exactly when the Video had no Clips (nothing to ship); `body`/`description` were null when the author simply hadn't written them yet. Each is a gap on our side, so the manifest should never carry it. A downstream consumer should be able to trust that every emitted Video has a real file path, a real hash, and real copy.
+
+- **The Publish is the right place to catch it.** Publish is already the gate that decides "what this course ships" (the effective-output filter, role-combo validation). Requiring completeness there means a broken manifest can never reach Dropbox — the failure is loud, at the moment of publishing, naming the offending Videos.
+
+- **Collect every gap, then fail.** `buildCourseJson` scans the whole course, gathers every incomplete Video (`IncompleteVideosError` carries a list of `{ sectionPath, lessonPath, videoTitle, missing }`), and fails once. The author fixes all gaps in a single pass instead of re-running Publish and hitting them one at a time.
+
+## Considered alternatives
+
+- **Silently elide clip-less Videos** (the way empty Sections are elided). Rejected: a Video with no Clips inside a shipping Lesson is a mistake we want surfaced, not a Video to quietly drop. Dropping it hides the problem and can leave a Lesson looking complete when it isn't.
+
+- **Keep `body`/`description` genuinely optional (key-absent, not null).** Rejected for these two fields: every shipping Video is supposed to have both, so a missing one is an authoring gap to catch, not honest absence.
+
+- **Fail fast on the first gap.** Rejected: whack-a-mole. Collecting all gaps up front is strictly friendlier when a course has several unfinished Videos.
+
+## What stays optional
+
+- **`lesson.solution`** remains an optional (key-absent) field. A **Problem** Lesson can legitimately ship without a worked-solution Video, so its absence is real optionality — modelled honestly as a missing key, never as `null`.
+
+## Surfaced before publish, not just at publish
+
+The failure is a lousy first line of defence — by the time `buildCourseJson` throws, the author has already hit Publish. So the blockers are enumerated **up front** and shown on the publish page, where they block the button (exactly like the existing "unexported videos" and "course-view lints" gates).
+
+The key move is a single shared collector, `collectPublishBlockers(sections, includeTodoLessons)`, that walks the effective output once and returns **every** blocker: incomplete Videos _and_ invalid Lesson role combos (a lone solution, an explainer beside a problem, duplicate roles, …). Both consumers read it:
+
+- **The publish page** (`validatePublishability` → loader → amber warning cards) lists them per toggle position and disables Publish until they're fixed.
+- **`buildCourseJson`** calls the same collector as its backstop and fails on a non-empty result.
+
+Because the warning and the failure derive from the _same walk_, they can never disagree — the thing that warns you is literally the thing that would fail. Invalid Lesson combos, previously also invisible (they surfaced only as the generic "Publish failed unexpectedly"), now show on the page too.
+
+## Consequences
+
+- `CourseJsonVideo` fields `relativePath`, `hash`, `body`, `description` are now `Schema.String`; `$schema` on the document is now required (the builder always emits it). The generated `course.schema.json` sidecar tightens to match.
+- `buildCourseJson`'s error channel gains `IncompleteVideosError` alongside `InvalidLessonRoleComboError`; both propagate through Publish and fail it loudly as the backstop.
+- `collectPublishBlockers` is the single source of truth for "why can't this publish?"; `validatePublishability` returns its `incompleteVideos` and `invalidLessonCombos` for both toggle positions, and the publish page blocks on them.
+- Archived Videos are never checked — completeness is asked only of Videos that actually ship.


### PR DESCRIPTION
## What

Two connected changes.

### 1. Every `course.json` Video field is required (no more fake nulls)
`relativePath`, `hash`, `body`, `description` were `NullOr(String)`, but a `null` never meant real optionality — it meant the Video was unfinished. All four are now required `string`, and `$schema` on the document is required too. A Video reaches the manifest only if it's **complete**: exportable **Clips** (→ `.mp4` + **Export Hash**) plus an authored `body` and `description`.

`lesson.solution` **stays optional** (key-absent) — a Problem lesson can legitimately ship without a worked solution, so that's genuine optionality, honestly modelled.

### 2. Publish blockers are shown on the publish page (and block it)
Previously `buildCourseJson`'s failures (`IncompleteVideosError`, and the pre-existing `InvalidLessonRoleComboError`) were **invisible** — they have no `message`, so the SSE fallback rendered a bare *"Publish failed unexpectedly"* and dropped which videos/lessons were at fault.

Now a single shared collector — `collectPublishBlockers(sections, includeTodoLessons)` — walks the effective output once and returns **every** blocker (incomplete Videos + invalid Lesson role combos). Both consumers read it:
- **The publish page** (`validatePublishability` → loader → amber warning cards) lists them per toggle position and **disables Publish** until fixed, exactly like the existing unexported-videos / course-view-lint gates.
- **`buildCourseJson`** calls the same collector as its non-negotiable backstop.

Because the warning and the failure come from the *same walk*, they can never disagree — the thing that warns you is literally the thing that would fail. Invalid lesson combos, also invisible before, now surface too.

### Per-field verdicts (from the grilling session)
| Field | Was | Now |
|---|---|---|
| `video.relativePath` | `null` when no clips | required `string`; blocked pre-publish + build backstop |
| `video.hash` | `null` when no clips | required `string`; blocked pre-publish + build backstop |
| `video.body` | `null` when unauthored | required `string`; blocked pre-publish + build backstop |
| `video.description` | `null` when unauthored | required `string`; blocked pre-publish + build backstop |
| `lesson.solution` | optional (key-absent) | unchanged — genuine optionality |
| `$schema` | optional (always emitted) | required |

## Notes
- Decision recorded as **ADR 0019** (incl. the pre-publish surface + shared collector) and summarised on the `Publish` glossary entry in `CONTEXT.md`.
- `course.schema.json` sidecar tightens automatically. The current real published manifest already has zero nulls, so no live output changes shape.

## Tests
- `course-json` package: null-behaviour tests rewritten as `IncompleteVideosError` tests; new `collectPublishBlockers` suite (complete course, incomplete-across-course, invalid combos, combo-suppresses-gap-check, withheld-to-do, archived-ignored). **41 pass.**
- `course-publish-service`: new wiring test that `validatePublishability` surfaces incomplete videos from real DB data. **18 pass.**
- `course-publish-service-sync`: fixtures given body/description. **13 pass.**
- Full suite: only pre-existing, unrelated CLI-harness ANSI-parsing failures remain (identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)