### PR TITLE
Itemise course warnings on publish page + fix count drift

### DIFF
--- a/app/features/course-view/lesson-warning-labels.ts
+++ b/app/features/course-view/lesson-warning-labels.ts
@@ -1,0 +1,14 @@
+import type { LessonWarning } from "@/services/lesson-warnings";
+
+export const LESSON_WARNING_LABELS: Record<LessonWarning["kind"], string> = {
+  solutionWithoutProblem: "Solution without a Problem video",
+  explainerBesideProblem: "Explainer beside a Problem video",
+  duplicateRoles: "Duplicate video roles",
+  numberedRoleName:
+    "Numbered role name (a lesson has one video per role — name it e.g. “Explainer”, not “Explainer 2”)",
+  tooManyVideos: "Too many videos on this lesson",
+};
+
+export function lessonWarningLabel(warnings: LessonWarning[]): string {
+  return warnings.map((w) => LESSON_WARNING_LABELS[w.kind]).join("; ");
+}

--- a/app/features/course-view/sortable-lesson-item.tsx
+++ b/app/features/course-view/sortable-lesson-item.tsx
@@ -40,22 +40,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import type { LessonWarning } from "@/services/lesson-warnings";
-
 import { useLessonDependencyDrag } from "./use-lesson-dependency-drag";
-
-const WARNING_LABELS: Record<LessonWarning["kind"], string> = {
-  solutionWithoutProblem: "Solution without a Problem video",
-  explainerBesideProblem: "Explainer beside a Problem video",
-  duplicateRoles: "Duplicate video roles",
-  numberedRoleName:
-    "Numbered role name (a lesson has one video per role — name it e.g. “Explainer”, not “Explainer 2”)",
-  tooManyVideos: "Too many videos on this lesson",
-};
-
-function lessonWarningLabel(warnings: LessonWarning[]): string {
-  return warnings.map((w) => WARNING_LABELS[w.kind]).join("; ");
-}
+import { lessonWarningLabel } from "./lesson-warning-labels";
 import { Suspense, use, useCallback, useRef, useState } from "react";
 import { useNavigate, useFetcher } from "react-router";
 

