### PR TITLE
fix(sse): don't close an already-closed controller on client disconnect

### DIFF
--- a/app/lib/create-sse-response.server.test.ts
+++ b/app/lib/create-sse-response.server.test.ts
@@ -138,6 +138,31 @@ describe("createSSEResponse", () => {
     ]);
   });
 
+  it("does not throw when the client disconnects mid-stream", async () => {
+    let sendAfterCancel: (() => void) | undefined;
+
+    const response = createSSEResponse({
+      runtime: testRuntime,
+      program: (sendEvent) =>
+        Effect.async<void>((resume) => {
+          sendEvent("stage", { stage: "rendering" });
+          // Simulate the program still trying to emit after the client left.
+          sendAfterCancel = () => {
+            sendEvent("stage", { stage: "later" });
+            resume(Effect.void);
+          };
+        }),
+    });
+
+    const reader = response.body!.getReader();
+    await reader.read();
+    // Client disconnects.
+    await reader.cancel();
+
+    // The program emitting and settling after cancel must not throw.
+    expect(() => sendAfterCancel?.()).not.toThrow();
+  });
+
   it("matches the first applicable tagged error handler", async () => {
     class FirstError {
       readonly _tag = "FirstError";

--- a/app/lib/create-sse-response.server.ts
+++ b/app/lib/create-sse-response.server.ts
@@ -18,13 +18,27 @@ export function createSSEResponse<R, RE>(
   config: SSEResponseConfig<R, RE>
 ): Response {
   const encoder = new TextEncoder();
+  // Aborts the running program when the client disconnects, so we stop
+  // doing work (and enqueueing events) for a stream nobody is reading.
+  const abortController = new AbortController();
+
   const stream = new ReadableStream({
     start(controller) {
+      // Once the stream is closed — either because the program finished or
+      // because the client disconnected (`cancel`) — any further enqueue or
+      // close would throw "Invalid state: Controller is already closed".
+      let closed = false;
+
       const sendEvent: SendEvent = (event, data) => {
+        if (closed) return;
         controller.enqueue(
           encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
         );
       };
+
+      abortController.signal.addEventListener("abort", () => {
+        closed = true;
+      });
 
       let effect: Effect.Effect<void, any, any> = config.program(sendEvent);
 
@@ -51,11 +65,25 @@ export function createSSEResponse<R, RE>(
               });
             })
           ),
-          config.runtime.runPromise
+          (self) =>
+            config.runtime.runPromise(self, {
+              signal: abortController.signal,
+            })
         )
+        // The program may reject when interrupted by the abort signal; that
+        // is expected on client disconnect and must not go unhandled.
+        .catch(() => {})
         .finally(() => {
+          if (closed) return;
+          closed = true;
           controller.close();
         });
+    },
+    cancel() {
+      // Client disconnected: the controller is already closed by the stream
+      // machinery, so interrupt the program and let `start`'s `finally` skip
+      // its own `controller.close()`.
+      abortController.abort();
     },
   });
 


### PR DESCRIPTION
## Problem

Observed error in the running CVM:

\`\`\`
TypeError: Invalid state: Controller is already closed
    at ReadableStreamDefaultController.close (node:internal/webstreams/readablestream)
    at build/server/index.js  (createSSEResponse)
\`\`\`

When a client disconnects mid-stream (browser navigates away / aborts the request), the \`ReadableStream\`'s \`cancel\` runs and the controller is closed by the stream machinery. The program's \`.finally()\` then called \`controller.close()\` **again** — and any late \`sendEvent\` (\`controller.enqueue\`) fired after the disconnect — throwing \`Invalid state: Controller is already closed\`.

## Fix

In \`app/lib/create-sse-response.server.ts\`:

- Track a \`closed\` flag; \`sendEvent\` no-ops once closed and \`.finally()\` skips \`controller.close()\` if already closed.
- Implement the stream's \`cancel()\` to \`abort()\` an \`AbortController\` that is passed to \`runtime.runPromise(..., { signal })\`, so the Effect is **interrupted** on disconnect and we stop doing work for a client that's gone.
- Swallow the expected interruption rejection so it doesn't become an unhandled rejection.

## Test

Added a regression test: after the reader cancels mid-stream, a late \`sendEvent\` + program settle must not throw. Full \`create-sse-response.server\` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)