### PR TITLE
fix: normalize concat clips to portrait 1080x1920 (fix landscape export)

### DIFF
--- a/app/services/ffmpeg-commands.ts
+++ b/app/services/ffmpeg-commands.ts
@@ -131,12 +131,18 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
           );
         }
 
-        // Build filter complex
+        // Build filter complex. Normalize every input to the vertical 1080x1920
+        // frame (and stereo audio) so the concat filter — which requires all
+        // inputs to share dimensions/SAR/channel layout — accepts odd effect
+        // clips (e.g. white noise at 854x480 mono). The target MUST stay
+        // portrait: these are 9:16 shorts and the subtitle overlay is 1080x1920,
+        // so scaling to landscape here produced a landscape export with the
+        // portrait overlay pinned top-left.
         const filterParts: string[] = [];
         const concatInputs: string[] = [];
         for (let i = 0; i < clips.length; i++) {
           filterParts.push(
-            `[${i}:v]setpts=PTS-STARTPTS,scale=1920:1080,setsar=1[v${i}]`,
+            `[${i}:v]setpts=PTS-STARTPTS,scale=1080:1920,setsar=1[v${i}]`,
             `[${i}:a]asetpts=PTS-STARTPTS,aformat=channel_layouts=stereo[a${i}]`
           );
           concatInputs.push(`[v${i}][a${i}]`);


### PR DESCRIPTION
## Problem

Finished vertical videos (e.g. `D:\finished-videos\<id>.mp4`) came out with the **wrong aspect ratio and too small** — a landscape 1920×1080 export with the portrait subtitle overlay crammed into the top-left and clipped.

## Root cause

`createAndConcatenateVideoClipsSinglePass` in `app/services/ffmpeg-commands.ts` scaled **every** concat input to `scale=1920:1080` (landscape). This was added in `7c991f1d` to normalize odd effect clips (e.g. 854×480 white noise) so the concat filter — which requires matching dimensions/SAR/channel layout — wouldn't fail. But these are 9:16 shorts and the subtitle overlay is **1080×1920 portrait**, so:

- the base concat video became landscape 1920×1080,
- the composite (`overlay=0:0`) inherits the base dimensions,
- the 1080×1920 overlay is pinned top-left and clipped.

The original `total-typescript-monorepo` used **no scale** in default mode, preserving the source shorts' native portrait dimensions, which matched the overlay.

## Fix

Normalize to portrait `scale=1080:1920` instead of landscape `scale=1920:1080`. This keeps the concat normalization the earlier fix intended, but with the correct 9:16 aspect ratio so the export and overlay agree again.

## Testing

- `render-vertical-video-service.test.ts` and existing ffmpeg tests pass.
- Pre-commit typecheck / boundary / prettier checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)