### PR TITLE
Fix pnpm version conflict in agent CI workflows

### DIFF
--- a/.github/workflows/agent-implement-pr.yml
+++ b/.github/workflows/agent-implement-pr.yml
@@ -86,8 +86,6 @@ jobs:
       - name: Setup pnpm
         if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js 22
         if: steps.state.outputs.proceed == 'true' && steps.inputs.outputs.proceed == 'true'

--- a/.github/workflows/agent-implement-prd.yml
+++ b/.github/workflows/agent-implement-prd.yml
@@ -163,8 +163,6 @@ jobs:
       - name: Setup pnpm
         if: steps.shape.outputs.mode == 'run'
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js 22
         if: steps.shape.outputs.mode == 'run'

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -130,8 +130,6 @@ jobs:
       - name: Setup pnpm
         if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true'
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js 22
         if: steps.shape.outputs.proceed == 'true' && steps.preflight.outputs.refused != 'true'

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js 22
         uses: actions/setup-node@v4

--- a/.github/workflows/agent-to-issues-prd.yml
+++ b/.github/workflows/agent-to-issues-prd.yml
@@ -82,8 +82,6 @@ jobs:
       - name: Setup pnpm
         if: steps.shape.outputs.mode == 'run'
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js 22
         if: steps.shape.outputs.mode == 'run'

--- a/.github/workflows/agent-update-branch.yml
+++ b/.github/workflows/agent-update-branch.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js 22
         uses: actions/setup-node@v4

--- a/.github/workflows/architecture-review.yml
+++ b/.github/workflows/architecture-review.yml
@@ -60,8 +60,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js 22
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

The agent CI workflows fail at the **Setup pnpm** step with:

```
Error: Multiple versions of pnpm specified:
  - version 9 in the GitHub Action config with the key "version"
  - version pnpm@9.12.3 in the package.json with the key "packageManager"
```

(see [failing run](https://github.com/mattpocock/course-video-manager/actions/runs/29496946460/job/87616028820))

`pnpm/action-setup` refuses to run when the version is pinned in both the workflow and `package.json`'s `packageManager` field.

## Fix

Remove the redundant `version: 9` (and now-empty `with:`) from the `pnpm/action-setup@v4` steps across all 7 agent workflows. pnpm's version now comes solely from `package.json`'s `packageManager: pnpm@9.12.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)