### PR TITLE
fix: query Buffer createPost via PostActionPayload union fragments

### DIFF
--- a/app/services/buffer-api-service.server.ts
+++ b/app/services/buffer-api-service.server.ts
@@ -51,34 +51,60 @@ const createBufferApiOperations = (token: string) => ({
   createPost: (opts: { channelId: string; text: string; videoUrl: string }) =>
     graphql({
       token,
+      // `createPost` returns the `PostActionPayload` union, so the created post's
+      // `id` lives behind the `PostActionSuccess` inline fragment; on failure the
+      // `MutationError` fragment carries a human-readable message.
       query: `
         mutation CreatePost($input: CreatePostInput!) {
           createPost(input: $input) {
-            id
+            ... on PostActionSuccess {
+              post {
+                id
+              }
+            }
+            ... on MutationError {
+              message
+            }
           }
         }
       `,
       variables: {
         input: {
-          channelIds: [opts.channelId],
+          channelId: opts.channelId,
           text: opts.text,
           assets: [{ video: { url: opts.videoUrl } }],
           schedulingType: "automatic",
+          mode: "addToQueue",
         },
       },
-    }).pipe(Effect.map((data) => ({ id: data.createPost.id as string }))),
+    }).pipe(
+      Effect.flatMap((data) => {
+        const payload = data.createPost as {
+          post?: { id: string };
+          message?: string;
+        };
+        if (payload.post?.id) {
+          return Effect.succeed({ id: payload.post.id });
+        }
+        return Effect.fail(
+          new BufferApiError({
+            message: `Buffer createPost failed: ${payload.message ?? "unknown error"}`,
+          })
+        );
+      })
+    ),
 
   getPostStatus: (postId: string) =>
     graphql({
       token,
       query: `
-        query GetPostStatus($id: ID!) {
-          post(id: $id) {
+        query GetPostStatus($input: PostInput!) {
+          post(input: $input) {
             status
           }
         }
       `,
-      variables: { id: postId },
+      variables: { input: { id: postId } },
     }).pipe(
       Effect.map((data) => ({
         status: data.post.status as BufferPostStatus,


### PR DESCRIPTION
## Problem

Posting a video to Buffer failed with:

> Buffer GraphQL: Cannot query field "id" on type "PostActionPayload".

Buffer's `createPost` mutation returns the **`PostActionPayload` union**, not a bare `Post`, so selecting `id` directly is invalid.

## Fix (`app/services/buffer-api-service.server.ts`)

- **`createPost` selection set** — select through the union's inline fragments: `... on PostActionSuccess { post { id } }` and `... on MutationError { message }`. On the error branch we now surface Buffer's message as a `BufferApiError` instead of crashing on a missing field.
- **`CreatePostInput` shape** corrected to match Buffer's schema:
  - `channelId` (singular) instead of `channelIds: [...]`
  - added the **required** `mode: addToQueue` field
- **`getPostStatus`** now uses the schema's `post(input: PostInput!)` query shape instead of `post(id: $id)`.

Shapes verified against Buffer's official GraphQL docs (create-video-post example + schema reference).

## Testing

- `buffer-posting-orchestration.server.test.ts` — 5/5 pass (mocks the API, confirms the service interface is unchanged).
- `typecheck` + `lint:boundaries` pass via pre-commit.

> Note: the existing tests mock `BufferApiService`, so they don't exercise the GraphQL query strings. The `getPostStatus` fix in particular should be validated against a live post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)