### PR TITLE
Exclude archived videos from publish course-view lints

### DIFF
--- a/app/services/lesson-warnings.test.ts
+++ b/app/services/lesson-warnings.test.ts
@@ -253,6 +253,55 @@ describe("collectCourseViewLints", () => {
     });
   });
 
+  it("excludes archived videos from lesson warnings", () => {
+    // Three live videos would trip the "too many videos" lesson warning, but two
+    // of them are archived — so the lesson has one active video and no warning.
+    const sections = [
+      {
+        path: "01-intro",
+        lessons: [
+          {
+            path: "01-a",
+            videos: [
+              { ...makeVideo("Explainer"), archived: false },
+              { ...makeVideo("Problem"), archived: true },
+              { ...makeVideo("Solution"), archived: true },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(
+      collectCourseViewLints(sections).filter((l) => l.scope === "lesson")
+    ).toEqual([]);
+  });
+
+  it("excludes archived videos from video warnings", () => {
+    // The archived video is missing its opening chapter, but archived videos are
+    // never published, so it must not raise a warning.
+    const sections = [
+      {
+        path: "01-intro",
+        lessons: [
+          {
+            path: "01-a",
+            videos: [
+              {
+                ...makeVideo(
+                  "Explainer",
+                  [{ order: "a0", archived: false }],
+                  []
+                ),
+                archived: true,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(collectCourseViewLints(sections)).toEqual([]);
+  });
+
   it("tags a video-level lint with the offending video title", () => {
     const lints = collectCourseViewLints([
       {

--- a/app/services/lesson-warnings.ts
+++ b/app/services/lesson-warnings.ts
@@ -81,6 +81,7 @@ export const computeLessonWarnings = (input: {
 
 type LintVideo = {
   title: string;
+  archived?: boolean;
   lessonId?: string | null;
   body?: string | null;
   description?: string | null;
@@ -125,7 +126,12 @@ export function collectCourseViewLints(
     const sectionPath = section.path ?? "";
     for (const lesson of section.lessons) {
       const lessonPath = lesson.path ?? "";
-      for (const warning of computeLessonWarnings({ videos: lesson.videos })) {
+      // Archived videos are "deleted" — never shown in the course view and
+      // never published — so they can't be the subject of a warning. Excluding
+      // them here keeps this walk in step with collectPublishBlockers (which
+      // lints only `activeVideos`) and with the course view's DB-level filter.
+      const activeVideos = lesson.videos.filter((v) => !v.archived);
+      for (const warning of computeLessonWarnings({ videos: activeVideos })) {
         lints.push({
           scope: "lesson",
           sectionPath,
@@ -133,7 +139,7 @@ export function collectCourseViewLints(
           kind: warning.kind,
         });
       }
-      for (const video of lesson.videos) {
+      for (const video of activeVideos) {
         const videoWarnings = computeVideoWarnings({
           clips: video.clips,
           chapters: video.chapters,


### PR DESCRIPTION
## Problem

The publish page's course-warning lints (`collectCourseViewLints`) walked **every** video in a lesson, including **archived** (deleted) ones. Archived videos are never shown in the course view and never published, yet they could trip course warnings on the publish page — e.g. "too many videos on this lesson", or a missing opening chapter / body / SEO description on a video that will never ship.

## Fix

Filter to active (`!archived`) videos before linting in `collectCourseViewLints`. This matches:
- `collectPublishBlockers`, which already lints only `activeVideos` (`build-course-json.ts:322`), and
- the course view, which filters archived videos at the DB level (`db-course-operations.server.ts:254`).

So the publish count, the itemised publish list, and the course-page badge all agree and all ignore archived videos.

## Tests

- Added cases: archived videos excluded from both lesson-level and video-level lints.
- Full suite green (709 passing); typecheck / prettier / boundaries pass via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)