### PR TITLE
feat: capture on-screen web links during recording via Chrome extension

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -76,6 +76,10 @@ _Avoid_: Clip group, Divider, Marker, Section (ambiguous with course Section)
 A clip added to the frontend state during recording before it is persisted to the database.
 _Avoid_: Pending clip, Temporary clip
 
+**Clip Web Link**:
+A web page that was on screen — in a focused Chrome window, showing an `http(s)` page — while a **Clip** was being recorded. A one-to-many child of a Clip (a Clip can have several), captured live during the **Optimistic Clip** lifecycle from the browser link-capture Chrome extension (see `chrome-extension/`), which streams focus/URL events over the Stream Deck **WebSocket** hub. Deduped to one row per distinct URL per Clip. Surfaced as chips under the Clip in the editor and annotated inline in the **Transcript** (`«on screen: …»`, deduped to a URL's first appearance) so the writer agent knows which page accompanied each moment. Deliberately distinct from the global **Link** list (course-wide reference URLs with no clip/timing association): a Clip Web Link is positional and per-clip.
+_Avoid_: Link (reserved for the global reference-URL list), Clip URL, On-screen link (informal, ok in prose)
+
 **Transcript**:
 The ordered text projection of a **Video** — its **Clips** and **Chapters** interleaved in timeline order. The unit of comparison for changelog diffs. Changes to either Clips or Chapters are first-class changes to the Transcript: a Chapter rename, insertion, deletion, or reorder is a Transcript change in the same sense that editing a Clip's text is. Rendered with each Chapter as a `## <name>` header between paragraphs of clip text.
 _Avoid_: Clip text (only covers Clips), Joined clips, Caption (reserved for the per-clip transcription product)

--- a/app/db/migrations/0002_regular_steel_serpent.sql
+++ b/app/db/migrations/0002_regular_steel_serpent.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "course-video-manager_clip_web_link" (
+	"id" varchar(255) PRIMARY KEY NOT NULL,
+	"clip_id" varchar(255) NOT NULL,
+	"url" text NOT NULL,
+	"title" text,
+	"captured_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "course-video-manager_clip_web_link" ADD CONSTRAINT "course-video-manager_clip_web_link_clip_id_course-video-manager_clip_id_fk" FOREIGN KEY ("clip_id") REFERENCES "public"."course-video-manager_clip"("id") ON DELETE cascade ON UPDATE no action;

--- a/app/db/migrations/meta/0002_snapshot.json
+++ b/app/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1560 @@
+{
+  "id": "012d94a4-cc75-4345-9ed6-1e5eb9331823",
+  "prevId": "a4581526-2663-4bce-a671-e2733bf3b7f5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.course-video-manager_ai_hero_auth": {
+      "name": "course-video-manager_ai_hero_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_beat": {
+      "name": "course-video-manager_beat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'definition'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "order": {
+          "name": "order",
+          "type": "varchar(255) COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_beat_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_beat_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_beat",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": [
+            "video_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_chapter": {
+      "name": "course-video-manager_chapter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "varchar(255) COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_chapter_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_chapter_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_chapter",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": [
+            "video_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_clip_web_link": {
+      "name": "course-video-manager_clip_web_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clip_id": {
+          "name": "clip_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_clip_web_link_clip_id_course-video-manager_clip_id_fk": {
+          "name": "course-video-manager_clip_web_link_clip_id_course-video-manager_clip_id_fk",
+          "tableFrom": "course-video-manager_clip_web_link",
+          "tableTo": "course-video-manager_clip",
+          "columnsFrom": [
+            "clip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_clip": {
+      "name": "course-video-manager_clip",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video_filename": {
+          "name": "video_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_start_time": {
+          "name": "source_start_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_end_time": {
+          "name": "source_end_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order": {
+          "name": "order",
+          "type": "varchar(255) COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcribed_at": {
+          "name": "transcribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene": {
+          "name": "scene",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_type": {
+          "name": "pause_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "diagram_snapshot_id": {
+          "name": "diagram_snapshot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_clip_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_clip_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_clip",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": [
+            "video_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course-video-manager_clip_diagram_snapshot_id_course-video-manager_diagram_snapshot_id_fk": {
+          "name": "course-video-manager_clip_diagram_snapshot_id_course-video-manager_diagram_snapshot_id_fk",
+          "tableFrom": "course-video-manager_clip",
+          "tableTo": "course-video-manager_diagram_snapshot",
+          "columnsFrom": [
+            "diagram_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_course_version": {
+      "name": "course-video-manager_course_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_course_version_course_id_course-video-manager_course_id_fk": {
+          "name": "course-video-manager_course_version_course_id_course-video-manager_course_id_fk",
+          "tableFrom": "course-video-manager_course_version",
+          "tableTo": "course-video-manager_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_course": {
+      "name": "course-video-manager_course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory": {
+          "name": "memory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "course_slug_uniq": {
+          "name": "course_slug_uniq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "NOT \"course-video-manager_course\".\"archived\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_deliverable": {
+      "name": "course-video-manager_deliverable",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_deliverable_course": {
+      "name": "course-video-manager_deliverable_course",
+      "schema": "",
+      "columns": {
+        "deliverable_id": {
+          "name": "deliverable_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_deliverable_course_deliverable_id_course-video-manager_deliverable_id_fk": {
+          "name": "course-video-manager_deliverable_course_deliverable_id_course-video-manager_deliverable_id_fk",
+          "tableFrom": "course-video-manager_deliverable_course",
+          "tableTo": "course-video-manager_deliverable",
+          "columnsFrom": [
+            "deliverable_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course-video-manager_deliverable_course_course_id_course-video-manager_course_id_fk": {
+          "name": "course-video-manager_deliverable_course_course_id_course-video-manager_course_id_fk",
+          "tableFrom": "course-video-manager_deliverable_course",
+          "tableTo": "course-video-manager_course",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course-video-manager_deliverable_course_deliverable_id_course_id_pk": {
+          "name": "course-video-manager_deliverable_course_deliverable_id_course_id_pk",
+          "columns": [
+            "deliverable_id",
+            "course_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_deliverable_pitch": {
+      "name": "course-video-manager_deliverable_pitch",
+      "schema": "",
+      "columns": {
+        "deliverable_id": {
+          "name": "deliverable_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pitch_id": {
+          "name": "pitch_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_deliverable_pitch_deliverable_id_course-video-manager_deliverable_id_fk": {
+          "name": "course-video-manager_deliverable_pitch_deliverable_id_course-video-manager_deliverable_id_fk",
+          "tableFrom": "course-video-manager_deliverable_pitch",
+          "tableTo": "course-video-manager_deliverable",
+          "columnsFrom": [
+            "deliverable_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course-video-manager_deliverable_pitch_pitch_id_course-video-manager_pitch_id_fk": {
+          "name": "course-video-manager_deliverable_pitch_pitch_id_course-video-manager_pitch_id_fk",
+          "tableFrom": "course-video-manager_deliverable_pitch",
+          "tableTo": "course-video-manager_pitch",
+          "columnsFrom": [
+            "pitch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course-video-manager_deliverable_pitch_deliverable_id_pitch_id_pk": {
+          "name": "course-video-manager_deliverable_pitch_deliverable_id_pitch_id_pk",
+          "columns": [
+            "deliverable_id",
+            "pitch_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_diagram_snapshot": {
+      "name": "course-video-manager_diagram_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "diagram_id": {
+          "name": "diagram_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene": {
+          "name": "scene",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preserved": {
+          "name": "preserved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(search_text, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "diagram_snapshot_diagram_id_content_hash_idx": {
+          "name": "diagram_snapshot_diagram_id_content_hash_idx",
+          "columns": [
+            {
+              "expression": "diagram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diagram_snapshot_search_vector_idx": {
+          "name": "diagram_snapshot_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_diagram_snapshot_diagram_id_course-video-manager_diagram_id_fk": {
+          "name": "course-video-manager_diagram_snapshot_diagram_id_course-video-manager_diagram_id_fk",
+          "tableFrom": "course-video-manager_diagram_snapshot",
+          "tableTo": "course-video-manager_diagram",
+          "columnsFrom": [
+            "diagram_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_diagram": {
+      "name": "course-video-manager_diagram",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled 1'"
+        },
+        "head_scene": {
+          "name": "head_scene",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(search_text, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "diagram_search_vector_idx": {
+          "name": "diagram_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_lesson": {
+      "name": "course-video-manager_lesson",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_version_lesson_id": {
+          "name": "previous_version_lesson_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authoring_status": {
+          "name": "authoring_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order": {
+          "name": "order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "lesson_section_order_uniq": {
+          "name": "lesson_section_order_uniq",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "NOT \"course-video-manager_lesson\".\"archived\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_lesson_section_id_course-video-manager_section_id_fk": {
+          "name": "course-video-manager_lesson_section_id_course-video-manager_section_id_fk",
+          "tableFrom": "course-video-manager_lesson",
+          "tableTo": "course-video-manager_section",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_link": {
+      "name": "course-video-manager_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "course-video-manager_link_url_unique": {
+          "name": "course-video-manager_link_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_pitch": {
+      "name": "course-video-manager_pitch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_plan": {
+          "name": "content_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "youtube_title": {
+          "name": "youtube_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "youtube_thumbnail_description": {
+          "name": "youtube_thumbnail_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "newsletter_title": {
+          "name": "newsletter_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tweet": {
+          "name": "tweet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "effort": {
+          "name": "effort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_section": {
+      "name": "course-video-manager_section",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_version_id": {
+          "name": "course_version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_version_section_id": {
+          "name": "previous_version_section_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order": {
+          "name": "order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "section_version_order_uniq": {
+          "name": "section_version_order_uniq",
+          "columns": [
+            {
+              "expression": "course_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course-video-manager_section\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_section_course_version_id_course-video-manager_course_version_id_fk": {
+          "name": "course-video-manager_section_course_version_id_course-video-manager_course_version_id_fk",
+          "tableFrom": "course-video-manager_section",
+          "tableTo": "course-video-manager_course_version",
+          "columnsFrom": [
+            "course_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_thumbnail": {
+      "name": "course-video-manager_thumbnail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layers": {
+          "name": "layers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_for_upload": {
+          "name": "selected_for_upload",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_thumbnail_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_thumbnail_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_thumbnail",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": [
+            "video_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_video": {
+      "name": "course-video-manager_video",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pitch_id": {
+          "name": "pitch_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_footage_path": {
+          "name": "original_footage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_description": {
+          "name": "video_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "video_lesson_title_uniq": {
+          "name": "video_lesson_title_uniq",
+          "columns": [
+            {
+              "expression": "lesson_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "NOT \"course-video-manager_video\".\"archived\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_video_lesson_id_course-video-manager_lesson_id_fk": {
+          "name": "course-video-manager_video_lesson_id_course-video-manager_lesson_id_fk",
+          "tableFrom": "course-video-manager_video",
+          "tableTo": "course-video-manager_lesson",
+          "columnsFrom": [
+            "lesson_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course-video-manager_video_pitch_id_course-video-manager_pitch_id_fk": {
+          "name": "course-video-manager_video_pitch_id_course-video-manager_pitch_id_fk",
+          "tableFrom": "course-video-manager_video",
+          "tableTo": "course-video-manager_pitch",
+          "columnsFrom": [
+            "pitch_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_youtube_auth": {
+      "name": "course-video-manager_youtube_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/db/migrations/meta/_journal.json
+++ b/app/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783632802590,
       "tag": "0001_sudden_maelstrom",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784029785555,
+      "tag": "0002_regular_steel_serpent",
+      "breakpoints": true
     }
   ]
 }

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -268,6 +268,32 @@ export const clips = createTable("clip", {
   ),
 });
 
+/**
+ * Web pages that were on screen (in a focused Chrome window) while a clip was
+ * being recorded. Captured live during the optimistic-clip lifecycle from the
+ * browser link-capture extension, one row per distinct URL shown during the
+ * clip. See docs/adr on clip web links and the `chrome-extension/` directory.
+ */
+export const clipWebLinks = createTable("clip_web_link", {
+  id: varchar("id", { length: 255 })
+    .notNull()
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  clipId: varchar("clip_id", { length: 255 })
+    .references(() => clips.id, { onDelete: "cascade" })
+    .notNull(),
+  url: text("url").notNull(),
+  title: text("title"),
+  // Wall-clock time the URL was first shown during the clip. Used to order the
+  // links within a clip chronologically.
+  capturedAt: timestamp("captured_at", {
+    mode: "date",
+    withTimezone: true,
+  })
+    .notNull()
+    .default(sql`CURRENT_TIMESTAMP`),
+});
+
 export const chapters = createTable("chapter", {
   id: varchar("id", { length: 255 })
     .notNull()
@@ -322,13 +348,29 @@ export namespace DB {
   > {
     id: DatabaseId;
   }
+
+  export interface ClipWebLink extends Omit<
+    InferSelectModel<typeof clipWebLinks>,
+    "id" | "clipId"
+  > {
+    id: DatabaseId;
+    clipId: DatabaseId;
+  }
 }
 
-export const clipsRelations = relations(clips, ({ one }) => ({
+export const clipsRelations = relations(clips, ({ one, many }) => ({
   video: one(videos, { fields: [clips.videoId], references: [videos.id] }),
   diagramSnapshot: one(diagramSnapshots, {
     fields: [clips.diagramSnapshotId],
     references: [diagramSnapshots.id],
+  }),
+  webLinks: many(clipWebLinks),
+}));
+
+export const clipWebLinksRelations = relations(clipWebLinks, ({ one }) => ({
+  clip: one(clips, {
+    fields: [clipWebLinks.clipId],
+    references: [clips.id],
   }),
 }));
 

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -272,7 +272,8 @@ export const clips = createTable("clip", {
  * Web pages that were on screen (in a focused Chrome window) while a clip was
  * being recorded. Captured live during the optimistic-clip lifecycle from the
  * browser link-capture extension, one row per distinct URL shown during the
- * clip. See docs/adr on clip web links and the `chrome-extension/` directory.
+ * clip. See docs/adr/0020-clip-web-links-over-websocket.md and the
+ * `chrome-extension/` directory.
  */
 export const clipWebLinks = createTable("clip_web_link", {
   id: varchar("id", { length: 255 })

--- a/app/features/video-editor/clip-state-reducer-diagram-pin.test.ts
+++ b/app/features/video-editor/clip-state-reducer-diagram-pin.test.ts
@@ -36,6 +36,7 @@ const createClipOnDatabase = (
   pauseType: "none",
   diagramSnapshotId: null,
   diagramName: null,
+  webLinks: [],
   ...overrides,
 });
 

--- a/app/features/video-editor/clip-state-reducer-effect-clips.test.ts
+++ b/app/features/video-editor/clip-state-reducer-effect-clips.test.ts
@@ -37,6 +37,7 @@ const createClipOnDatabase = (
   pauseType: "none",
   diagramSnapshotId: null,
   diagramName: null,
+  webLinks: [],
   ...overrides,
 });
 

--- a/app/features/video-editor/clip-state-reducer-recording-handler.test.ts
+++ b/app/features/video-editor/clip-state-reducer-recording-handler.test.ts
@@ -258,6 +258,7 @@ describe("recording session sub-handler", () => {
           sessionId,
           activeDiagramId: "diagram-1",
           diagramFocused: true,
+          webLinks: [],
         },
         createExec()
       );

--- a/app/features/video-editor/clip-state-reducer-recording.ts
+++ b/app/features/video-editor/clip-state-reducer-recording.ts
@@ -1,6 +1,7 @@
 import type { PauseType } from "@/services/video-processing-service";
 import { DEFAULT_SILENCE_LENGTH } from "@/silence-detection-constants";
 import { shouldSnapshot } from "@/lib/snapshot-rule";
+import type { CapturedWebLink } from "@/lib/clip-web-link-timeline";
 import type {
   ClipOnDatabase,
   ClipOptimisticallyAdded,
@@ -266,6 +267,38 @@ const emitSnapshotForClipEffects = (
   }
 };
 
+type PendingWebLinksEffect = {
+  clipId: DatabaseId;
+  links: CapturedWebLink[];
+};
+
+const collectWebLinksForClip = (
+  frontendClip: TimelineItem | undefined,
+  databaseClipId: DatabaseId
+): PendingWebLinksEffect | null => {
+  if (
+    frontendClip?.type !== "optimistically-added" ||
+    !frontendClip.pendingWebLinks ||
+    frontendClip.pendingWebLinks.length === 0
+  ) {
+    return null;
+  }
+  return { clipId: databaseClipId, links: frontendClip.pendingWebLinks };
+};
+
+const emitPersistWebLinksEffects = (
+  webLinks: PendingWebLinksEffect[],
+  exec: ClipReducerExec
+) => {
+  for (const entry of webLinks) {
+    exec({
+      type: "persist-web-links",
+      clipId: entry.clipId,
+      links: entry.links,
+    });
+  }
+};
+
 const handleNewDatabaseClips = (
   state: ClipReducerState,
   action: Extract<ClipReducerAction, { type: "new-database-clips" }>,
@@ -277,6 +310,7 @@ const handleNewDatabaseClips = (
   const databaseClipIdsToTranscribe = new Set<DatabaseId>();
   const frontendClipIdsToTranscribe = new Set<FrontendId>();
   const snapshotsToCreate: PendingSnapshotEffect[] = [];
+  const webLinksToPersist: PendingWebLinksEffect[] = [];
   const clipsToUpdateScene = new Map<
     DatabaseId,
     { scene: string; profile: string; pauseType: PauseType }
@@ -316,6 +350,12 @@ const handleNewDatabaseClips = (
       );
       if (pendingSnapshot) snapshotsToCreate.push(pendingSnapshot);
 
+      const pendingWebLinks = collectWebLinksForClip(
+        frontendClip,
+        databaseClip.id
+      );
+      if (pendingWebLinks) webLinksToPersist.push(pendingWebLinks);
+
       if (
         frontendClip?.type === "optimistically-added" &&
         frontendClip?.shouldArchive
@@ -331,6 +371,7 @@ const handleNewDatabaseClips = (
           pauseType: frontendClip.pauseType,
           diagramSnapshotId: databaseClip.diagramSnapshotId ?? null,
           diagramName: null,
+          webLinks: [],
           shouldArchive: true,
           sessionId: frontendClip.sessionId,
         };
@@ -355,6 +396,7 @@ const handleNewDatabaseClips = (
           pauseType: frontendClip.pauseType,
           diagramSnapshotId: databaseClip.diagramSnapshotId ?? null,
           diagramName: null,
+          webLinks: [],
         };
         newClipsState[index] = newDatabaseClip;
         clipsToUpdateScene.set(databaseClip.id, {
@@ -377,6 +419,7 @@ const handleNewDatabaseClips = (
         pauseType: databaseClip.pauseType as PauseType,
         diagramSnapshotId: databaseClip.diagramSnapshotId ?? null,
         diagramName: null,
+        webLinks: [],
       };
 
       const result = insertAtPoint(
@@ -421,6 +464,7 @@ const handleNewDatabaseClips = (
   }
 
   emitSnapshotForClipEffects(snapshotsToCreate, exec);
+  emitPersistWebLinksEffects(webLinksToPersist, exec);
 
   return {
     ...state,
@@ -439,6 +483,7 @@ const handleClipAudioWindowClosed = (
     sessionId: SessionId;
     activeDiagramId: string | null;
     diagramFocused: boolean;
+    webLinks: CapturedWebLink[];
   }
 ): ClipReducerState => {
   let targetIndex = -1;
@@ -465,6 +510,7 @@ const handleClipAudioWindowClosed = (
               activeDiagramId: action.activeDiagramId,
               diagramFocused: action.diagramFocused,
             },
+            pendingWebLinks: action.webLinks,
           }
         : item
     ),

--- a/app/features/video-editor/clip-state-reducer-snapshot-pinning.test.ts
+++ b/app/features/video-editor/clip-state-reducer-snapshot-pinning.test.ts
@@ -44,6 +44,7 @@ describe("clipStateReducer — diagram snapshot pinning", () => {
         sessionId,
         activeDiagramId: "diagram-1",
         diagramFocused: true,
+        webLinks: [],
       });
 
       const clip = tester.getState().items[0] as ClipOptimisticallyAdded;
@@ -75,6 +76,7 @@ describe("clipStateReducer — diagram snapshot pinning", () => {
           sessionId,
           activeDiagramId: "diagram-1",
           diagramFocused: true,
+          webLinks: [],
         })
         .send(
           fromPartial({
@@ -87,6 +89,7 @@ describe("clipStateReducer — diagram snapshot pinning", () => {
           sessionId,
           activeDiagramId: "diagram-2",
           diagramFocused: false,
+          webLinks: [],
         });
 
       const items = tester.getState().items as ClipOptimisticallyAdded[];
@@ -116,6 +119,7 @@ describe("clipStateReducer — diagram snapshot pinning", () => {
         sessionId,
         activeDiagramId: "diagram-1",
         diagramFocused: true,
+        webLinks: [],
       });
 
       expect(tester.getState().items).toEqual(before.items);

--- a/app/features/video-editor/clip-state-reducer.ts
+++ b/app/features/video-editor/clip-state-reducer.ts
@@ -402,6 +402,7 @@ export const clipStateReducer: EffectReducer<
               pauseType: item.pauseType,
               diagramSnapshotId: null,
               diagramName: null,
+              webLinks: [],
             };
             return onDatabase;
           }
@@ -522,6 +523,42 @@ export const clipStateReducer: EffectReducer<
               ...item,
               diagramSnapshotId: action.diagramSnapshotId,
               diagramName: action.diagramName,
+            };
+          }
+          return item;
+        }),
+      };
+    }
+    case "set-clip-web-links": {
+      return {
+        ...state,
+        items: state.items.map((item) => {
+          if (
+            item.type === "on-database" &&
+            item.databaseId === action.clipId
+          ) {
+            return { ...item, webLinks: action.webLinks };
+          }
+          return item;
+        }),
+      };
+    }
+    case "remove-clip-web-link": {
+      exec({
+        type: "delete-web-link",
+        clipId: action.clipId,
+        linkId: action.linkId,
+      });
+      return {
+        ...state,
+        items: state.items.map((item) => {
+          if (
+            item.type === "on-database" &&
+            item.frontendId === action.clipId
+          ) {
+            return {
+              ...item,
+              webLinks: item.webLinks.filter((l) => l.id !== action.linkId),
             };
           }
           return item;

--- a/app/features/video-editor/clip-state-reducer.types.ts
+++ b/app/features/video-editor/clip-state-reducer.types.ts
@@ -1,6 +1,7 @@
 import type { DB } from "@/db/schema";
 import type { PauseType } from "@/services/video-processing-service";
 import type { SilenceLength } from "@/silence-detection-constants";
+import type { CapturedWebLink } from "@/lib/clip-web-link-timeline";
 import type { Brand } from "./utils";
 
 export type DatabaseId = Brand<string, "DatabaseId">;
@@ -36,6 +37,12 @@ export type ClipOnDatabase = {
   pauseType: PauseType;
   diagramSnapshotId: string | null;
   diagramName: string | null;
+  /**
+   * Web pages that were on screen (focused Chrome window) while this clip was
+   * recorded. Loaded from the DB for existing clips, and filled in after a
+   * freshly-recorded clip's captured links are persisted.
+   */
+  webLinks: DB.ClipWebLink[];
   /**
    * If true, this clip has been archived by the user (deleted from session panel).
    * The clip stays in state so it can appear in the archived sub-section of the
@@ -93,6 +100,12 @@ export type ClipOptimisticallyAdded = {
     activeDiagramId: string | null;
     diagramFocused: boolean;
   };
+  /**
+   * Web links that were on screen during this clip, captured when the clip's
+   * audio window closed. Read when the optimistic clip is paired with a database
+   * clip, at which point they are persisted as `clip_web_link` rows.
+   */
+  pendingWebLinks?: CapturedWebLink[];
 };
 
 export const createFrontendId = (): FrontendId => {
@@ -305,6 +318,17 @@ export type ClipReducerAction =
       sessionId: SessionId;
       activeDiagramId: string | null;
       diagramFocused: boolean;
+      webLinks: CapturedWebLink[];
+    }
+  | {
+      type: "set-clip-web-links";
+      clipId: DatabaseId;
+      webLinks: DB.ClipWebLink[];
+    }
+  | {
+      type: "remove-clip-web-link";
+      clipId: FrontendId;
+      linkId: DatabaseId;
     };
 
 export type ClipReducerEffect =
@@ -399,6 +423,16 @@ export type ClipReducerEffect =
       type: "snapshot-for-clip";
       diagramId: string;
       clipId: DatabaseId;
+    }
+  | {
+      type: "persist-web-links";
+      clipId: DatabaseId;
+      links: CapturedWebLink[];
+    }
+  | {
+      type: "delete-web-link";
+      clipId: FrontendId;
+      linkId: DatabaseId;
     };
 
 export type ClipReducerExec = (effect: ClipReducerEffect) => void;

--- a/app/features/video-editor/components/clip-item.tsx
+++ b/app/features/video-editor/components/clip-item.tsx
@@ -17,6 +17,7 @@ import {
   ChevronRightIcon,
   FilmIcon,
   ImageIcon,
+  Link2Icon,
   Loader2,
   PauseIcon,
   PlusIcon,
@@ -39,6 +40,7 @@ import {
   fetchMeta,
 } from "@/features/diagrams/use-diagram-snapshot-scene";
 import { resolveForClip } from "@/lib/diagram-action-resolver";
+import { getWebLinkLabel } from "@/lib/clip-web-link-timeline";
 import {
   openPlayground,
   openPlaygroundWithDiagram,
@@ -94,6 +96,10 @@ export const ClipItem = (props: ClipItemProps) => {
   const onSetInsertionPoint = useContextSelector(
     VideoEditorContext,
     (ctx) => ctx.onSetInsertionPoint
+  );
+  const onRemoveWebLink = useContextSelector(
+    VideoEditorContext,
+    (ctx) => ctx.onRemoveWebLink
   );
   const onMoveClip = useContextSelector(
     VideoEditorContext,
@@ -238,6 +244,41 @@ export const ClipItem = (props: ClipItemProps) => {
                 snapshotId={clip.diagramSnapshotId}
                 diagramName={clip.diagramName}
               />
+            )}
+
+            {/* On-screen web links captured during recording */}
+            {clip.type === "on-database" && clip.webLinks.length > 0 && (
+              <div className="z-10 relative mt-2 flex flex-wrap gap-1">
+                {clip.webLinks.map((link) => (
+                  <span
+                    key={link.id}
+                    className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground max-w-[16rem]"
+                  >
+                    <Link2Icon className="w-3 h-3 shrink-0" />
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      title={link.url}
+                      className="truncate hover:underline"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {link.title || getWebLinkLabel(link.url)}
+                    </a>
+                    <button
+                      type="button"
+                      aria-label="Remove link"
+                      className="shrink-0 rounded hover:text-foreground"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onRemoveWebLink(clip.frontendId, link.id);
+                      }}
+                    >
+                      <XIcon className="w-3 h-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
             )}
           </div>
         </button>

--- a/app/features/video-editor/edit-effect-handlers.ts
+++ b/app/features/video-editor/edit-effect-handlers.ts
@@ -294,6 +294,58 @@ export function createEditEffectHandlers(
         clipId: effect.clipId,
       });
     },
+    "persist-web-links": (_state, effect, dispatch) => {
+      fetch(`/api/clips/${effect.clipId}/web-links`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ links: effect.links }),
+      })
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+          }
+          return res.json();
+        })
+        .then((body: { webLinks: DB.ClipWebLink[] }) => {
+          dispatch({
+            type: "set-clip-web-links",
+            clipId: effect.clipId,
+            webLinks: body.webLinks,
+          });
+        })
+        .catch((error) => {
+          dispatch({
+            type: "effect-failed",
+            effectType: "persist-web-links",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Failed to persist web links",
+          });
+        });
+    },
+    "delete-web-link": (_state, effect, dispatch) => {
+      const clip = clipStateRef.current.items.find(
+        (i) => i.type === "on-database" && i.frontendId === effect.clipId
+      );
+      const databaseClipId =
+        clip?.type === "on-database" ? clip.databaseId : null;
+      if (!databaseClipId) return;
+      fetch(`/api/clips/${databaseClipId}/web-links`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ linkId: effect.linkId }),
+      }).catch((error) => {
+        dispatch({
+          type: "effect-failed",
+          effectType: "delete-web-link",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Failed to delete web link",
+        });
+      });
+    },
     "create-chapter-at": (_state, effect, dispatch) => {
       clipService
         .createChapterAtPosition({

--- a/app/features/video-editor/hooks/use-browser-link-capture.ts
+++ b/app/features/video-editor/hooks/use-browser-link-capture.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { browserEventMessageSchema } from "stream-deck-forwarder/stream-deck-forwarder-types";
+import { recordBrowserEvent } from "@/lib/browser-link-window";
+
+/**
+ * Subscribes to the forwarder hub (ws://localhost:5172) and feeds browser
+ * link-capture events from the Chrome extension into the live event log.
+ *
+ * The extension is a dumb tap that emits `browser-focus` / `browser-url`; this
+ * hook simply records them (stamped with the extension's `ts`). The clip window
+ * draining happens elsewhere (the edit route's `onClipAudioWindowClosed`).
+ *
+ * Non-browser messages on the hub (Stream Deck actions) are ignored. The socket
+ * is best-effort: if the hub is down there is simply no capture, and the socket
+ * is closed on unmount.
+ */
+export function useBrowserLinkCapture() {
+  useEffect(() => {
+    const socket = new WebSocket("ws://localhost:5172");
+    socket.addEventListener("message", (event) => {
+      const parsed = browserEventMessageSchema.safeParse(
+        JSON.parse(event.data)
+      );
+      if (!parsed.success) return;
+      recordBrowserEvent(parsed.data);
+    });
+    return () => {
+      socket.close();
+    };
+  }, []);
+}

--- a/app/features/video-editor/hooks/use-websocket.ts
+++ b/app/features/video-editor/hooks/use-websocket.ts
@@ -24,9 +24,15 @@ export function useWebSocket(params: {
   useEffect(() => {
     const socket = new WebSocket("ws://localhost:5172");
     socket.addEventListener("message", (event) => {
-      const data = streamDeckForwarderMessageSchema.parse(
+      // The hub rebroadcasts every client's messages (Stream Deck actions AND
+      // browser link-capture events) to every client. This hook only handles
+      // Stream Deck actions, so unrecognized message types are ignored rather
+      // than throwing.
+      const parsed = streamDeckForwarderMessageSchema.safeParse(
         JSON.parse(event.data)
       );
+      if (!parsed.success) return;
+      const data = parsed.data;
       if (data.type === "delete-last-clip") {
         params.onDeleteLatestInsertedClip();
       } else if (data.type === "toggle-last-frame-of-video") {

--- a/app/features/video-editor/video-editor-context.tsx
+++ b/app/features/video-editor/video-editor-context.tsx
@@ -2,6 +2,7 @@ import { createContext } from "use-context-selector";
 import type {
   Clip,
   ClipOnDatabase,
+  DatabaseId,
   FrontendId,
   FrontendInsertionPoint,
   RecordingSession,
@@ -143,6 +144,9 @@ export type VideoEditorContextType = {
 
   // Diagram pin
   onUnpinDiagram: (clipId: FrontendId) => void;
+
+  // Web links captured during recording
+  onRemoveWebLink: (clipId: FrontendId, linkId: DatabaseId) => void;
 };
 
 export const VideoEditorContext = createContext<VideoEditorContextType>(null!);

--- a/app/features/video-editor/video-editor-selectors-capture.test.ts
+++ b/app/features/video-editor/video-editor-selectors-capture.test.ts
@@ -33,6 +33,7 @@ const makeClipOnDatabase = (
   pauseType: "none",
   diagramSnapshotId: null,
   diagramName: null,
+  webLinks: [],
   ...overrides,
 });
 

--- a/app/features/video-editor/video-editor-selectors-chapters.test.ts
+++ b/app/features/video-editor/video-editor-selectors-chapters.test.ts
@@ -23,6 +23,7 @@ const makeClip = (
   pauseType: "none",
   diagramSnapshotId: null,
   diagramName: null,
+  webLinks: [],
   ...overrides,
 });
 

--- a/app/features/video-editor/video-editor-selectors-clips.test.ts
+++ b/app/features/video-editor/video-editor-selectors-clips.test.ts
@@ -45,6 +45,7 @@ const makeClipOnDatabase = (
   pauseType: "none",
   diagramSnapshotId: null,
   diagramName: null,
+  webLinks: [],
   ...overrides,
 });
 

--- a/app/features/video-editor/video-editor-selectors-danger-metadata.test.ts
+++ b/app/features/video-editor/video-editor-selectors-danger-metadata.test.ts
@@ -47,6 +47,7 @@ const makeClipOnDatabase = (
   pauseType: "none",
   diagramSnapshotId: null,
   diagramName: null,
+  webLinks: [],
   ...overrides,
 });
 

--- a/app/features/video-editor/video-editor-selectors-timeline.test.ts
+++ b/app/features/video-editor/video-editor-selectors-timeline.test.ts
@@ -30,6 +30,7 @@ const makeClipOnDatabase = (
   pauseType: "none",
   diagramSnapshotId: null,
   diagramName: null,
+  webLinks: [],
   ...overrides,
 });
 

--- a/app/features/video-editor/video-editor.tsx
+++ b/app/features/video-editor/video-editor.tsx
@@ -34,6 +34,7 @@ import {
 import { enableVideoEditorMode } from "@/lib/diagram-window";
 import { useFetcher, useRevalidator, useSubmit } from "react-router";
 import type {
+  DatabaseId,
   EditorError,
   FrontendId,
   FrontendInsertionPoint,
@@ -134,6 +135,7 @@ export const VideoEditor = (props: {
     mode: "copy" | "move"
   ) => void;
   onUpdateClipDiagramPin: UpdateClipDiagramPinFn;
+  onRemoveWebLink: (clipId: FrontendId, linkId: DatabaseId) => void;
 }) => {
   // Filter items for the main timeline (excludes optimistic clips and archived items)
   const timelineItems = useMemo(
@@ -220,6 +222,8 @@ export const VideoEditor = (props: {
     props.items,
     props.onUpdateClipDiagramPin
   );
+
+  const onRemoveWebLink = props.onRemoveWebLink;
 
   // Setup keyboard shortcuts
   useKeyboardShortcuts(dispatch);
@@ -457,6 +461,9 @@ export const VideoEditor = (props: {
 
       // Diagram pin
       onUnpinDiagram,
+
+      // Web links
+      onRemoveWebLink,
     }),
     [
       state,
@@ -526,6 +533,7 @@ export const VideoEditor = (props: {
       generateDefaultChapterName,
       onOpenGenerateChaptersModal,
       onUnpinDiagram,
+      onRemoveWebLink,
     ]
   );
 

--- a/app/lib/browser-link-window.test.ts
+++ b/app/lib/browser-link-window.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  recordBrowserEvent,
+  openClipWindow,
+  drainClipWebLinks,
+  __resetBrowserLinkWindow,
+} from "./browser-link-window";
+
+describe("browser-link-window", () => {
+  beforeEach(() => {
+    __resetBrowserLinkWindow();
+  });
+
+  it("attaches a URL shown throughout the clip window", () => {
+    recordBrowserEvent({ type: "browser-focus", focused: true, ts: 1000 });
+    recordBrowserEvent({
+      type: "browser-url",
+      url: "https://a.com",
+      title: "A",
+      ts: 1000,
+    });
+    openClipWindow(1000);
+    const links = drainClipWebLinks(6000);
+    expect(links).toEqual([
+      { url: "https://a.com", title: "A", capturedAt: 1000 },
+    ]);
+  });
+
+  it("only counts activity since the clip window opened (silence-gap URLs are dropped)", () => {
+    // A shown-and-dismissed page during the silence gap before the clip opens.
+    recordBrowserEvent({ type: "browser-focus", focused: true, ts: 100 });
+    recordBrowserEvent({
+      type: "browser-url",
+      url: "https://gap.com",
+      title: "Gap",
+      ts: 100,
+    });
+    recordBrowserEvent({
+      type: "browser-url",
+      url: "chrome://newtab/",
+      ts: 500,
+    });
+    // Clip opens at 2000; a different page is shown for the whole window.
+    recordBrowserEvent({
+      type: "browser-url",
+      url: "https://clip.com",
+      title: "Clip",
+      ts: 2000,
+    });
+    openClipWindow(2000);
+    const links = drainClipWebLinks(7000);
+    expect(links).toEqual([
+      { url: "https://clip.com", title: "Clip", capturedAt: 2000 },
+    ]);
+  });
+
+  it("seeds from a page opened during silence that is still visible at clip open", () => {
+    recordBrowserEvent({ type: "browser-focus", focused: true, ts: 100 });
+    recordBrowserEvent({
+      type: "browser-url",
+      url: "https://seed.com",
+      title: "Seed",
+      ts: 200,
+    });
+    // No navigation before the clip opens — still visible.
+    openClipWindow(3000);
+    const links = drainClipWebLinks(8000);
+    expect(links).toEqual([
+      { url: "https://seed.com", title: "Seed", capturedAt: 3000 },
+    ]);
+  });
+});

--- a/app/lib/browser-link-window.ts
+++ b/app/lib/browser-link-window.ts
@@ -1,0 +1,68 @@
+// Live singleton that records the browser link-capture event stream and, on
+// demand, computes the set of web pages that were on screen during a clip.
+//
+// The Chrome extension broadcasts `browser-focus` / `browser-url` events over
+// the forwarder hub; `use-browser-link-capture.ts` feeds them here. The Video
+// Editor opens a "clip window" when speech is detected (an optimistic clip is
+// added) and drains it when the clip's audio window closes — mirroring how the
+// diagram feature locks in focus state at the silence-detected transition.
+//
+// All timing/side-effects live here; the actual interval maths is the pure
+// `computeClipWebLinks` in `clip-web-link-timeline.ts`.
+
+import {
+  computeClipWebLinks,
+  type BrowserLinkEvent,
+  type CapturedWebLink,
+} from "./clip-web-link-timeline";
+
+// Keep a few minutes of events so a clip's seed state (the last URL/focus event
+// before the clip opened) is always available. Clips are seconds long.
+const LOG_RETENTION_MS = 5 * 60 * 1000;
+
+// Upper bound on a clip window if `openClipWindow` was somehow missed, so a
+// stale open timestamp can never pull in minutes of unrelated browsing.
+const MAX_WINDOW_MS = 2 * 60 * 1000;
+
+let eventLog: BrowserLinkEvent[] = [];
+let openedAt: number | null = null;
+
+function prune(now: number): void {
+  const cutoff = now - LOG_RETENTION_MS;
+  if (eventLog.length > 0 && eventLog[0]!.ts < cutoff) {
+    eventLog = eventLog.filter((e) => e.ts >= cutoff);
+  }
+}
+
+export function recordBrowserEvent(event: BrowserLinkEvent): void {
+  eventLog.push(event);
+  prune(event.ts);
+}
+
+/** Mark the wall-clock start of the clip currently being recorded. */
+export function openClipWindow(ts: number): void {
+  openedAt = ts;
+}
+
+/**
+ * Compute the web links that were on screen during the clip whose window just
+ * closed at `windowEnd`, then return them. The window starts at the last
+ * `openClipWindow` timestamp (clamped so it can never exceed MAX_WINDOW_MS).
+ */
+export function drainClipWebLinks(windowEnd: number): CapturedWebLink[] {
+  const windowStart = Math.max(
+    openedAt ?? windowEnd - MAX_WINDOW_MS,
+    windowEnd - MAX_WINDOW_MS
+  );
+  return computeClipWebLinks({
+    events: eventLog,
+    windowStart,
+    windowEnd,
+  });
+}
+
+/** Test-only: reset module state between cases. */
+export function __resetBrowserLinkWindow(): void {
+  eventLog = [];
+  openedAt = null;
+}

--- a/app/lib/clip-web-link-timeline.test.ts
+++ b/app/lib/clip-web-link-timeline.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  isCapturableUrl,
+  computeClipWebLinks,
+  type BrowserLinkEvent,
+} from "./clip-web-link-timeline";
+
+describe("isCapturableUrl", () => {
+  it("accepts http and https URLs", () => {
+    expect(isCapturableUrl("http://example.com")).toBe(true);
+    expect(isCapturableUrl("https://example.com/page?x=1")).toBe(true);
+    expect(isCapturableUrl("https://localhost:5173/foo")).toBe(true);
+  });
+
+  it("rejects file, chrome, edge, about and extension URLs", () => {
+    expect(isCapturableUrl("file:///Users/matt/notes.txt")).toBe(false);
+    expect(isCapturableUrl("chrome://newtab/")).toBe(false);
+    expect(isCapturableUrl("edge://settings")).toBe(false);
+    expect(isCapturableUrl("about:blank")).toBe(false);
+    expect(isCapturableUrl("chrome-extension://abc/page.html")).toBe(false);
+  });
+
+  it("rejects empty and malformed URLs", () => {
+    expect(isCapturableUrl("")).toBe(false);
+    expect(isCapturableUrl("not a url")).toBe(false);
+  });
+});
+
+// Window is [1000, 5000] throughout unless stated. Threshold defaults to 1500ms.
+const WINDOW_START = 1000;
+const WINDOW_END = 5000;
+const compute = (events: BrowserLinkEvent[], minVisibleMs = 1500) =>
+  computeClipWebLinks({
+    events,
+    windowStart: WINDOW_START,
+    windowEnd: WINDOW_END,
+    minVisibleMs,
+  });
+
+describe("computeClipWebLinks", () => {
+  it("captures a URL that is focused and visible for the whole window", () => {
+    const links = compute([
+      { type: "browser-focus", focused: true, ts: 500 },
+      { type: "browser-url", url: "https://a.com", title: "A", ts: 500 },
+    ]);
+    expect(links).toEqual([
+      { url: "https://a.com", title: "A", capturedAt: WINDOW_START },
+    ]);
+  });
+
+  it("does not capture a URL while Chrome is not focused", () => {
+    const links = compute([
+      { type: "browser-focus", focused: false, ts: 500 },
+      { type: "browser-url", url: "https://a.com", title: "A", ts: 500 },
+    ]);
+    expect(links).toEqual([]);
+  });
+
+  it("drops a URL visible for less than the minimum duration", () => {
+    // Visible from 4700..5000 = 300ms, below the 1500ms threshold.
+    const links = compute([
+      { type: "browser-focus", focused: true, ts: 4700 },
+      { type: "browser-url", url: "https://flash.com", title: "F", ts: 4700 },
+    ]);
+    expect(links).toEqual([]);
+  });
+
+  it("captures multiple distinct URLs in chronological order", () => {
+    const links = compute([
+      { type: "browser-focus", focused: true, ts: 900 },
+      { type: "browser-url", url: "https://a.com", title: "A", ts: 900 },
+      { type: "browser-url", url: "https://b.com", title: "B", ts: 3000 },
+    ]);
+    expect(links).toEqual([
+      { url: "https://a.com", title: "A", capturedAt: WINDOW_START },
+      { url: "https://b.com", title: "B", capturedAt: 3000 },
+    ]);
+  });
+
+  it("dedupes a URL shown twice (A, B, A) into one row keeping the first sighting", () => {
+    const links = compute([
+      { type: "browser-focus", focused: true, ts: 900 },
+      { type: "browser-url", url: "https://a.com", title: "A", ts: 900 },
+      { type: "browser-url", url: "https://b.com", title: "B", ts: 2000 },
+      { type: "browser-url", url: "https://a.com", title: "A", ts: 3600 },
+    ]);
+    // b.com visible 2000..3600 = 1600ms (>= threshold); a.com 1000..2000 +
+    // 3600..5000 = 2400ms. Both kept, ordered by first sighting.
+    expect(links.map((l) => l.url)).toEqual(["https://a.com", "https://b.com"]);
+    expect(links.find((l) => l.url === "https://a.com")!.capturedAt).toBe(
+      WINDOW_START
+    );
+  });
+
+  it("seeds from the URL visible at window open even if it was opened during prior silence", () => {
+    // URL set and focused well before the window opens; still visible when the
+    // clip starts, so it should attach with capturedAt clamped to windowStart.
+    const links = compute([
+      { type: "browser-focus", focused: true, ts: 100 },
+      { type: "browser-url", url: "https://seed.com", title: "Seed", ts: 200 },
+    ]);
+    expect(links).toEqual([
+      { url: "https://seed.com", title: "Seed", capturedAt: WINDOW_START },
+    ]);
+  });
+
+  it("ends an interval when switching to a non-capturable URL", () => {
+    // a.com visible 900..1200 (200ms in-window) then chrome://newtab from 1200.
+    const links = compute([
+      { type: "browser-focus", focused: true, ts: 900 },
+      { type: "browser-url", url: "https://a.com", title: "A", ts: 900 },
+      { type: "browser-url", url: "chrome://newtab/", ts: 1200 },
+    ]);
+    expect(links).toEqual([]);
+  });
+
+  it("ends an interval when Chrome loses focus", () => {
+    // Focused 900..1200 (200ms in-window) then blur.
+    const links = compute([
+      { type: "browser-focus", focused: true, ts: 900 },
+      { type: "browser-url", url: "https://a.com", title: "A", ts: 900 },
+      { type: "browser-focus", focused: false, ts: 1200 },
+    ]);
+    expect(links).toEqual([]);
+  });
+
+  it("re-attaches a URL after focus returns, summing in-window duration", () => {
+    // a.com focused 1000..1400 (400ms), blur, focus again 4000..5000 (1000ms).
+    // Total in-window = 1400ms < 1500 -> dropped.
+    const dropped = compute([
+      { type: "browser-url", url: "https://a.com", title: "A", ts: 900 },
+      { type: "browser-focus", focused: true, ts: 1000 },
+      { type: "browser-focus", focused: false, ts: 1400 },
+      { type: "browser-focus", focused: true, ts: 4000 },
+    ]);
+    expect(dropped).toEqual([]);
+
+    // Same but the second focused stretch is longer -> total >= 1500 -> kept.
+    const kept = compute([
+      { type: "browser-url", url: "https://a.com", title: "A", ts: 900 },
+      { type: "browser-focus", focused: true, ts: 1000 },
+      { type: "browser-focus", focused: false, ts: 1400 },
+      { type: "browser-focus", focused: true, ts: 3500 },
+    ]);
+    expect(kept).toEqual([
+      { url: "https://a.com", title: "A", capturedAt: WINDOW_START },
+    ]);
+  });
+
+  it("returns null title when the URL event carried no title", () => {
+    const links = compute([
+      { type: "browser-focus", focused: true, ts: 900 },
+      { type: "browser-url", url: "https://a.com", ts: 900 },
+    ]);
+    expect(links).toEqual([
+      { url: "https://a.com", title: null, capturedAt: WINDOW_START },
+    ]);
+  });
+
+  it("ignores events entirely and returns nothing when there is no activity", () => {
+    expect(compute([])).toEqual([]);
+  });
+});

--- a/app/lib/clip-web-link-timeline.ts
+++ b/app/lib/clip-web-link-timeline.ts
@@ -1,0 +1,130 @@
+// Pure reconstruction of "which web pages were on screen during a clip" from
+// the raw browser event stream emitted by the link-capture Chrome extension.
+//
+// The extension is a dumb tap: it emits `browser-focus` when Chrome gains/loses
+// OS focus and `browser-url` when the active tab's URL changes. From that stream
+// we reconstruct, for any instant, the *effective visible URL* — the active tab
+// URL when Chrome is focused and the URL is a capturable web page. We then
+// intersect each URL's visible intervals with the clip's wall-clock window and
+// keep the URLs that were visible long enough.
+//
+// This module is intentionally pure (no `Date.now`, no I/O) so it can be unit
+// tested exhaustively. The live singleton in `browser-link-window.ts` records
+// timestamped events and calls into this for the actual computation.
+
+export type BrowserLinkEvent =
+  | { type: "browser-focus"; focused: boolean; ts: number }
+  | { type: "browser-url"; url: string; title?: string; ts: number };
+
+export type CapturedWebLink = {
+  url: string;
+  title: string | null;
+  /** Wall-clock time the URL was first visible within the clip window. */
+  capturedAt: number;
+};
+
+/**
+ * Minimum time (ms) a URL must be effectively visible within a clip's window
+ * before it is attached. Filters transient flashes as you tab between windows.
+ */
+export const DEFAULT_MIN_VISIBLE_MS = 1500;
+
+/**
+ * A URL is capturable if it is an ordinary web page (http/https). File URLs,
+ * browser-internal pages (`chrome://`, `edge://`, `about:`) and extension pages
+ * are skipped.
+ */
+export function isCapturableUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === "http:" || parsed.protocol === "https:";
+}
+
+/**
+ * A short human label for a URL when no page title is available: host + path,
+ * without the scheme or a trailing slash. Falls back to the raw URL.
+ */
+export function getWebLinkLabel(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const path = parsed.pathname === "/" ? "" : parsed.pathname;
+    return `${parsed.host}${path}${parsed.search}`;
+  } catch {
+    return url;
+  }
+}
+
+type Accumulated = {
+  visibleMs: number;
+  capturedAt: number;
+  title: string | null;
+};
+
+export function computeClipWebLinks(input: {
+  events: readonly BrowserLinkEvent[];
+  windowStart: number;
+  windowEnd: number;
+  minVisibleMs?: number;
+}): CapturedWebLink[] {
+  const { windowStart, windowEnd } = input;
+  const minVisibleMs = input.minVisibleMs ?? DEFAULT_MIN_VISIBLE_MS;
+  if (windowEnd <= windowStart) return [];
+
+  const sorted = [...input.events].sort((a, b) => a.ts - b.ts);
+
+  const totals = new Map<string, Accumulated>();
+
+  // Effective-visible state, updated as we consume each event. Each event takes
+  // effect from its own timestamp; the resulting state holds until the next
+  // event (or the end of the window for the final event).
+  let focused = false;
+  let rawUrl: string | null = null;
+  let rawTitle: string | null = null;
+
+  const effectiveUrl = (): string | null =>
+    focused && rawUrl !== null && isCapturableUrl(rawUrl) ? rawUrl : null;
+
+  const accumulate = (url: string, title: string | null, segStart: number, segEnd: number) => {
+    const start = Math.max(segStart, windowStart);
+    const end = Math.min(segEnd, windowEnd);
+    if (end <= start) return;
+    const existing = totals.get(url);
+    if (existing) {
+      existing.visibleMs += end - start;
+      // Keep the earliest sighting's capturedAt and title. Events are processed
+      // in chronological order, so the first insert already holds the earliest.
+    } else {
+      totals.set(url, { visibleMs: end - start, capturedAt: start, title });
+    }
+  };
+
+  for (let i = 0; i < sorted.length; i++) {
+    const event = sorted[i]!;
+    if (event.type === "browser-focus") {
+      focused = event.focused;
+    } else {
+      rawUrl = event.url;
+      rawTitle = event.title ?? null;
+    }
+
+    const segStart = event.ts;
+    const segEnd = i + 1 < sorted.length ? sorted[i + 1]!.ts : windowEnd;
+    const eff = effectiveUrl();
+    if (eff !== null) {
+      accumulate(eff, rawTitle, segStart, segEnd);
+    }
+  }
+
+  return [...totals.entries()]
+    .filter(([, acc]) => acc.visibleMs >= minVisibleMs)
+    .map(([url, acc]) => ({
+      url,
+      title: acc.title,
+      capturedAt: acc.capturedAt,
+    }))
+    .sort((a, b) => a.capturedAt - b.capturedAt);
+}

--- a/app/lib/transcript-builder.test.ts
+++ b/app/lib/transcript-builder.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildTranscript,
+  formatOnScreenLinks,
   formatProseTranscript,
   toDiffArray,
   toTranscriptItems,
@@ -295,5 +296,84 @@ describe("buildTranscript", () => {
       videoFilename: "recording.webm",
       text: "Test",
     });
+  });
+});
+
+describe("formatOnScreenLinks", () => {
+  it("renders title and URL, wrapped in the on-screen marker", () => {
+    const seen = new Set<string>();
+    expect(
+      formatOnScreenLinks(
+        [{ url: "https://a.com", title: "A Site" }],
+        seen
+      )
+    ).toBe("«on screen: A Site — https://a.com» ");
+  });
+
+  it("falls back to the bare URL when there is no title", () => {
+    const seen = new Set<string>();
+    expect(
+      formatOnScreenLinks([{ url: "https://a.com", title: null }], seen)
+    ).toBe("«on screen: https://a.com» ");
+  });
+
+  it("joins multiple fresh links and marks them all seen", () => {
+    const seen = new Set<string>();
+    expect(
+      formatOnScreenLinks(
+        [
+          { url: "https://a.com", title: "A" },
+          { url: "https://b.com", title: null },
+        ],
+        seen
+      )
+    ).toBe("«on screen: A — https://a.com; https://b.com» ");
+    expect(seen.has("https://a.com")).toBe(true);
+    expect(seen.has("https://b.com")).toBe(true);
+  });
+
+  it("skips already-seen URLs and returns empty when nothing is fresh", () => {
+    const seen = new Set<string>(["https://a.com"]);
+    expect(
+      formatOnScreenLinks([{ url: "https://a.com", title: "A" }], seen)
+    ).toBe("");
+  });
+
+  it("returns empty for undefined or empty link lists", () => {
+    expect(formatOnScreenLinks(undefined, new Set())).toBe("");
+    expect(formatOnScreenLinks([], new Set())).toBe("");
+  });
+});
+
+describe("buildTranscript on-screen web links", () => {
+  it("injects the annotation inline after the clip index", () => {
+    const { transcript } = buildTranscript(
+      [
+        makeClip("a0", "So here is the docs page.", {
+          webLinks: [{ url: "https://docs.com", title: "Docs" }],
+        }),
+      ],
+      []
+    );
+    expect(transcript).toBe(
+      "[1] «on screen: Docs — https://docs.com» So here is the docs page."
+    );
+  });
+
+  it("annotates a repeated URL only on its first appearance (global dedup)", () => {
+    const { transcript } = buildTranscript(
+      [
+        makeClip("a0", "First mention.", {
+          webLinks: [{ url: "https://docs.com", title: "Docs" }],
+        }),
+        makeClip("a1", "Second mention.", {
+          webLinks: [{ url: "https://docs.com", title: "Docs" }],
+        }),
+      ],
+      []
+    );
+    expect(transcript).toBe(
+      "[1] «on screen: Docs — https://docs.com» First mention. [2] Second mention."
+    );
   });
 });

--- a/app/lib/transcript-builder.ts
+++ b/app/lib/transcript-builder.ts
@@ -4,12 +4,42 @@ import type {
   SectionWithWordCount,
 } from "@/features/article-writer/types";
 
+export interface TranscriptWebLink {
+  url: string;
+  title: string | null;
+}
+
 export interface ClipInput {
   order: string;
   text: string | null;
   sourceStartTime: number;
   sourceEndTime: number;
   videoFilename: string;
+  webLinks?: readonly TranscriptWebLink[];
+}
+
+/**
+ * Renders the "on screen" annotation for the web links shown during a clip,
+ * for inline injection right after the clip's `[N]` marker.
+ *
+ * Deduped globally across the transcript via `seenUrls`: a URL is only annotated
+ * on its first appearance, so the writer is nudged to cite each page once. The
+ * passed set is mutated with any newly-seen URLs. Returns "" when there is
+ * nothing new to annotate.
+ */
+export function formatOnScreenLinks(
+  webLinks: readonly TranscriptWebLink[] | undefined,
+  seenUrls: Set<string>
+): string {
+  if (!webLinks || webLinks.length === 0) return "";
+  const fresh: string[] = [];
+  for (const link of webLinks) {
+    if (seenUrls.has(link.url)) continue;
+    seenUrls.add(link.url);
+    fresh.push(link.title ? `${link.title} — ${link.url}` : link.url);
+  }
+  if (fresh.length === 0) return "";
+  return `«on screen: ${fresh.join("; ")}» `;
 }
 
 export interface ChapterInput {
@@ -30,6 +60,7 @@ type OrderedItem =
       sourceStartTime: number;
       sourceEndTime: number;
       videoFilename: string;
+      webLinks?: readonly TranscriptWebLink[];
     }
   | { type: "section"; order: string; id: string; name: string };
 
@@ -45,6 +76,7 @@ function toOrderedItems(
       sourceStartTime: clip.sourceStartTime,
       sourceEndTime: clip.sourceEndTime,
       videoFilename: clip.videoFilename,
+      webLinks: clip.webLinks,
     })),
     ...chapters.map<OrderedItem>((section) => ({
       type: "section",
@@ -143,6 +175,10 @@ export function buildTranscript(
   const sections: SectionWithWordCount[] = [];
   let currentSectionIndex = -1;
 
+  // URLs already annotated earlier in the transcript. A given page is only
+  // called out on its first appearance so the writer cites it once.
+  const seenUrls = new Set<string>();
+
   for (const item of sortedItems) {
     if (item.type === "section") {
       if (currentParagraph.length > 0) {
@@ -168,7 +204,8 @@ export function buildTranscript(
       });
 
       if (item.text) {
-        currentParagraph.push(`[${clipIndex}] ${item.text}`);
+        const onScreen = formatOnScreenLinks(item.webLinks, seenUrls);
+        currentParagraph.push(`[${clipIndex}] ${onScreen}${item.text}`);
         if (currentSectionIndex >= 0) {
           sections[currentSectionIndex]!.wordCount +=
             item.text.split(/\s+/).length;

--- a/app/prompts/generate-article.ts
+++ b/app/prompts/generate-article.ts
@@ -33,6 +33,8 @@ export const generateArticlePrompt = (opts: {
 ${opts.transcript}
 </transcript>
 
+Some clips are annotated with a «on screen: …» marker directly after their [N] index. This means those web pages were visible on screen during that part of the video. Treat them as context, not narration — do not read the marker out as prose. Where it genuinely helps the reader, you may link to those URLs at the relevant point. Each page is annotated only once, at its first appearance.
+
 `
     : "";
 

--- a/app/routes/_app.videos.$videoId.edit.tsx
+++ b/app/routes/_app.videos.$videoId.edit.tsx
@@ -26,6 +26,8 @@ import { Effect } from "effect";
 import { useEffectReducer } from "use-effect-reducer";
 import { getActiveDiagramId } from "@/lib/diagram-window";
 import { isDiagramFocused } from "@/lib/diagram-focus-tracking";
+import { useBrowserLinkCapture } from "@/features/video-editor/hooks/use-browser-link-capture";
+import { openClipWindow, drainClipWebLinks } from "@/lib/browser-link-window";
 import type { Route } from "./+types/_app.videos.$videoId.edit";
 
 export const handle = { fullscreen: true };
@@ -215,6 +217,7 @@ export const ComponentInner = (props: Route.ComponentProps) => {
           pauseType: clip.pauseType as PauseType,
           diagramSnapshotId: clip.diagramSnapshotId ?? null,
           diagramName: clip.diagramSnapshot?.diagram?.name ?? null,
+          webLinks: (clip.webLinks ?? []) as ClipOnDatabase["webLinks"],
         } satisfies ClipOnDatabase;
       } else {
         const chapter = item.data;
@@ -265,8 +268,16 @@ export const ComponentInner = (props: Route.ComponentProps) => {
   const silenceLengthRef = useRef(silenceLength);
   silenceLengthRef.current = silenceLength;
 
+  // Records browser link-capture events from the Chrome extension so the drain
+  // below can attach on-screen URLs to the clip being recorded. Best-effort: no
+  // extension / hub means no capture.
+  useBrowserLinkCapture();
+
   const obsConnector = useOBSConnector({
     onNewClipOptimisticallyAdded: ({ scene, profile, soundDetectionId }) => {
+      // A clip's live window opens when speech is detected. Mark it so the
+      // browser-link timeline knows where this clip's window begins.
+      openClipWindow(Date.now());
       dispatch({
         type: "new-optimistic-clip-detected",
         scene,
@@ -284,6 +295,7 @@ export const ComponentInner = (props: Route.ComponentProps) => {
         sessionId: activeSession.id,
         activeDiagramId: getActiveDiagramId(),
         diagramFocused: isDiagramFocused(),
+        webLinks: drainClipWebLinks(Date.now()),
       });
     },
     silenceLength,
@@ -498,6 +510,9 @@ export const ComponentInner = (props: Route.ComponentProps) => {
           .catch((error) => {
             console.error("Failed to update diagram pin", error);
           });
+      }}
+      onRemoveWebLink={(clipId, linkId) => {
+        dispatch({ type: "remove-clip-web-link", clipId, linkId });
       }}
       error={clipState.error}
       onCreateVideoFromSelection={(

--- a/app/routes/api.clips.$clipId.web-links.ts
+++ b/app/routes/api.clips.$clipId.web-links.ts
@@ -1,0 +1,84 @@
+import { Effect } from "effect";
+import { ClipOperationsService } from "@/services/db-clip-operations.server";
+import { makeAction } from "@/services/route-action.server";
+import type { Route } from "./+types/api.clips.$clipId.web-links";
+import { data } from "react-router";
+
+/**
+ * Persist / remove the web links that were on screen during a clip.
+ *
+ * POST   { links: { url, title, capturedAt }[] }  -> creates clip_web_link rows
+ * DELETE { linkId: string }                        -> removes one link
+ *
+ * Called by the Video Editor when a freshly-recorded clip's captured links are
+ * ready (POST) and when the user removes a mis-captured link chip (DELETE).
+ */
+const createAction = makeAction({
+  input: "json",
+  effect: ({ params, payload }) =>
+    Effect.gen(function* () {
+      if (
+        !payload ||
+        typeof payload !== "object" ||
+        Array.isArray(payload) ||
+        !("links" in payload)
+      ) {
+        return yield* Effect.die(
+          data("Body must be a JSON object with a links array", { status: 400 })
+        );
+      }
+
+      const { links } = payload as { links: unknown };
+      if (!Array.isArray(links)) {
+        return yield* Effect.die(
+          data("links must be an array", { status: 400 })
+        );
+      }
+
+      const parsed = links.map((link) => {
+        const l = link as Record<string, unknown>;
+        return {
+          url: String(l.url),
+          title: typeof l.title === "string" ? l.title : null,
+          capturedAt:
+            typeof l.capturedAt === "number" ? l.capturedAt : Date.now(),
+        };
+      });
+
+      const clipOps = yield* ClipOperationsService;
+      const webLinks = yield* clipOps.createClipWebLinks(params.clipId!, parsed);
+      return data({ webLinks });
+    }),
+});
+
+const deleteAction = makeAction({
+  input: "json",
+  effect: ({ payload }) =>
+    Effect.gen(function* () {
+      if (
+        !payload ||
+        typeof payload !== "object" ||
+        Array.isArray(payload) ||
+        typeof (payload as Record<string, unknown>).linkId !== "string"
+      ) {
+        return yield* Effect.die(
+          data("Body must include a linkId string", { status: 400 })
+        );
+      }
+
+      const { linkId } = payload as { linkId: string };
+      const clipOps = yield* ClipOperationsService;
+      const result = yield* clipOps.deleteClipWebLink(linkId);
+      return data(result);
+    }),
+});
+
+export const action = async (args: Route.ActionArgs) => {
+  if (args.request.method === "POST") {
+    return createAction(args);
+  }
+  if (args.request.method === "DELETE") {
+    return deleteAction(args);
+  }
+  return data("Method not allowed", { status: 405 });
+};

--- a/app/routes/api.clips.$clipId.web-links.ts
+++ b/app/routes/api.clips.$clipId.web-links.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import { z } from "zod";
 import { ClipOperationsService } from "@/services/db-clip-operations.server";
 import { makeAction } from "@/services/route-action.server";
 import type { Route } from "./+types/api.clips.$clipId.web-links";
@@ -7,46 +8,45 @@ import { data } from "react-router";
 /**
  * Persist / remove the web links that were on screen during a clip.
  *
- * POST   { links: { url, title, capturedAt }[] }  -> creates clip_web_link rows
- * DELETE { linkId: string }                        -> removes one link
+ * POST   { links: { url, title?, capturedAt? }[] }  -> creates clip_web_link rows
+ * DELETE { linkId: string }                          -> removes one link
  *
  * Called by the Video Editor when a freshly-recorded clip's captured links are
  * ready (POST) and when the user removes a mis-captured link chip (DELETE).
  */
+const createBodySchema = z.object({
+  links: z.array(
+    z.object({
+      url: z.string().min(1),
+      title: z.string().nullish(),
+      capturedAt: z.number().optional(),
+    })
+  ),
+});
+
+const deleteBodySchema = z.object({
+  linkId: z.string().min(1),
+});
+
 const createAction = makeAction({
   input: "json",
   effect: ({ params, payload }) =>
     Effect.gen(function* () {
-      if (
-        !payload ||
-        typeof payload !== "object" ||
-        Array.isArray(payload) ||
-        !("links" in payload)
-      ) {
+      const parsed = createBodySchema.safeParse(payload);
+      if (!parsed.success) {
         return yield* Effect.die(
           data("Body must be a JSON object with a links array", { status: 400 })
         );
       }
 
-      const { links } = payload as { links: unknown };
-      if (!Array.isArray(links)) {
-        return yield* Effect.die(
-          data("links must be an array", { status: 400 })
-        );
-      }
-
-      const parsed = links.map((link) => {
-        const l = link as Record<string, unknown>;
-        return {
-          url: String(l.url),
-          title: typeof l.title === "string" ? l.title : null,
-          capturedAt:
-            typeof l.capturedAt === "number" ? l.capturedAt : Date.now(),
-        };
-      });
+      const links = parsed.data.links.map((link) => ({
+        url: link.url,
+        title: link.title ?? null,
+        capturedAt: link.capturedAt ?? Date.now(),
+      }));
 
       const clipOps = yield* ClipOperationsService;
-      const webLinks = yield* clipOps.createClipWebLinks(params.clipId!, parsed);
+      const webLinks = yield* clipOps.createClipWebLinks(params.clipId!, links);
       return data({ webLinks });
     }),
 });
@@ -55,20 +55,15 @@ const deleteAction = makeAction({
   input: "json",
   effect: ({ payload }) =>
     Effect.gen(function* () {
-      if (
-        !payload ||
-        typeof payload !== "object" ||
-        Array.isArray(payload) ||
-        typeof (payload as Record<string, unknown>).linkId !== "string"
-      ) {
+      const parsed = deleteBodySchema.safeParse(payload);
+      if (!parsed.success) {
         return yield* Effect.die(
           data("Body must include a linkId string", { status: 400 })
         );
       }
 
-      const { linkId } = payload as { linkId: string };
       const clipOps = yield* ClipOperationsService;
-      const result = yield* clipOps.deleteClipWebLink(linkId);
+      const result = yield* clipOps.deleteClipWebLink(parsed.data.linkId);
       return data(result);
     }),
 });

--- a/app/services/db-clip-operations.server.ts
+++ b/app/services/db-clip-operations.server.ts
@@ -2,7 +2,7 @@ import {
   DrizzleService,
   type Database,
 } from "@/services/drizzle-service.server";
-import { clips, chapters } from "@/db/schema";
+import { clips, chapters, clipWebLinks } from "@/db/schema";
 import {
   NotFoundError,
   UnknownDBServiceError,
@@ -659,6 +659,42 @@ export const createClipOperations = (db: Database) => {
     return clipsResult;
   });
 
+  const createClipWebLinks = Effect.fn("createClipWebLinks")(function* (
+    clipId: string,
+    links: readonly {
+      url: string;
+      title: string | null;
+      capturedAt: number;
+    }[]
+  ) {
+    if (links.length === 0) return [];
+
+    const inserted = yield* makeDbCall(() =>
+      db
+        .insert(clipWebLinks)
+        .values(
+          links.map((link) => ({
+            clipId,
+            url: link.url,
+            title: link.title,
+            capturedAt: new Date(link.capturedAt),
+          }))
+        )
+        .returning()
+    );
+
+    return inserted;
+  });
+
+  const deleteClipWebLink = Effect.fn("deleteClipWebLink")(function* (
+    linkId: string
+  ) {
+    yield* makeDbCall(() =>
+      db.delete(clipWebLinks).where(eq(clipWebLinks.id, linkId))
+    );
+    return { success: true };
+  });
+
   return {
     getClipById,
     getClipsByIds,
@@ -673,6 +709,8 @@ export const createClipOperations = (db: Database) => {
     archiveChapter,
     reorderChapter,
     appendClips,
+    createClipWebLinks,
+    deleteClipWebLink,
   };
 };
 

--- a/app/services/db-video-operations.server.ts
+++ b/app/services/db-video-operations.server.ts
@@ -3,7 +3,7 @@ import {
   type Database,
 } from "@/services/drizzle-service.server";
 import { CourseOperationsService } from "@/services/db-course-operations.server";
-import { clips, chapters, videos } from "@/db/schema";
+import { clips, chapters, videos, clipWebLinks } from "@/db/schema";
 import {
   CannotArchiveLessonVideoError,
   NotFoundError,
@@ -213,6 +213,9 @@ export const createVideoOperations = (
                     columns: { name: true },
                   },
                 },
+              },
+              webLinks: {
+                orderBy: asc(clipWebLinks.capturedAt),
               },
             },
           },

--- a/app/services/text-writing-agent.ts
+++ b/app/services/text-writing-agent.ts
@@ -1,4 +1,5 @@
 import { sortByOrder } from "@/lib/sort-by-order";
+import { formatOnScreenLinks } from "@/lib/transcript-builder";
 import { generateArticlePrompt } from "@/prompts/generate-article";
 import { generateArticlePlanPrompt } from "@/prompts/generate-article-plan";
 import { generateStepsToCompleteForProjectPrompt } from "@/prompts/generate-steps-to-complete-for-project";
@@ -372,6 +373,8 @@ export const acquireTextWritingContext = Effect.fn("acquireVideoContext")(
       let currentParagraph: string[] = [];
       let currentSectionEnabled = allSectionsEnabled; // If no sections exist, include clips before first section
       let clipIndex = 0;
+      // On-screen web links are annotated inline once, on their first appearance.
+      const seenUrls = new Set<string>();
 
       for (const item of sortedAllItems) {
         if (item.type === "chapter") {
@@ -389,7 +392,10 @@ export const acquireTextWritingContext = Effect.fn("acquireVideoContext")(
         } else {
           clipIndex++;
           if (item.clip.text && currentSectionEnabled) {
-            currentParagraph.push(`[${clipIndex}] ${item.clip.text}`);
+            const onScreen = formatOnScreenLinks(item.clip.webLinks, seenUrls);
+            currentParagraph.push(
+              `[${clipIndex}] ${onScreen}${item.clip.text}`
+            );
           }
         }
       }

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -1,0 +1,77 @@
+# CVM Browser Link Capture
+
+A tiny Chrome extension that captures the web pages you show on screen while
+recording, so they get attached to the right clips in the Course Video Manager.
+
+## Why it exists
+
+Matt films with the **CVM open in Edge** on one side and a **Chrome browser** on
+the other showing reference pages. Because the two live in different browsers, an
+in-page link can't bridge them — so this extension streams the focused Chrome
+tab's URL to CVM over the **forwarder hub WebSocket** (`ws://localhost:5172`,
+the same hub the Stream Deck uses).
+
+The extension is a **dumb event tap**. It emits two kinds of message:
+
+- `browser-focus` — when the Chrome window gains/loses OS focus.
+- `browser-url` — when the active tab's URL changes (tab switch or navigation).
+
+CVM's Video Editor reconstructs, from that stream, which pages were on screen
+(Chrome focused + a real web page) during each recorded clip, and stores them as
+`clip_web_link` rows. They then show as chips under each clip and are annotated
+inline in the transcript handed to the writer agent.
+
+## Design guarantees
+
+- **Send-only.** It never receives anything from the hub.
+- **Best-effort.** If CVM/OBS isn't running (the usual case while you browse),
+  connections fail fast and events are dropped — no buffering, no retry storm,
+  no degradation to normal browsing.
+- **Self-healing.** MV3 service workers sleep when idle; any focus/tab event
+  wakes it and it reconnects lazily. During filming there's enough activity to
+  keep the socket alive.
+
+The toolbar badge shows **`on`** (green) when connected to the hub and nothing
+when disconnected — glance at it before a shoot.
+
+## Install (unpacked, dev-only)
+
+This is a personal tool — not published to the Chrome Web Store.
+
+1. Open `chrome://extensions` in the **Chrome** browser you film with.
+2. Enable **Developer mode** (top-right).
+3. Click **Load unpacked** and select this `chrome-extension/` directory.
+4. Pin the extension so you can see its badge.
+
+Config is hardcoded to `ws://localhost:5172` (matches the rest of the CVM
+localhost stack). If that ever changes, edit `HUB_URL` in `background.js`.
+
+## Smoke test (≈2 minutes)
+
+Do this after loading/updating the extension, before relying on it in a shoot:
+
+1. Start CVM (`pnpm dev`) so the forwarder hub is listening on `:5172`.
+2. Reload the extension at `chrome://extensions`. Its badge should turn to a
+   green **`on`** within a second or two. (If it stays blank, the hub isn't up.)
+3. Open the CVM video editor for any video in Edge.
+4. Start an OBS recording and talk for a few seconds while a Chrome tab
+   (e.g. `https://example.com`) is focused. Switch to a second page and talk
+   about it too.
+5. Stop recording. Once the clips land, confirm:
+   - Link **chips** appear under the clips where those pages were focused.
+   - Flipping a page for under ~1.5s does **not** create a chip.
+   - Tabbing away to Edge (Chrome loses focus) stops capture.
+6. Open the article writer and confirm the transcript shows
+   `«on screen: … — https://…»` inline after the relevant `[N]` markers, each
+   URL annotated only once.
+
+### Testing the CVM side without a browser
+
+You don't need Chrome to exercise the editor half — run the synthetic event
+sender, which pushes fake `browser-focus` / `browser-url` messages onto the hub:
+
+```sh
+pnpm tsx chrome-extension/dev-send-events.ts
+```
+
+See that script's header for options.

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,149 @@
+// CVM Browser Link Capture — MV3 background service worker.
+//
+// A dumb event tap. It watches Chrome window focus and the active tab's URL and
+// forwards state-change events to the Course Video Manager over the forwarder
+// hub (ws://localhost:5172). The Video Editor reconstructs which pages were on
+// screen during each recorded clip.
+//
+// Design notes:
+//   * Send-only. We never receive from the hub.
+//   * Best-effort. If the hub is down (CVM/OBS not running — the common case),
+//     connects fail fast and events are dropped. No buffering, no retry storm.
+//   * MV3 service workers sleep when idle; that's fine. Any focus/tab event
+//     wakes the worker, which reconnects lazily and sends. During filming there
+//     is enough activity to keep the socket alive.
+
+const HUB_URL = "ws://localhost:5172";
+// After a failed connect, don't try again for this long (avoids hammering the
+// hub while CVM is closed and you're just browsing).
+const RECONNECT_COOLDOWN_MS = 5000;
+// Only the newest events matter; cap the tiny buffer used during the brief
+// connect handshake.
+const MAX_PENDING = 10;
+
+let socket = null;
+let connecting = false;
+let lastConnectFailAt = 0;
+let pending = [];
+
+function setConnectedBadge(connected) {
+  chrome.action.setBadgeBackgroundColor({
+    color: connected ? "#16a34a" : "#9ca3af",
+  });
+  chrome.action.setBadgeText({ text: connected ? "on" : "" });
+  chrome.action.setTitle({
+    title: connected
+      ? "CVM Link Capture: connected"
+      : "CVM Link Capture: not connected",
+  });
+}
+
+function ensureConnected() {
+  if (socket && socket.readyState === WebSocket.OPEN) return;
+  if (connecting) return;
+  if (Date.now() - lastConnectFailAt < RECONNECT_COOLDOWN_MS) return;
+
+  connecting = true;
+  let ws;
+  try {
+    ws = new WebSocket(HUB_URL);
+  } catch {
+    connecting = false;
+    lastConnectFailAt = Date.now();
+    return;
+  }
+
+  ws.addEventListener("open", () => {
+    socket = ws;
+    connecting = false;
+    setConnectedBadge(true);
+    const toFlush = pending;
+    pending = [];
+    for (const msg of toFlush) {
+      try {
+        ws.send(JSON.stringify(msg));
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  const onGone = () => {
+    if (socket === ws) socket = null;
+    connecting = false;
+    lastConnectFailAt = Date.now();
+    pending = [];
+    setConnectedBadge(false);
+  };
+  ws.addEventListener("close", onGone);
+  ws.addEventListener("error", onGone);
+}
+
+function send(message) {
+  ensureConnected();
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    try {
+      socket.send(JSON.stringify(message));
+    } catch {
+      // ignore
+    }
+    return;
+  }
+  // Socket is mid-handshake (or just woke up): keep only the newest events so
+  // they flush once open. If the connect fails, pending is cleared.
+  pending.push(message);
+  if (pending.length > MAX_PENDING) pending.shift();
+}
+
+function sendFocus(focused) {
+  send({ type: "browser-focus", focused, ts: Date.now() });
+}
+
+function sendUrl(url, title) {
+  if (typeof url !== "string" || url === "") return;
+  send({
+    type: "browser-url",
+    url,
+    ...(typeof title === "string" && title !== "" ? { title } : {}),
+    ts: Date.now(),
+  });
+}
+
+// The active tab of the last-focused normal window.
+async function sendActiveTabUrl() {
+  try {
+    const [tab] = await chrome.tabs.query({
+      active: true,
+      lastFocusedWindow: true,
+    });
+    if (tab) sendUrl(tab.url, tab.title);
+  } catch {
+    // ignore
+  }
+}
+
+// Chrome gained/lost OS focus. WINDOW_ID_NONE means no Chrome window is focused
+// (you tabbed away to another app, e.g. the CVM in Edge).
+chrome.windows.onFocusChanged.addListener((windowId) => {
+  const focused = windowId !== chrome.windows.WINDOW_ID_NONE;
+  sendFocus(focused);
+  // On regaining focus, resend the current URL so the editor's effective-visible
+  // state is correct even if the active tab changed while Chrome was in the
+  // background.
+  if (focused) sendActiveTabUrl();
+});
+
+// Switched to a different tab.
+chrome.tabs.onActivated.addListener(() => {
+  sendActiveTabUrl();
+});
+
+// The active tab navigated to a new URL (or its title resolved).
+chrome.tabs.onUpdated.addListener((_tabId, changeInfo, tab) => {
+  if (!tab.active) return;
+  if (changeInfo.url || changeInfo.title) {
+    sendUrl(tab.url, tab.title);
+  }
+});
+
+setConnectedBadge(false);

--- a/chrome-extension/dev-send-events.ts
+++ b/chrome-extension/dev-send-events.ts
@@ -1,0 +1,62 @@
+// Synthetic browser link-capture event sender.
+//
+// Pushes fake `browser-focus` / `browser-url` messages onto the forwarder hub
+// (ws://localhost:5172) so you can exercise the CVM side of the link-capture
+// feature without loading the Chrome extension or driving a real browser.
+//
+// Usage:
+//   pnpm tsx chrome-extension/dev-send-events.ts
+//   pnpm tsx chrome-extension/dev-send-events.ts https://a.com https://b.com
+//
+// It walks through a small scripted scenario: focus Chrome, show the first URL,
+// switch to the second, then blur — the same shape the extension emits while you
+// narrate over two reference pages. Run it with the CVM dev server up; watch the
+// video editor's link event log / recorded clips react.
+//
+// Note: attaching links to clips still requires a recording (OBS drives clip
+// creation). This script verifies the extension -> hub -> editor event path.
+
+import { once } from "node:events";
+import { setTimeout as sleep } from "node:timers/promises";
+import {
+  createBrowserEventMessage,
+  type BrowserEventMessage,
+} from "../stream-deck-forwarder/stream-deck-forwarder-types";
+
+const HUB_URL = "ws://localhost:5172";
+
+const urls =
+  process.argv.slice(2).length > 0
+    ? process.argv.slice(2)
+    : ["https://example.com/one", "https://example.com/two"];
+
+async function main() {
+  const ws = new WebSocket(HUB_URL);
+  ws.addEventListener("error", () => {
+    console.error(
+      `Could not connect to the forwarder hub at ${HUB_URL}. Is the CVM dev server running?`
+    );
+    process.exit(1);
+  });
+  await once(ws, "open");
+  console.log(`Connected to ${HUB_URL}`);
+
+  const emit = (message: BrowserEventMessage) => {
+    ws.send(createBrowserEventMessage(message));
+    console.log("→", JSON.stringify(message));
+  };
+
+  emit({ type: "browser-focus", focused: true, ts: Date.now() });
+  for (const url of urls) {
+    emit({ type: "browser-url", url, ts: Date.now() });
+    await sleep(3000);
+  }
+  emit({ type: "browser-focus", focused: false, ts: Date.now() });
+
+  await sleep(200);
+  ws.close();
+  console.log("Done.");
+  process.exit(0);
+}
+
+void main();

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "CVM Browser Link Capture",
+  "version": "1.0.0",
+  "description": "Streams the focused Chrome tab's URL to the Course Video Manager over WebSocket, so web pages shown on screen during recording get attached to clips.",
+  "permissions": ["tabs"],
+  "host_permissions": ["http://*/*", "https://*/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_title": "CVM Link Capture"
+  }
+}

--- a/docs/adr/0020-clip-web-links-over-websocket.md
+++ b/docs/adr/0020-clip-web-links-over-websocket.md
@@ -1,0 +1,23 @@
+# Clip Web Links captured over the Stream Deck WebSocket hub
+
+A **Clip Web Link** records that a web page was on screen (in a focused Chrome window, showing an `http(s)` page) while a **Clip** was being recorded. Matt films with the CVM open in **Edge** and reference pages in a separate **Chrome** browser. A dumb MV3 Chrome extension (`chrome-extension/`) streams two event types — `browser-focus` and `browser-url` — over the existing Stream Deck forwarder **WebSocket** hub (`ws://localhost:5172`). The Video Editor reconstructs the effective-visible-URL timeline from that stream and attaches the pages shown during each clip.
+
+The capture rides the **Optimistic Clip** lifecycle exactly as diagram pinning does (see ADR 0003–0005): the clip's window opens when speech is detected and drains when its audio window closes; the drained links are stashed on the optimistic clip and persisted as `clip_web_link` rows when it pairs with a database clip. No source-time arithmetic — the live wall-clock window is the association.
+
+## Why WebSocket here, when ADR 0005 rejected it for diagrams
+
+ADR 0005 chose `BroadcastChannel` for the Diagram Playground ↔ Video Editor link and rejected WebSocket, but named the exact conditions under which WebSocket _would_ be right: _"if editor and playground could live on different machines or if the server itself needed to push … — neither is true today."_
+
+For Clip Web Links the first condition holds. The two endpoints are **different browsers** (Edge and Chrome) — different processes, different origins. `BroadcastChannel` is same-origin, same-user-agent; it cannot bridge Edge↔Chrome. So the reasoning of ADR 0005 points _at_ WebSocket here, not away from it. And the transport already exists: the Stream Deck forwarder is a broadcast hub that rebroadcasts any client's message to all clients, so the extension is just another producer and the editor just another consumer.
+
+## Considered alternatives
+
+- **`BroadcastChannel` (as diagrams use).** Impossible: it does not cross the Edge↔Chrome browser boundary. This is the constraint ADR 0005 flagged.
+- **A dedicated WebSocket server/port for browser events.** Rejected: a second server to run and a second thing that can be down, for no benefit — the forwarder hub already fans out client messages. Reuse keeps one lifecycle.
+- **A native-messaging host / file drop / clipboard bridge.** Rejected: heavier to install and operate than an unpacked extension pointed at a localhost socket the stack already runs.
+
+## Consequences
+
+- The forwarder message schema (`stream-deck-forwarder/stream-deck-forwarder-types.ts`) now carries two message families — Stream Deck actions and browser events — as separate schemas over the same hub. Consumers that care about only one family must **ignore unknown types gracefully** (`use-websocket.ts` now `safeParse`s and drops non-Stream-Deck messages) instead of throwing.
+- The extension is **send-only and best-effort**: when the hub is down (CVM/OBS not running — the common case while browsing) connects fail fast and events are dropped, so normal browsing never degrades. It tolerates the hub, the browser, and OBS each being absent.
+- Capture is **live-only, going forward** — there is no backfill of links for already-recorded clips.

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../../node_modules

--- a/stream-deck-forwarder/run-stream-deck-forwarder.test.ts
+++ b/stream-deck-forwarder/run-stream-deck-forwarder.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from "vitest";
+import type { AddressInfo } from "node:net";
+import { WebSocket as WsClient } from "ws";
+import { startStreamDeckForwarder } from "./run-stream-deck-forwarder";
+
+// Integration test for the hub's client-message rebroadcast — the path the
+// browser link-capture extension relies on. Runs on ephemeral ports so it never
+// collides with a running dev server.
+
+let stop: (() => Promise<void>) | null = null;
+
+afterEach(async () => {
+  if (stop) await stop();
+  stop = null;
+});
+
+const openClient = (port: number) =>
+  new Promise<WsClient>((resolve, reject) => {
+    const ws = new WsClient(`ws://localhost:${port}`);
+    ws.once("open", () => resolve(ws));
+    ws.once("error", reject);
+  });
+
+async function startHub() {
+  const { wss, httpServer } = startStreamDeckForwarder({
+    wsPort: 0,
+    httpPort: 0,
+  });
+  await new Promise<void>((r) => wss.once("listening", r));
+  const port = (wss.address() as AddressInfo).port;
+  stop = () =>
+    new Promise<void>((resolve) => {
+      wss.close(() => httpServer.close(() => resolve()));
+    });
+  return port;
+}
+
+describe("stream deck forwarder hub", () => {
+  it("rebroadcasts a client's message to every other client", async () => {
+    const port = await startHub();
+    const receiver = await openClient(port);
+    const received = new Promise<string>((resolve) => {
+      receiver.once("message", (data) => resolve(data.toString()));
+    });
+
+    const sender = await openClient(port);
+    const payload = JSON.stringify({
+      type: "browser-url",
+      url: "https://example.com",
+      ts: 1,
+    });
+    sender.send(payload);
+
+    expect(await received).toBe(payload);
+    receiver.close();
+    sender.close();
+  });
+
+  it("does not echo a message back to the client that sent it", async () => {
+    const port = await startHub();
+    const sender = await openClient(port);
+
+    let echoed = false;
+    sender.once("message", () => {
+      echoed = true;
+    });
+    sender.send(JSON.stringify({ type: "browser-focus", focused: true, ts: 1 }));
+
+    await new Promise((r) => setTimeout(r, 200));
+    expect(echoed).toBe(false);
+    sender.close();
+  });
+});

--- a/stream-deck-forwarder/run-stream-deck-forwarder.ts
+++ b/stream-deck-forwarder/run-stream-deck-forwarder.ts
@@ -2,58 +2,106 @@ import http from "node:http";
 import { WebSocket, WebSocketServer } from "ws";
 import { type StreamDeckForwarderMessage } from "./stream-deck-forwarder-types";
 
-const wss = new WebSocketServer({ port: 5172 }, () => {
-  console.log("Stream Deck Forwarder server started on port 5172");
-});
+export const DEFAULT_WS_PORT = 5172;
+export const DEFAULT_HTTP_PORT = 5174;
 
-const clients = new Map<string, WebSocket>();
+/**
+ * Starts the Stream Deck forwarder: a WebSocket broadcast hub plus an HTTP
+ * server that turns Stream Deck button presses into broadcast messages.
+ *
+ * The hub fans out in two directions:
+ *   - Stream Deck presses hit the HTTP endpoints and are broadcast to every
+ *     connected client.
+ *   - Anything a client sends over the socket is rebroadcast to every *other*
+ *     client, so producers like the browser link-capture extension can reach
+ *     the Video Editor over the same hub.
+ *
+ * Ports are injectable so this can be started on ephemeral ports in tests.
+ */
+export function startStreamDeckForwarder(opts?: {
+  wsPort?: number;
+  httpPort?: number;
+}) {
+  const wsPort = opts?.wsPort ?? DEFAULT_WS_PORT;
+  const httpPort = opts?.httpPort ?? DEFAULT_HTTP_PORT;
 
-const sendMessage = (message: StreamDeckForwarderMessage) => {
-  clients.values().forEach((client) => {
-    client.send(JSON.stringify(message));
+  const wss = new WebSocketServer({ port: wsPort }, () => {
+    console.log(`Stream Deck Forwarder server started on port ${wsPort}`);
   });
-};
 
-wss.on("connection", (ws) => {
-  console.log("Client connected");
-  const connectionId = crypto.randomUUID();
-  clients.set(connectionId, ws);
+  const clients = new Map<string, WebSocket>();
 
-  ws.on("close", () => {
-    clients.delete(connectionId);
+  const sendMessage = (message: StreamDeckForwarderMessage) => {
+    clients.values().forEach((client) => {
+      client.send(JSON.stringify(message));
+    });
+  };
+
+  wss.on("connection", (ws) => {
+    console.log("Client connected");
+    const connectionId = crypto.randomUUID();
+    clients.set(connectionId, ws);
+
+    // Rebroadcast anything a client sends over the socket to every other client.
+    // Stream Deck actions arrive via the HTTP endpoints below, but other
+    // producers (e.g. the browser link-capture extension emitting
+    // browser-focus/browser-url) send directly over the socket and rely on the
+    // hub fanning them out to the Video Editor. The payload is forwarded
+    // verbatim so any message family passes through untouched.
+    ws.on("message", (data, isBinary) => {
+      const payload = isBinary ? data : data.toString();
+      for (const [id, client] of clients) {
+        if (id === connectionId) continue;
+        if (client.readyState === WebSocket.OPEN) {
+          client.send(payload);
+        }
+      }
+    });
+
+    ws.on("close", () => {
+      clients.delete(connectionId);
+    });
+    ws.on("error", (error) => {
+      console.error("WebSocket error:", error);
+      clients.delete(connectionId);
+    });
   });
-  ws.on("error", (error) => {
-    console.error("WebSocket error:", error);
-    clients.delete(connectionId);
+
+  const httpServer = http.createServer((req, res) => {
+    if (req.url === "/api/delete-last-clip") {
+      sendMessage({
+        type: "delete-last-clip",
+      });
+    } else if (req.url === "/api/toggle-last-frame-of-video") {
+      sendMessage({
+        type: "toggle-last-frame-of-video",
+      });
+    } else if (req.url === "/api/toggle-pause") {
+      sendMessage({
+        type: "toggle-pause",
+      });
+    } else if (req.url === "/api/add-chapter") {
+      sendMessage({
+        type: "add-chapter",
+      });
+    } else if (req.url === "/api/clear-all-archived") {
+      sendMessage({
+        type: "clear-all-archived",
+      });
+    }
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("Hello, world!");
   });
-});
 
-const httpServer = http.createServer((req, res) => {
-  if (req.url === "/api/delete-last-clip") {
-    sendMessage({
-      type: "delete-last-clip",
-    });
-  } else if (req.url === "/api/toggle-last-frame-of-video") {
-    sendMessage({
-      type: "toggle-last-frame-of-video",
-    });
-  } else if (req.url === "/api/toggle-pause") {
-    sendMessage({
-      type: "toggle-pause",
-    });
-  } else if (req.url === "/api/add-chapter") {
-    sendMessage({
-      type: "add-chapter",
-    });
-  } else if (req.url === "/api/clear-all-archived") {
-    sendMessage({
-      type: "clear-all-archived",
-    });
-  }
-  res.writeHead(200, { "Content-Type": "text/plain" });
-  res.end("Hello, world!");
-});
+  httpServer.listen(httpPort, () => {
+    console.log(`HTTP server started on port ${httpPort}`);
+  });
 
-httpServer.listen(5174, () => {
-  console.log("HTTP server started on port 5174");
-});
+  return { wss, httpServer, sendMessage };
+}
+
+// Auto-start when run as the process entry point (e.g. `tsx run-…`), but not
+// when imported by tests.
+if (!process.env.VITEST) {
+  startStreamDeckForwarder();
+}

--- a/stream-deck-forwarder/stream-deck-forwarder-types.ts
+++ b/stream-deck-forwarder/stream-deck-forwarder-types.ts
@@ -19,3 +19,52 @@ export const createStreamDeckForwarderMessage = (
 ) => {
   return JSON.stringify(message);
 };
+
+/**
+ * Browser link-capture messages.
+ *
+ * These are broadcast over the same forwarder hub (ws://localhost:5172) by the
+ * Chrome extension (see `chrome-extension/`). The extension is a dumb event tap:
+ * it emits a `browser-focus` whenever Chrome gains/loses OS focus, and a
+ * `browser-url` whenever the active tab's URL changes (tab switch or navigation).
+ * The Video Editor reconstructs the live `(activeUrl, chromeFocused)` timeline
+ * from this stream and attaches on-screen URLs to the clip being recorded.
+ *
+ * The hub rebroadcasts every client message to every client, so these coexist
+ * with the Stream Deck messages above. Consumers that only care about one family
+ * (e.g. `use-websocket.ts` only handles Stream Deck actions) must ignore the
+ * other family gracefully rather than throwing on parse.
+ */
+export const browserFocusMessageSchema = z.object({
+  type: z.literal("browser-focus"),
+  /** True when the Chrome browser window is the foreground OS window. */
+  focused: z.boolean(),
+  /** `Date.now()` stamped by the extension. Same machine, same clock. */
+  ts: z.number(),
+});
+
+export const browserUrlMessageSchema = z.object({
+  type: z.literal("browser-url"),
+  /**
+   * The raw URL of the now-active tab (may be a non-web URL such as
+   * `chrome://newtab/` — the Video Editor decides what is capturable).
+   */
+  url: z.string(),
+  /** The active tab's page title, when the extension can read it. */
+  title: z.string().optional(),
+  /** `Date.now()` stamped by the extension. */
+  ts: z.number(),
+});
+
+export const browserEventMessageSchema = z.discriminatedUnion("type", [
+  browserFocusMessageSchema,
+  browserUrlMessageSchema,
+]);
+
+export type BrowserFocusMessage = z.infer<typeof browserFocusMessageSchema>;
+export type BrowserUrlMessage = z.infer<typeof browserUrlMessageSchema>;
+export type BrowserEventMessage = z.infer<typeof browserEventMessageSchema>;
+
+export const createBrowserEventMessage = (message: BrowserEventMessage) => {
+  return JSON.stringify(message);
+};


### PR DESCRIPTION
## What & why

Matt films with the **CVM open in Edge** and a **Chrome browser** on the other side showing reference pages. This adds a **clip web link** domain concept: web pages shown in a *focused* Chrome window while a clip records are captured and attached to that clip (one-to-many), so they surface to the writer agent.

Because CVM (Edge) and the browser (Chrome) are separate apps, a Chrome extension bridges them over the **existing forwarder hub WebSocket** (`ws://localhost:5172`).

## Design (locked via grilling)

- **Dumb extension, editor is the brain.** `chrome-extension/` is an MV3 send-only tap emitting `browser-focus` / `browser-url`. Best-effort: if the hub is down (the common case while browsing) it drops events — no buffering, no retry storm, no degradation.
- **Rides the optimistic-clip lifecycle**, mirroring the diagram-pinning feature: open a window on speech detection, drain on audio-window-closed, persist on DB pairing. No source-time math.
- **Interval/overlap model** with a ~1.5s min-visible threshold (filters transient flashes) and seed-at-open (a page opened during silence that's still visible when the clip starts attaches). Pure logic, unit-tested.
- **Hard link:** `clip_web_link` table with `clip_id` FK, cascade delete; one row per distinct URL per clip, ordered by capture time.
- **Transcript:** inline `«on screen: … — https://…»` annotation after the `[N]` marker, **global first-wins dedup** (each URL annotated once) to nudge the writer to cite it once, plus a prompt line explaining it.
- **Editor UI:** per-clip link chips with a delete (×).

## Verification

- New unit tests: pure timeline logic, the drain seam, and the transcript annotation/dedup.
- Full typecheck clean; full suite green except 2 pre-existing CLI-spawn test files that fail identically on `origin/main` (ANSI-in-stdout env issue, unrelated).
- Extension + end-to-end capture (OBS/Chrome) needs Matt's manual smoke test — checklist in `chrome-extension/README.md`. A synthetic-event sender (`chrome-extension/dev-send-events.ts`) exercises the editor side without a browser.

## Out of scope (v1)

Options page, Web Store packaging, manual link add, non-Chrome browsers, incognito, background/multi-window tabs, backfill of existing recordings.

## Migration

Adds `0002_regular_steel_serpent.sql` (new `clip_web_link` table). Run `pnpm db:migrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)