### PR TITLE
refactor: route overlay composite through FFmpegCommandsService GPU semaphore

### DIFF
--- a/app/services/ffmpeg-commands.ts
+++ b/app/services/ffmpeg-commands.ts
@@ -312,6 +312,65 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
         return outputFile;
       });
 
+      const compositeOverlay = Effect.fn("compositeOverlay")(function* (
+        videoPath: string,
+        overlayPath: string,
+        outputPath: string
+      ) {
+        const args = [
+          "-y",
+          "-hide_banner",
+          "-i",
+          videoPath,
+          "-i",
+          overlayPath,
+          "-filter_complex",
+          "[0:v][1:v]overlay=0:0:format=auto[outv]",
+          "-map",
+          "[outv]",
+          "-map",
+          "0:a",
+          "-c:v",
+          "libx264",
+          "-preset",
+          "slow",
+          "-crf",
+          "18",
+          "-c:a",
+          "copy",
+          "-movflags",
+          "+faststart",
+          outputPath,
+        ];
+
+        yield* gpuSemaphore.withPermits(1)(
+          Effect.gen(function* () {
+            const code = yield* Command.exitCode(
+              Command.make("ffmpeg", ...args).pipe(
+                Command.stdout("inherit"),
+                Command.stderr("inherit")
+              )
+            ).pipe(
+              Effect.mapError(
+                (e) =>
+                  new FFmpegError({
+                    cause: e,
+                    message: `Failed to composite overlay: ${e.message}`,
+                  })
+              )
+            );
+            if (code !== 0) {
+              yield* new FFmpegError({
+                cause: null,
+                message: `ffmpeg composite exited with code ${code}`,
+              });
+            }
+          })
+        );
+
+        return outputPath;
+      });
+
       const captureFrameAtTime = Effect.fn("captureFrameAtTime")(function* (
         inputVideo: string,
         timestamp: number,
@@ -366,6 +425,7 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
         getFPS,
         createAndConcatenateVideoClipsSinglePass,
         normalizeAudio,
+        compositeOverlay,
         captureFrameAtTime,
       };
     }),

--- a/app/services/render-vertical-video-service.ts
+++ b/app/services/render-vertical-video-service.ts
@@ -121,7 +121,11 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
             recursive: true,
           });
 
-          yield* compositeOverlay(concatenatedPath, overlayPath, outputPath);
+          yield* ffmpegCommands.compositeOverlay(
+            concatenatedPath,
+            overlayPath,
+            outputPath
+          );
 
           // Clean up intermediate files
           yield* effectFs
@@ -286,60 +290,5 @@ function renderOverlay(
     yield* effectFs.remove(propsFile).pipe(Effect.catchAll(() => Effect.void));
 
     return result;
-  });
-}
-
-function compositeOverlay(
-  videoPath: string,
-  overlayPath: string,
-  outputPath: string
-) {
-  const args = [
-    "-y",
-    "-hide_banner",
-    "-i",
-    videoPath,
-    "-i",
-    overlayPath,
-    "-filter_complex",
-    "[0:v][1:v]overlay=0:0:format=auto[outv]",
-    "-map",
-    "[outv]",
-    "-map",
-    "0:a",
-    "-c:v",
-    "libx264",
-    "-preset",
-    "slow",
-    "-crf",
-    "18",
-    "-c:a",
-    "copy",
-    "-movflags",
-    "+faststart",
-    outputPath,
-  ];
-
-  return Effect.gen(function* () {
-    const code = yield* Command.exitCode(
-      Command.make("ffmpeg", ...args).pipe(
-        Command.stdout("inherit"),
-        Command.stderr("inherit")
-      )
-    ).pipe(
-      Effect.mapError(
-        (e) =>
-          new RenderVerticalError({
-            cause: e,
-            message: `Failed to composite overlay: ${e.message}`,
-          })
-      )
-    );
-    if (code !== 0) {
-      yield* new RenderVerticalError({
-        cause: null,
-        message: `ffmpeg composite exited with code ${code}`,
-      });
-    }
   });
 }


### PR DESCRIPTION
## What

The final composite step of `renderVerticalVideo` — overlaying the transparent `.mov` onto the concatenated video — ran a **raw** `ffmpeg` command inline in `render-vertical-video-service.ts`, bypassing the `gpuSemaphore` that throttles the other GPU-bound ffmpeg work (`createAndConcatenateVideoClipsSinglePass`).

This moves the composite into a new `FFmpegCommandsService.compositeOverlay` method guarded by `gpuSemaphore.withPermits(1)`, so concurrent renders can no longer oversubscribe the encoder. Behaviour is otherwise identical (same ffmpeg args).

## Notes

- The composite encoder is `libx264` (CPU), not nvenc. It's guarded by the GPU semaphore as requested to give a single throttle point alongside the concat step; if the goal shifts toward CPU-contention throttling specifically, `cpuSemaphore` would be the more literal fit.
- Error type changes from `RenderVerticalError` to `FFmpegError`, matching the other `FFmpegCommandsService` methods already called in the same function (concat / normalize / getFPS), so the render error channel is unchanged in shape.

## Testing

- `npm run typecheck` — clean
- `npx vitest run app/services/render-vertical-video-service.test.ts` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)