--- a/app/routes/_app.courses.$courseId._index.tsx
+++ b/app/routes/_app.courses.$courseId._index.tsx
@@ -131,16 +131,16 @@ export default function Component(props: Route.ComponentProps) {
 
   const courseWarningCount = useMemo(() => {
     if (!loaderData.isLatestVersion) return 0;
+    // Count every warning (lesson- and video-level, all kinds) so this badge
+    // matches the publish page's course-warning count exactly — see
+    // collectCourseViewLints. Counting a narrower subset here is what let the
+    // two surfaces drift apart.
     let count = 0;
     for (const section of displaySections) {
       for (const lesson of section.lessons) {
-        if (lesson.lessonWarnings && lesson.lessonWarnings.length > 0) {
-          count++;
-        }
+        count += lesson.lessonWarnings?.length ?? 0;
         for (const video of lesson.videos) {
-          if (video.warnings.some((w) => w.kind === "missingOpeningChapter")) {
-            count++;
-          }
+          count += video.warnings.length;
         }
       }
     }

--- a/app/routes/_app.courses.$courseId.publish.tsx
+++ b/app/routes/_app.courses.$courseId.publish.tsx
@@ -11,6 +11,8 @@ import {
   ZERO_SEMVER,
   type BumpLevel,
 } from "@/lib/semver";
+import { LESSON_WARNING_LABELS } from "@/features/course-view/lesson-warning-labels";
+import { VIDEO_WARNING_LABELS } from "@/features/course-view/video-warning-labels";
 import { CoursePublishService } from "@/services/course-publish-service";
 import { CourseOperationsService } from "@/services/db-course-operations.server";
 import { VersionOperationsService } from "@/services/db-version-operations.server";
@@ -58,11 +60,13 @@ export const loader = makeLoader({
         previousVersionName: previousVersion?.name ?? null,
         withTodo: {
           courseViewLintCount: withTodo.courseViewLintCount,
+          courseViewLints: withTodo.courseViewLints,
           invalidLessonCombos: withTodo.invalidLessonCombos,
           incompleteVideos: withTodo.incompleteVideos,
         },
         withoutTodo: {
           courseViewLintCount: withoutTodo.courseViewLintCount,
+          courseViewLints: withoutTodo.courseViewLints,
           invalidLessonCombos: withoutTodo.invalidLessonCombos,
           incompleteVideos: withoutTodo.incompleteVideos,
         },
@@ -112,6 +116,7 @@ export default function Component(props: Route.ComponentProps) {
   // server round-trip.
   const effective = includeTodoLessons ? withTodo : withoutTodo;
   const courseViewLintCount = effective.courseViewLintCount;
+  const courseViewLints = effective.courseViewLints;
   const invalidLessonCombos = effective.invalidLessonCombos;
   const incompleteVideos = effective.incompleteVideos;
 
@@ -233,10 +238,12 @@ export default function Component(props: Route.ComponentProps) {
           </div>
         </div>
 
-        {/* Course-view Lints */}
+        {/* Course-view Lints — each warning is listed (not just counted) so it
+            can be found and fixed in the course view. The label wording matches
+            the course view exactly, keeping the two surfaces in lockstep. */}
         {hasCourseViewLints && (
           <div className="mb-8 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 mb-3">
               <AlertTriangle className="w-5 h-5 text-amber-500" />
               <span className="text-sm font-medium text-amber-500">
                 {courseViewLintCount} course warning
@@ -244,6 +251,35 @@ export default function Component(props: Route.ComponentProps) {
                 before publishing
               </span>
             </div>
+            <ul className="space-y-1.5">
+              {courseViewLints.map((lint, index) => (
+                <li
+                  key={`${lint.sectionPath}/${lint.lessonPath}/${
+                    lint.scope === "video" ? lint.videoTitle : "lesson"
+                  }/${lint.kind}/${index}`}
+                  className="text-xs text-muted-foreground"
+                >
+                  <span className="font-medium text-foreground">
+                    {lint.scope === "video"
+                      ? lint.videoTitle
+                      : lint.lessonPath || "Lesson"}
+                  </span>{" "}
+                  <span className="text-amber-500">
+                    (
+                    {lint.scope === "video"
+                      ? VIDEO_WARNING_LABELS[lint.kind]
+                      : LESSON_WARNING_LABELS[lint.kind]}
+                    )
+                  </span>
+                  <span className="block text-muted-foreground/70">
+                    {lint.sectionPath}
+                    {lint.scope === "video" && lint.lessonPath
+                      ? ` / ${lint.lessonPath}`
+                      : ""}
+                  </span>
+                </li>
+              ))}
+            </ul>
           </div>
         )}
 

--- a/app/services/course-publish-service.ts
+++ b/app/services/course-publish-service.ts
@@ -18,7 +18,7 @@ import {
   DoesNotExistOnDbError,
   resolveSectionsWithVideos,
 } from "./publish-to-dropbox";
-import { computeCourseViewLintCount } from "./lesson-warnings";
+import { collectCourseViewLints } from "./lesson-warnings";
 import {
   buildCourseJson,
   buildCourseJsonSchema,
@@ -306,8 +306,8 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
                 }
               }
             }
-            const courseViewLintCount =
-              computeCourseViewLintCount(effectiveSections);
+            const courseViewLints = collectCourseViewLints(effectiveSections);
+            const courseViewLintCount = courseViewLints.length;
 
             // Publish blockers computed from the exact same walk buildCourseJson
             // uses (its backstop), so the pre-publish warnings and the build
@@ -318,6 +318,7 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
             return {
               unexportedVideoIds,
               courseViewLintCount,
+              courseViewLints,
               invalidLessonCombos,
               incompleteVideos,
             };

--- a/app/services/lesson-warnings.test.ts
+++ b/app/services/lesson-warnings.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   computeLessonWarnings,
   computeCourseViewLintCount,
+  collectCourseViewLints,
   deriveVideoRole,
 } from "./lesson-warnings";
 
@@ -207,5 +208,71 @@ describe("computeCourseViewLintCount", () => {
       },
     ];
     expect(computeCourseViewLintCount(sections)).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("collectCourseViewLints", () => {
+  const makeVideo = (
+    title: string,
+    clips: { order: string; archived: boolean }[] = [],
+    chapters: { order: string; archived: boolean }[] = []
+  ) => ({ title, clips, chapters });
+
+  it("count is exactly the number of itemised lints", () => {
+    const sections = [
+      {
+        path: "01-intro",
+        lessons: [
+          { path: "01-a", videos: [makeVideo("Solution")] },
+          {
+            path: "02-b",
+            videos: [
+              makeVideo("Explainer", [{ order: "a0", archived: false }], []),
+            ],
+          },
+        ],
+      },
+    ];
+    expect(collectCourseViewLints(sections)).toHaveLength(
+      computeCourseViewLintCount(sections)
+    );
+  });
+
+  it("tags a lesson-level lint with its section and lesson path", () => {
+    const lints = collectCourseViewLints([
+      {
+        path: "01-intro",
+        lessons: [{ path: "01-a", videos: [makeVideo("Solution")] }],
+      },
+    ]);
+    expect(lints).toContainEqual({
+      scope: "lesson",
+      sectionPath: "01-intro",
+      lessonPath: "01-a",
+      kind: "solutionWithoutProblem",
+    });
+  });
+
+  it("tags a video-level lint with the offending video title", () => {
+    const lints = collectCourseViewLints([
+      {
+        path: "01-intro",
+        lessons: [
+          {
+            path: "01-a",
+            videos: [
+              makeVideo("Explainer", [{ order: "a0", archived: false }], []),
+            ],
+          },
+        ],
+      },
+    ]);
+    expect(lints).toContainEqual({
+      scope: "video",
+      sectionPath: "01-intro",
+      lessonPath: "01-a",
+      videoTitle: "Explainer",
+      kind: "missingOpeningChapter",
+    });
   });
 });

--- a/app/services/lesson-warnings.ts
+++ b/app/services/lesson-warnings.ts
@@ -1,4 +1,4 @@
-import { computeVideoWarnings } from "./video-warnings";
+import { computeVideoWarnings, type VideoWarningKind } from "./video-warnings";
 
 export type LessonWarningKind =
   | "solutionWithoutProblem"
@@ -79,34 +79,83 @@ export const computeLessonWarnings = (input: {
   return warnings;
 };
 
-type LintLesson = {
-  videos: Array<{
-    title: string;
-    lessonId?: string | null;
-    body?: string | null;
-    description?: string | null;
-    clips: Array<{ order: string; archived: boolean }>;
-    chapters: Array<{ order: string; archived: boolean }>;
-  }>;
+type LintVideo = {
+  title: string;
+  lessonId?: string | null;
+  body?: string | null;
+  description?: string | null;
+  clips: Array<{ order: string; archived: boolean }>;
+  chapters: Array<{ order: string; archived: boolean }>;
 };
 
-export function computeCourseViewLintCount(
-  sections: { lessons: LintLesson[] }[]
-): number {
-  let count = 0;
+type LintLesson = { path?: string; videos: LintVideo[] };
+type LintSection = { path?: string; lessons: LintLesson[] };
+
+/**
+ * One course-view warning, tagged with where it lives so the publish page can
+ * name it (not just count it). `scope` distinguishes a lesson-level warning
+ * (an invalid video-role combo) from a video-level one (a missing chapter,
+ * body, or SEO description).
+ */
+export type CourseViewLint =
+  | {
+      scope: "lesson";
+      sectionPath: string;
+      lessonPath: string;
+      kind: LessonWarningKind;
+    }
+  | {
+      scope: "video";
+      sectionPath: string;
+      lessonPath: string;
+      videoTitle: string;
+      kind: VideoWarningKind;
+    };
+
+/**
+ * The full, itemised list of course-view warnings across a course. This is the
+ * single source of truth: {@link computeCourseViewLintCount} is its length, and
+ * the publish page renders each entry so a warning is never merely counted.
+ */
+export function collectCourseViewLints(
+  sections: LintSection[]
+): CourseViewLint[] {
+  const lints: CourseViewLint[] = [];
   for (const section of sections) {
+    const sectionPath = section.path ?? "";
     for (const lesson of section.lessons) {
-      count += computeLessonWarnings({ videos: lesson.videos }).length;
+      const lessonPath = lesson.path ?? "";
+      for (const warning of computeLessonWarnings({ videos: lesson.videos })) {
+        lints.push({
+          scope: "lesson",
+          sectionPath,
+          lessonPath,
+          kind: warning.kind,
+        });
+      }
       for (const video of lesson.videos) {
-        count += computeVideoWarnings({
+        const videoWarnings = computeVideoWarnings({
           clips: video.clips,
           chapters: video.chapters,
           lessonId: video.lessonId,
           body: video.body,
           description: video.description,
-        }).length;
+        });
+        for (const warning of videoWarnings) {
+          lints.push({
+            scope: "video",
+            sectionPath,
+            lessonPath,
+            videoTitle: video.title,
+            kind: warning.kind,
+          });
+        }
       }
     }
   }
-  return count;
+  return lints;
+}
+
+export function computeCourseViewLintCount(sections: LintSection[]): number {
+  return collectCourseViewLints(sections).length;
 }


### PR DESCRIPTION
## Problem

On the **publish page**, course-view warnings showed only as an aggregate line — *"N course warnings — fix in the course view before publishing"* — with **no list of the individual warnings**. So you could see there were warnings but not *what* they were or *where*, making them impossible to act on.

Separately, the **course-page badge** counted a narrower subset than the publish page (only `missingOpeningChapter` for videos, one-per-lesson), while publish counted every warning kind (`missingBody`, `missingDescription`, …) per-warning. The two numbers drifted apart.

## Changes

- **`collectCourseViewLints()`** — new single source of truth returning each warning tagged with its `section` / `lesson` / `video` location and `kind`. `computeCourseViewLintCount()` is now just its `.length`.
- **Publish page** now lists every warning with its location and label (matching the `incompleteVideos` / `invalidLessonCombos` blocks), using the exact same label wording as the course view.
- **Course-page badge** counts every warning kind, so it matches the publish count exactly — removing the drift.
- **`lesson-warning-labels.ts`** extracted (mirroring `video-warning-labels.ts`) so both surfaces share label strings.

## Tests

- Added `collectCourseViewLints` tests (count == item count; lesson- and video-level tagging).
- Full suite green (682 passing); typecheck, prettier, and dependency-boundary checks pass via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)