### PR TITLE
feat: restore always-on AI call-to-action on vertical video overlay

### DIFF
--- a/app/services/render-vertical-video-service.ts
+++ b/app/services/render-vertical-video-service.ts
@@ -90,12 +90,16 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
           const durationInFrames = Math.ceil(totalDuration * fps);
 
           // The call-to-action pill pops up at the very start and fades out over
-          // the length of the first clip. This mirrors the original Total
-          // TypeScript renderer, which set `ctaDurationInFrames` to the first
-          // clip's length. It is always the "ai" branded CTA.
+          // the length of the first clip, capped at 5 seconds so a long opening
+          // clip doesn't leave it on screen too long. This mirrors the original
+          // Total TypeScript renderer, which timed `ctaDurationInFrames` to the
+          // first clip. It is always the "ai" branded CTA.
+          const CTA_MAX_SECONDS = 5;
           const firstClip = video.clips[0]!;
+          const firstClipDuration =
+            firstClip.sourceEndTime - firstClip.sourceStartTime;
           const ctaDurationInFrames = Math.ceil(
-            (firstClip.sourceEndTime - firstClip.sourceStartTime) * fps
+            Math.min(firstClipDuration, CTA_MAX_SECONDS) * fps
           );
 
           // Step 5: Render Remotion overlay

--- a/app/services/render-vertical-video-service.ts
+++ b/app/services/render-vertical-video-service.ts
@@ -89,6 +89,15 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
           );
           const durationInFrames = Math.ceil(totalDuration * fps);
 
+          // The call-to-action pill pops up at the very start and fades out over
+          // the length of the first clip. This mirrors the original Total
+          // TypeScript renderer, which set `ctaDurationInFrames` to the first
+          // clip's length. It is always the "ai" branded CTA.
+          const firstClip = video.clips[0]!;
+          const ctaDurationInFrames = Math.ceil(
+            (firstClip.sourceEndTime - firstClip.sourceStartTime) * fps
+          );
+
           // Step 5: Render Remotion overlay
           opts.onStageChange?.("rendering-overlay");
           const overlayDir = path.join(tmpdir(), "cvm-overlay-render");
@@ -106,7 +115,7 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
             fps,
             durationInFrames,
             subtitles,
-            cta: null,
+            cta: { variant: "ai", durationInFrames: ctaDurationInFrames },
           });
 
           yield* renderOverlay(effectFs, propsJson, overlayPath);


### PR DESCRIPTION
## What

The subtitle overlay renderer (`packages/subtitle-overlay-renderer`) already supports a call-to-action pill — the composition, Zod schema, and the branded `ai-cta.png` / `typescript-cta.png` assets were all carried over when the renderer was extracted from the old Total TypeScript monorepo. But the app hard-coded `cta: null` when driving the renderer, so it never appeared.

This restores the CTA in `app/services/render-vertical-video-service.ts`:

- Always shows the **`ai`** branded CTA (no per-video decision — it's always the AI one).
- Times it to the **first clip's length** (`ctaDurationInFrames`), matching the original renderer, which computed `clips[0].duration * fps`.
- The pill pops up at the start of the video (frame 0) and fades in/out as it drifts up — unchanged animation from the original.

## Why

In the previous (TypeScript monorepo) implementation the CTA always popped up. That behaviour was lost in the extraction because the app never passed a `cta` prop. No changes were needed in the renderer package itself.

## Testing

- `npm run typecheck` — clean
- `render-vertical-video-service.test.ts` — 6/6 pass
- Pre-commit hooks (typecheck, lint:boundaries, file-token/dirname checks) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)