### PR TITLE
fix: post to Buffer immediately (shareNow) instead of queuing

### DIFF
--- a/app/services/buffer-api-service.server.ts
+++ b/app/services/buffer-api-service.server.ts
@@ -74,7 +74,11 @@ const createBufferApiOperations = (token: string) => ({
           text: opts.text,
           assets: [{ video: { url: opts.videoUrl } }],
           schedulingType: "automatic",
-          mode: "addToQueue",
+          // `shareNow` publishes the post immediately instead of dropping it
+          // into the channel's queue (`addToQueue`). Buffer still downloads the
+          // video asset asynchronously, so the caller polls `getPostStatus`
+          // until the post reaches `sent`.
+          mode: "shareNow",
         },
       },
     }).pipe(

--- a/app/services/buffer-posting-orchestration.server.ts
+++ b/app/services/buffer-posting-orchestration.server.ts
@@ -6,7 +6,10 @@ import { VercelBlobService } from "@/services/vercel-blob-service.server";
 import type { SendEvent } from "@/lib/create-sse-response.server";
 
 const DEFAULT_POLL_INTERVAL_MS = 10_000;
-const DEFAULT_POLL_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
+// The post is published immediately (`shareNow`), so delivery only takes as long
+// as Buffer needs to download and process the video asset — minutes, not the
+// open-ended wait a queued post would require.
+const DEFAULT_POLL_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 
 export const bufferPostProgram = (opts: {
   videoId: string;


### PR DESCRIPTION
## What

The Buffer export path always dropped exported vertical videos into the channel's **queue** (`mode: "addToQueue"`) rather than publishing them. This switches it to publish immediately.

## Changes

- **`buffer-api-service.server.ts`** — `createPost` mutation now uses `mode: "shareNow"` instead of `mode: "addToQueue"`. `shareNow` is Buffer's `ShareMode` value for immediate publishing.
- **`buffer-posting-orchestration.server.ts`** — reduced the delivery poll timeout from **1 hour → 15 minutes**. With a queued post, delivery could be arbitrarily far in the future, so the poll routinely timed out and orphaned the Vercel blob. Now delivery is bounded only by how long Buffer takes to download the video asset.

## Why the poll loop stays

The `getPostStatus` poll wasn't waiting on the queue — it gates cleanup of the uploaded **Vercel blob**. Buffer downloads the video asset asynchronously from the blob URL, so the blob must stay alive until the post reaches `sent`; only then does the orchestration delete it and mark the post posted. That dependency is unchanged.

## Testing

- `buffer-posting-orchestration.server.test.ts` — 5/5 pass
- `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)