### PR TITLE
fix(export): keep landscape videos 16:9 (stop portrait export regression)

### DIFF
--- a/app/features/course-view/course-view-loader.server.ts
+++ b/app/features/course-view/course-view-loader.server.ts
@@ -110,6 +110,7 @@ export function courseViewEffect(input: {
             courseId: selectedCourse.id,
             videos: (allVideos ?? []).map((v) => ({
               id: v.id,
+              format: v.format,
               clips: v.clips as ExportClip[],
             })),
           })

--- a/app/features/upload-manager/sse-render-vertical-client.ts
+++ b/app/features/upload-manager/sse-render-vertical-client.ts
@@ -25,5 +25,5 @@ export const startSSERenderVertical = (
       error: (data: { message: string }) => callbacks.onError(data.message),
     },
     onError: callbacks.onError,
-    errorLabel: "Export vertical failed",
+    errorLabel: "Vertical short render failed",
   });

--- a/app/features/video-editor/components/actions-dropdown.tsx
+++ b/app/features/video-editor/components/actions-dropdown.tsx
@@ -242,9 +242,9 @@ export const ActionsDropdown = (props: {
               <DropdownMenuItem onSelect={props.onRenderVertical}>
                 <FilmIcon className="w-4 h-4 mr-2" />
                 <div className="flex flex-col">
-                  <span className="font-medium">Export Vertical</span>
+                  <span className="font-medium">Render Vertical Short</span>
                   <span className="text-xs text-muted-foreground">
-                    Export captioned 9:16 video
+                    Render a captioned 9:16 short from this video
                   </span>
                 </div>
               </DropdownMenuItem>

--- a/app/features/video-editor/components/studio-actions-dropdown.tsx
+++ b/app/features/video-editor/components/studio-actions-dropdown.tsx
@@ -64,9 +64,9 @@ export const StudioActionsDropdown = (props: {
           <DropdownMenuItem onSelect={props.onRenderVertical}>
             <FilmIcon className="w-4 h-4 mr-2" />
             <div className="flex flex-col">
-              <span className="font-medium">Export Vertical</span>
+              <span className="font-medium">Render Vertical Short</span>
               <span className="text-xs text-muted-foreground">
-                Export captioned 9:16 video
+                Render a captioned 9:16 short from this video
               </span>
             </div>
           </DropdownMenuItem>

--- a/app/features/videos/video-format.ts
+++ b/app/features/videos/video-format.ts
@@ -8,3 +8,31 @@ export const VIDEO_FORMAT_LABELS: Record<VideoFormat, string> = {
   landscape: "Landscape",
   short: "Short",
 };
+
+/**
+ * The output frame dimensions each format is exported at. `short` is portrait
+ * 9:16; everything else is landscape 16:9. These drive the ffmpeg `scale`
+ * target during concatenation, so an export lands in the aspect ratio that
+ * matches the video's format instead of always being portrait.
+ */
+export const VIDEO_FORMAT_DIMENSIONS: Record<
+  VideoFormat,
+  { width: number; height: number }
+> = {
+  landscape: { width: 1920, height: 1080 },
+  short: { width: 1080, height: 1920 },
+};
+
+/**
+ * Coerce a raw `format` string (e.g. from the DB column) into a known
+ * {@link VideoFormat}, falling back to {@link DEFAULT_VIDEO_FORMAT} (landscape)
+ * for anything unrecognised. Anything not explicitly a portrait `short` is
+ * treated as landscape.
+ */
+export function resolveVideoFormat(
+  format: string | null | undefined
+): VideoFormat {
+  return (VIDEO_FORMATS as readonly string[]).includes(format ?? "")
+    ? (format as VideoFormat)
+    : DEFAULT_VIDEO_FORMAT;
+}

--- a/app/packages/course-json/lib/build-course-json.ts
+++ b/app/packages/course-json/lib/build-course-json.ts
@@ -255,6 +255,7 @@ type InputVideo = {
   body: string | null;
   description: string | null;
   archived: boolean;
+  format: string;
   clips: InputClip[];
   chapters: InputChapter[];
 };
@@ -417,7 +418,7 @@ function toVideoEntry(
     relativePath: `${assetBasePath}/${sectionPath}/${lessonPath}/${video.title}.mp4`,
     body: video.body!,
     description: video.description!,
-    hash: computeExportHash(exportClips)!,
+    hash: computeExportHash(exportClips, video.format)!,
     sha256: asset.sha256,
     bytes: asset.bytes,
     chapters: buildChapters(video.clips, video.chapters) ?? [],

--- a/app/packages/course-json/tests/course-json-validation.test.ts
+++ b/app/packages/course-json/tests/course-json-validation.test.ts
@@ -21,6 +21,7 @@ const makeVideo = (
   body: "Video body",
   description: "Video description",
   archived: false,
+  format: "landscape",
   clips: CLIPS,
   chapters: [],
   ...overrides,

--- a/app/packages/course-json/tests/course-json.test.ts
+++ b/app/packages/course-json/tests/course-json.test.ts
@@ -23,6 +23,7 @@ const makeVideo = (
   body: "Video body",
   description: "Video description",
   archived: false,
+  format: "landscape",
   clips: CLIPS,
   chapters: [],
   ...overrides,
@@ -362,7 +363,7 @@ describe("buildCourseJson", () => {
 
     const lesson = result.sections[0]!.lessons[0]!;
     if (lesson.type === "explainer") {
-      expect(lesson.explainer.hash).toBe(computeExportHash(CLIPS));
+      expect(lesson.explainer.hash).toBe(computeExportHash(CLIPS, "landscape"));
       expect(lesson.explainer.hash).not.toBeNull();
     }
   });

--- a/app/routes/api.fs-git-status.ts
+++ b/app/routes/api.fs-git-status.ts
@@ -77,6 +77,7 @@ export const loader = async (args: Route.LoaderArgs) => {
       courseId: course.id,
       videos: allVideos.map((v) => ({
         id: v.id,
+        format: v.format,
         clips: v.clips as ExportClip[],
       })),
     });

--- a/app/routes/api.videos.$videoId.render-vertical-sse.ts
+++ b/app/routes/api.videos.$videoId.render-vertical-sse.ts
@@ -36,6 +36,6 @@ export const action = async (args: Route.ActionArgs) => {
         },
       },
     ],
-    fallbackMessage: "Export vertical failed unexpectedly",
+    fallbackMessage: "Vertical short render failed unexpectedly",
   });
 };

--- a/app/services/batch-export.server.ts
+++ b/app/services/batch-export.server.ts
@@ -6,6 +6,10 @@ import {
   type PauseType,
 } from "@/services/video-processing-service";
 import { FINAL_VIDEO_PADDING } from "@/features/video-editor/constants";
+import {
+  resolveVideoFormat,
+  type VideoFormat,
+} from "@/features/videos/video-format";
 import path from "node:path";
 
 const MAX_CONCURRENT_EXPORTS = 6;
@@ -28,6 +32,7 @@ export const batchExportProgram = (
     const unexportedVideos: Array<{
       id: string;
       title: string;
+      format: VideoFormat;
       clips: Array<{
         videoFilename: string;
         sourceStartTime: number;
@@ -50,6 +55,7 @@ export const batchExportProgram = (
               unexportedVideos.push({
                 id: video.id,
                 title: `${section.path}/${lesson.path}/${video.title}`,
+                format: resolveVideoFormat(video.format),
                 clips: video.clips,
               });
             }
@@ -78,6 +84,7 @@ export const batchExportProgram = (
         videoProcessing
           .exportVideoClips({
             videoId: video.id,
+            format: video.format,
             shortsDirectoryOutputName: undefined,
             clips: video.clips.map((clip, index, array) => {
               const isFinalClip = index === array.length - 1;

--- a/app/services/course-loader-fs.ts
+++ b/app/services/course-loader-fs.ts
@@ -43,7 +43,7 @@ const listFilesRecursive = (
 
 export const loadExportStatusMap = (opts: {
   courseId: string;
-  videos: { id: string; clips: ExportClip[] }[];
+  videos: { id: string; format: string; clips: ExportClip[] }[];
 }) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
@@ -55,7 +55,7 @@ export const loadExportStatusMap = (opts: {
       opts.videos,
       (video) =>
         Effect.gen(function* () {
-          const hash = computeExportHash(video.clips);
+          const hash = computeExportHash(video.clips, video.format);
           if (!hash) {
             hasExportedVideoMap[video.id] = false;
             return;

--- a/app/services/course-publish-dropbox.ts
+++ b/app/services/course-publish-dropbox.ts
@@ -89,7 +89,10 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
     for (const lesson of section.lessons) {
       for (const video of lesson.videos) {
         if (video.clips.length === 0) continue;
-        const hash = computeExportHash(toExportClips(video.clips));
+        const hash = computeExportHash(
+          toExportClips(video.clips),
+          video.format
+        );
         if (!hash) continue;
         videoPathOverrides.set(
           video.id,

--- a/app/services/course-publish-service-publish.test.ts
+++ b/app/services/course-publish-service-publish.test.ts
@@ -123,7 +123,7 @@ const setup = async (opts?: {
     { videoFilename: "recording.mp4", sourceStartTime: 0, sourceEndTime: 10 },
     { videoFilename: "recording.mp4", sourceStartTime: 15, sourceEndTime: 25 },
   ];
-  const exportHash = computeExportHash(clips)!;
+  const exportHash = computeExportHash(clips, "landscape")!;
 
   const dropboxDir = fs.mkdtempSync(
     path.join(tmpdir(), "publish-test-dropbox-")

--- a/app/services/course-publish-service-sync.test.ts
+++ b/app/services/course-publish-service-sync.test.ts
@@ -164,7 +164,7 @@ const setupSync = async () => {
     sourceEndTime: c.sourceEndTime,
     order: c.order,
   }));
-  const exportHash = computeExportHash(clips)!;
+  const exportHash = computeExportHash(clips, "landscape")!;
 
   fs.writeFileSync(
     resolveExportPath(finishedVideosDir, course.id, exportHash),

--- a/app/services/course-publish-service.test.ts
+++ b/app/services/course-publish-service.test.ts
@@ -152,7 +152,7 @@ const setup = async () => {
       sourceEndTime: 25,
     },
   ];
-  const exportHash = computeExportHash(clips)!;
+  const exportHash = computeExportHash(clips, "landscape")!;
 
   const run = <A, E>(effect: Effect.Effect<A, E, any>) =>
     Effect.runPromise(

--- a/app/services/course-publish-service.ts
+++ b/app/services/course-publish-service.ts
@@ -14,6 +14,7 @@ import {
 } from "./export-hash";
 import { garbageCollect } from "./export-hash.server";
 import { FINAL_VIDEO_PADDING } from "@/features/video-editor/constants";
+import { resolveVideoFormat } from "@/features/videos/video-format";
 import { DoesNotExistOnDbError } from "./publish-to-dropbox";
 import { collectCourseViewLints } from "./lesson-warnings";
 import {
@@ -136,6 +137,7 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
         // Export via ffmpeg → writes to {videoId}.mp4
         yield* videoProcessing.exportVideoClips({
           videoId,
+          format: resolveVideoFormat(video.format),
           shortsDirectoryOutputName: undefined,
           clips: video.clips.map((clip, index, array) => {
             const isFinalClip = index === array.length - 1;

--- a/app/services/course-publish-service.ts
+++ b/app/services/course-publish-service.ts
@@ -30,6 +30,7 @@ import { syncFrozenCourseVersionToDropbox } from "./course-publish-dropbox";
 
 export type VideoForExport = {
   id: string;
+  format: string;
   lesson?: {
     section: { repoVersion: { repo: { id: string } } };
   } | null;
@@ -85,7 +86,10 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
             : videoOrId;
         if (video.clips.length === 0) return null;
 
-        const hash = computeExportHash(toExportClips(video.clips));
+        const hash = computeExportHash(
+          toExportClips(video.clips),
+          video.format
+        );
         if (!hash) return null;
 
         const namespace = video.lesson?.section.repoVersion.repo.id ?? video.id;
@@ -116,7 +120,7 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
         const namespace = courseId ?? videoId;
 
         const exportClips = toExportClips(video.clips);
-        const hash = computeExportHash(exportClips);
+        const hash = computeExportHash(exportClips, video.format);
         if (!hash) {
           return yield* Effect.fail(
             new ExportError({ message: "Video has no clips to export" })
@@ -200,7 +204,10 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
           for (const lesson of section.lessons) {
             for (const video of lesson.videos) {
               if (video.clips.length === 0) continue;
-              const hash = computeExportHash(toExportClips(video.clips));
+              const hash = computeExportHash(
+                toExportClips(video.clips),
+                video.format
+              );
               if (!hash) continue;
               const filePath = resolveExportPathPure(
                 FINISHED_VIDEOS_DIRECTORY,
@@ -274,7 +281,10 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
             for (const lesson of section.lessons) {
               for (const video of lesson.videos) {
                 if (video.clips.length === 0) continue;
-                const hash = computeExportHash(toExportClips(video.clips));
+                const hash = computeExportHash(
+                  toExportClips(video.clips),
+                  video.format
+                );
                 if (!hash) continue;
                 const filePath = resolveExportPathPure(
                   FINISHED_VIDEOS_DIRECTORY,

--- a/app/services/export-hash.server.ts
+++ b/app/services/export-hash.server.ts
@@ -27,7 +27,7 @@ export const garbageCollect = (courseId: string) =>
       for (const section of version.sections) {
         for (const lesson of section.lessons) {
           for (const video of lesson.videos) {
-            const hash = computeExportHash(video.clips);
+            const hash = computeExportHash(video.clips, video.format);
             if (hash) allValidHashes.add(hash);
           }
         }

--- a/app/services/export-hash.test.ts
+++ b/app/services/export-hash.test.ts
@@ -22,18 +22,48 @@ const makeClip = (
 describe("export-hash", () => {
   describe("computeExportHash", () => {
     it("returns null for empty clips", () => {
-      expect(computeExportHash([])).toBeNull();
+      expect(computeExportHash([], "landscape")).toBeNull();
     });
 
     it("returns a 32-char hex string for clips", () => {
-      const hash = computeExportHash([
+      const hash = computeExportHash(
+        [
+          makeClip({
+            videoFilename: "rec.mp4",
+            sourceStartTime: 0,
+            sourceEndTime: 10,
+          }),
+        ],
+        "landscape"
+      );
+      expect(hash).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it("changing the video format changes the hash", () => {
+      const clips = [
         makeClip({
           videoFilename: "rec.mp4",
           sourceStartTime: 0,
           sourceEndTime: 10,
         }),
-      ]);
-      expect(hash).toMatch(/^[0-9a-f]{32}$/);
+      ];
+      expect(computeExportHash(clips, "landscape")).not.toBe(
+        computeExportHash(clips, "short")
+      );
+    });
+
+    it("treats an unknown or missing format as landscape", () => {
+      const clips = [
+        makeClip({
+          videoFilename: "rec.mp4",
+          sourceStartTime: 0,
+          sourceEndTime: 10,
+        }),
+      ];
+      const landscape = computeExportHash(clips, "landscape");
+      expect(computeExportHash(clips, undefined)).toBe(landscape);
+      expect(computeExportHash(clips, null)).toBe(landscape);
+      expect(computeExportHash(clips, "bogus")).toBe(landscape);
     });
 
     it("is deterministic for the same input", () => {
@@ -49,8 +79,8 @@ describe("export-hash", () => {
           sourceEndTime: 15,
         }),
       ];
-      const hash1 = computeExportHash(clips);
-      const hash2 = computeExportHash(clips);
+      const hash1 = computeExportHash(clips, "landscape");
+      const hash2 = computeExportHash(clips, "landscape");
       expect(hash1).toBe(hash2);
     });
 
@@ -67,7 +97,9 @@ describe("export-hash", () => {
       });
       // Clip sequence lives in the array itself — reordering the same clips is a
       // different edit and must produce a different hash (and thus re-export).
-      expect(computeExportHash([a, b])).not.toBe(computeExportHash([b, a]));
+      expect(computeExportHash([a, b], "landscape")).not.toBe(
+        computeExportHash([b, a], "landscape")
+      );
     });
 
     it("transcript text changes do not affect the hash", () => {
@@ -87,24 +119,32 @@ describe("export-hash", () => {
           sourceEndTime: 10,
         }),
       ];
-      expect(computeExportHash(clips1)).toBe(computeExportHash(clips2));
+      expect(computeExportHash(clips1, "landscape")).toBe(
+        computeExportHash(clips2, "landscape")
+      );
     });
 
     it("different clip data produces different hashes", () => {
-      const hash1 = computeExportHash([
-        makeClip({
-          videoFilename: "rec.mp4",
-          sourceStartTime: 0,
-          sourceEndTime: 10,
-        }),
-      ]);
-      const hash2 = computeExportHash([
-        makeClip({
-          videoFilename: "rec.mp4",
-          sourceStartTime: 0,
-          sourceEndTime: 11,
-        }),
-      ]);
+      const hash1 = computeExportHash(
+        [
+          makeClip({
+            videoFilename: "rec.mp4",
+            sourceStartTime: 0,
+            sourceEndTime: 10,
+          }),
+        ],
+        "landscape"
+      );
+      const hash2 = computeExportHash(
+        [
+          makeClip({
+            videoFilename: "rec.mp4",
+            sourceStartTime: 0,
+            sourceEndTime: 11,
+          }),
+        ],
+        "landscape"
+      );
       expect(hash1).not.toBe(hash2);
     });
 
@@ -118,7 +158,7 @@ describe("export-hash", () => {
           sourceEndTime: 10,
         }),
       ];
-      const hash = computeExportHash(clips);
+      const hash = computeExportHash(clips, "landscape");
       expect(hash).toBeTruthy();
       // The EXPORT_VERSION is baked into the hash payload
       expect(EXPORT_VERSION).toBe(1);
@@ -143,13 +183,16 @@ describe("export-hash", () => {
 
   describe("isExported", () => {
     it("returns true when the file exists on disk", async () => {
-      const hash = computeExportHash([
-        makeClip({
-          videoFilename: "rec.mp4",
-          sourceStartTime: 0,
-          sourceEndTime: 10,
-        }),
-      ])!;
+      const hash = computeExportHash(
+        [
+          makeClip({
+            videoFilename: "rec.mp4",
+            sourceStartTime: 0,
+            sourceEndTime: 10,
+          }),
+        ],
+        "landscape"
+      )!;
 
       const fsLayer = FileSystem.layerNoop({
         exists: (filePath) =>
@@ -157,13 +200,18 @@ describe("export-hash", () => {
       });
 
       const result = await Effect.runPromise(
-        isExported("/output", "course-1", [
-          makeClip({
-            videoFilename: "rec.mp4",
-            sourceStartTime: 0,
-            sourceEndTime: 10,
-          }),
-        ]).pipe(Effect.provide(fsLayer))
+        isExported(
+          "/output",
+          "course-1",
+          [
+            makeClip({
+              videoFilename: "rec.mp4",
+              sourceStartTime: 0,
+              sourceEndTime: 10,
+            }),
+          ],
+          "landscape"
+        ).pipe(Effect.provide(fsLayer))
       );
 
       expect(result).toBe(true);
@@ -175,13 +223,18 @@ describe("export-hash", () => {
       });
 
       const result = await Effect.runPromise(
-        isExported("/output", "course-1", [
-          makeClip({
-            videoFilename: "rec.mp4",
-            sourceStartTime: 0,
-            sourceEndTime: 10,
-          }),
-        ]).pipe(Effect.provide(fsLayer))
+        isExported(
+          "/output",
+          "course-1",
+          [
+            makeClip({
+              videoFilename: "rec.mp4",
+              sourceStartTime: 0,
+              sourceEndTime: 10,
+            }),
+          ],
+          "landscape"
+        ).pipe(Effect.provide(fsLayer))
       );
 
       expect(result).toBe(false);
@@ -193,7 +246,9 @@ describe("export-hash", () => {
       });
 
       const result = await Effect.runPromise(
-        isExported("/output", "course-1", []).pipe(Effect.provide(fsLayer))
+        isExported("/output", "course-1", [], "landscape").pipe(
+          Effect.provide(fsLayer)
+        )
       );
 
       expect(result).toBe(false);
@@ -279,7 +334,7 @@ describe("export-hash", () => {
           sourceEndTime: 10,
         }),
       ];
-      const validHash = computeExportHash(validClips)!;
+      const validHash = computeExportHash(validClips, "landscape")!;
 
       const { layer, removedFiles } = makeGCLayer({
         versions: [{ id: "v1", clips: validClips }],
@@ -306,7 +361,7 @@ describe("export-hash", () => {
           sourceEndTime: 10,
         }),
       ];
-      const hash = computeExportHash(clips)!;
+      const hash = computeExportHash(clips, "landscape")!;
 
       const { layer, removedFiles } = makeGCLayer({
         versions: [{ id: "v1", clips }],
@@ -355,8 +410,8 @@ describe("export-hash", () => {
           sourceEndTime: 20,
         }),
       ];
-      const hash1 = computeExportHash(clips1)!;
-      const hash2 = computeExportHash(clips2)!;
+      const hash1 = computeExportHash(clips1, "landscape")!;
+      const hash2 = computeExportHash(clips2, "landscape")!;
 
       const { layer, removedFiles } = makeGCLayer({
         versions: [

--- a/app/services/export-hash.ts
+++ b/app/services/export-hash.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import { Effect } from "effect";
 import { FileSystem } from "@effect/platform";
+import { resolveVideoFormat } from "@/features/videos/video-format";
 
 /**
  * Bump this constant to force re-export of all videos (e.g., after changing
@@ -24,12 +25,23 @@ export type ExportClip = {
  * (not transcript text). Clip order therefore lives in the array itself — it is
  * never re-derived from an `order` field, so reordering a video's clips yields a
  * new hash and triggers a re-export.
+ *
+ * The video's `format` is part of the address because it decides the export
+ * frame (landscape 16:9 vs. short 9:16): two videos with identical clips but
+ * different formats produce different output files and must not collide, and
+ * flipping a video's format must invalidate its existing export. The raw column
+ * is normalised via {@link resolveVideoFormat} so callers can pass it straight
+ * from the DB.
  */
-export const computeExportHash = (clips: ExportClip[]): string | null => {
+export const computeExportHash = (
+  clips: ExportClip[],
+  format: string | null | undefined
+): string | null => {
   if (clips.length === 0) return null;
 
   const payload = {
     v: EXPORT_VERSION,
+    fmt: resolveVideoFormat(format),
     clips: clips.map((c) => ({
       f: c.videoFilename,
       s: c.sourceStartTime,
@@ -65,10 +77,11 @@ export const resolveExportPath = (
 export const isExported = (
   finishedVideosDir: string,
   courseId: string,
-  clips: ExportClip[]
+  clips: ExportClip[],
+  format: string | null | undefined
 ) =>
   Effect.gen(function* () {
-    const hash = computeExportHash(clips);
+    const hash = computeExportHash(clips, format);
     if (!hash) return false;
 
     const fs = yield* FileSystem.FileSystem;

--- a/app/services/ffmpeg-commands.ts
+++ b/app/services/ffmpeg-commands.ts
@@ -100,7 +100,8 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
           startTime: number;
           duration: number;
           pauseType: "none" | "long";
-        }[]
+        }[],
+        dimensions: { width: number; height: number }
       ) {
         const LONG_PAUSE_DURATION = 0.18;
 
@@ -131,18 +132,18 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
           );
         }
 
-        // Build filter complex. Normalize every input to the vertical 1080x1920
-        // frame (and stereo audio) so the concat filter — which requires all
-        // inputs to share dimensions/SAR/channel layout — accepts odd effect
-        // clips (e.g. white noise at 854x480 mono). The target MUST stay
-        // portrait: these are 9:16 shorts and the subtitle overlay is 1080x1920,
-        // so scaling to landscape here produced a landscape export with the
-        // portrait overlay pinned top-left.
+        // Build filter complex. Normalize every input to the target frame (and
+        // stereo audio) so the concat filter — which requires all inputs to
+        // share dimensions/SAR/channel layout — accepts odd effect clips (e.g.
+        // white noise at 854x480 mono). The target dimensions come from the
+        // video's format: portrait 1080x1920 for shorts (whose 9:16 subtitle
+        // overlay must line up), landscape 1920x1080 otherwise. Passing the
+        // wrong dimensions here is what previously forced every export portrait.
         const filterParts: string[] = [];
         const concatInputs: string[] = [];
         for (let i = 0; i < clips.length; i++) {
           filterParts.push(
-            `[${i}:v]setpts=PTS-STARTPTS,scale=1080:1920,setsar=1[v${i}]`,
+            `[${i}:v]setpts=PTS-STARTPTS,scale=${dimensions.width}:${dimensions.height},setsar=1[v${i}]`,
             `[${i}:a]asetpts=PTS-STARTPTS,aformat=channel_layouts=stereo[a${i}]`
           );
           concatInputs.push(`[v${i}][a${i}]`);

--- a/app/services/render-vertical-video-service.ts
+++ b/app/services/render-vertical-video-service.ts
@@ -7,12 +7,10 @@ import crypto from "node:crypto";
 import { VideoOperationsService } from "./db-video-operations.server";
 import { VideoProcessingService } from "./video-processing-service";
 import { FFmpegCommandsService } from "./ffmpeg-commands";
+import { VIDEO_FORMAT_DIMENSIONS } from "@/features/videos/video-format";
 
 export type RenderVerticalStage =
-  | "concatenating-clips"
-  | "transcribing"
-  | "rendering-overlay"
-  | "compositing";
+  "concatenating-clips" | "transcribing" | "rendering-overlay" | "compositing";
 
 export class RenderVerticalError extends Data.TaggedError(
   "RenderVerticalError"
@@ -58,7 +56,10 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
                 startTime: clip.sourceStartTime,
                 duration: clip.sourceEndTime - clip.sourceStartTime,
                 pauseType: clip.pauseType as "none" | "long",
-              }))
+              })),
+              // The vertical renderer always produces a 9:16 short — the Remotion
+              // subtitle/CTA overlay below is rendered at 1080x1920 to match.
+              VIDEO_FORMAT_DIMENSIONS.short
             );
           const concatenatedPath =
             yield* ffmpegCommands.normalizeAudio(rawConcatenatedPath);

--- a/app/services/video-processing-service.ts
+++ b/app/services/video-processing-service.ts
@@ -9,6 +9,10 @@ import OpenAI from "openai";
 import { FFmpegCommandsService } from "./ffmpeg-commands";
 import { findSilenceInVideo } from "./silence-detection";
 import type { SilenceLength } from "@/silence-detection-constants";
+import {
+  VIDEO_FORMAT_DIMENSIONS,
+  type VideoFormat,
+} from "@/features/videos/video-format";
 
 export type PauseType = "none" | "long";
 
@@ -127,6 +131,7 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
 
       const exportVideoClips = Effect.fn("exportVideoClips")(function* (opts: {
         videoId: string;
+        format: VideoFormat;
         clips: {
           inputVideo: string;
           startTime: number;
@@ -142,11 +147,14 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
           "FINISHED_VIDEOS_DIRECTORY"
         );
 
-        // Create concatenated video using native FFmpeg
+        // Create concatenated video using native FFmpeg, in the aspect ratio
+        // that matches the video's format (portrait for shorts, landscape
+        // otherwise).
         opts.onStageChange?.("concatenating-clips");
         const concatenatedPath =
           yield* ffmpegCommands.createAndConcatenateVideoClipsSinglePass(
-            opts.clips
+            opts.clips,
+            VIDEO_FORMAT_DIMENSIONS[opts.format]
           );
 
         // Normalize audio


### PR DESCRIPTION
## Problem

Horizontal (16:9 landscape) videos were being exported as vertical, and the content-addressed export cache made the regression sticky.

Two root causes:

1. **Concat forced portrait.** `createAndConcatenateVideoClipsSinglePass` hardcoded `scale=1080:1920`, normalising **every** export to a portrait 9:16 frame. Both standard export paths — **publish** and **batch export** — squashed landscape footage into a portrait frame.
2. **Export hash ignored format.** `computeExportHash` only covered the clips, so a landscape video already exported (wrongly) as portrait kept its old hash and was considered up-to-date — it would never re-export. Flipping a video's format likewise left the hash unchanged, serving the stale wrong-aspect export.

## Audit

Every export point that reaches the concat filter:

| Path | Call site | Before | After |
|------|-----------|--------|-------|
| Publish | `course-publish-service.ts` → `exportVideoClips` | forced 1080×1920 | uses video's format |
| Batch export | `batch-export.server.ts` → `exportVideoClips` | forced 1080×1920 | uses video's format |
| Vertical/shorts render | `render-vertical-video-service.ts` | 1080×1920 | still 1080×1920 (correct — Remotion subtitle/CTA overlay is 9:16) |

No other hardcoded portrait dimensions remain in the export path.

## Fix

**Orientation (commit 1)**
- Add `VIDEO_FORMAT_DIMENSIONS` (`landscape` 1920×1080, `short` 1080×1920) and `resolveVideoFormat()` in `video-format.ts`.
- `exportVideoClips` now takes a `format` and threads the matching target dimensions into the concat filter's `scale`.
- Publish and batch export resolve and pass each video's format.
- The vertical/shorts renderer keeps pinning `short` explicitly so its 1080×1920 overlay lines up.

**Export hash (commit 2)**
- `computeExportHash` (and the pure `isExported`) now take the video's format and bake the normalised value into the payload, so format is part of the content address.
- Every call site threads the video's format through; unknown/missing formats fall back to landscape via `resolveVideoFormat`.
- Because the payload shape changes, **every existing hash is invalidated** — landscape videos that were wrongly exported as portrait re-export in the corrected aspect ratio on the next publish.

## Verification

- `pnpm typecheck` passes.
- 95 tests across the affected suites pass, including service-computes-hash / test-asserts-hash cases that prove format is threaded consistently between production and test paths.
- Added tests: format changes the hash; unknown/missing format falls back to landscape.
- Pre-commit (prettier, boundary lint, file checks) passes.

## Not covered (flagging for a follow-up)

I did **not** verify whether the "render-vertical" action is UI-gated to only `short`-format videos. If a landscape video can be routed through that action it would still produce a vertical output — a separate, product-level path from this regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)