### PR TITLE
fix: copy video with "rename old" no longer violates title uniqueness

### DIFF
--- a/app/services/db-video-operations.copy.server.ts
+++ b/app/services/db-video-operations.copy.server.ts
@@ -21,6 +21,39 @@ const makeDbCall = <T>(fn: () => Promise<T>) =>
     catch: (e) => new UnknownDBServiceError({ cause: e }),
   });
 
+type Tx = Parameters<Parameters<Database["transaction"]>[0]>[0];
+
+/**
+ * Returns a title no other non-archived video in the lesson is using, appending
+ * " (2)", " (3)" … until one is free.
+ *
+ * Videos with no lesson aren't covered by video_lesson_title_uniq, so any title
+ * works there.
+ */
+const freeTitleInLesson = async (
+  tx: Tx,
+  lessonId: string | null,
+  desiredTitle: string,
+  excludeVideoId: string
+) => {
+  if (!lessonId) return desiredTitle;
+
+  const siblings = await tx.query.videos.findMany({
+    where: and(eq(videos.lessonId, lessonId), eq(videos.archived, false)),
+    columns: { id: true, title: true },
+  });
+
+  const taken = new Set(
+    siblings.filter((v) => v.id !== excludeVideoId).map((v) => v.title)
+  );
+
+  if (!taken.has(desiredTitle)) return desiredTitle;
+
+  let suffix = 2;
+  while (taken.has(`${desiredTitle} (${suffix})`)) suffix++;
+  return `${desiredTitle} (${suffix})`;
+};
+
 export const copyVideoImpl = (
   db: Database,
   opts: {
@@ -55,6 +88,24 @@ export const copyVideoImpl = (
       db.transaction(async (tx) => {
         const now = new Date();
 
+        // Rename the source before inserting: the new video normally reuses the
+        // source's exact title, and video_lesson_title_uniq — unique on
+        // (lesson_id, title) for non-archived rows — rejects the insert while
+        // the old row still holds that title.
+        if (renameOld) {
+          const oldTitle = await freeTitleInLesson(
+            tx,
+            sourceVideo.lessonId,
+            `${sourceVideo.title} (old)`,
+            sourceVideoId
+          );
+
+          await tx
+            .update(videos)
+            .set({ title: oldTitle, updatedAt: now })
+            .where(eq(videos.id, sourceVideoId));
+        }
+
         // Insert new video row
         const newVideoRows = await tx
           .insert(videos)
@@ -73,16 +124,6 @@ export const copyVideoImpl = (
         const newVideo = newVideoRows[0];
         if (!newVideo) {
           throw new Error("No video returned after insert");
-        }
-
-        if (renameOld) {
-          await tx
-            .update(videos)
-            .set({
-              title: `${sourceVideo.title} (old)`,
-              updatedAt: now,
-            })
-            .where(eq(videos.id, sourceVideoId));
         }
 
         if (copyClips) {

--- a/app/services/db-video-operations.copy.test.ts
+++ b/app/services/db-video-operations.copy.test.ts
@@ -6,6 +6,11 @@ import {
 } from "@/test-utils/pglite";
 import * as schema from "@/db/schema";
 import { copyVideoImpl } from "@/services/db-video-operations.copy.server";
+import {
+  createCourseAndVersion,
+  createLesson,
+  createSection,
+} from "@/services/path-uniqueness-test-helpers";
 import type { Database } from "@/services/drizzle-service.server";
 import { Effect } from "effect";
 
@@ -87,6 +92,75 @@ describe("copyVideoImpl — renameOld", () => {
 
     const newVideo = await getVideo(newVideoId);
     expect(newVideo!.title).toBe("problem");
+  });
+
+  // The videos above have no lesson, so video_lesson_title_uniq — unique on
+  // (lesson_id, title) for non-archived rows — never fires. These cover a
+  // video that actually belongs to a lesson.
+  async function createLessonId() {
+    const { versionId } = await createCourseAndVersion(testDb);
+    const section = await createSection(testDb, versionId, "Section", 0);
+    const lesson = await createLesson(testDb, section.id, "Lesson", 0);
+    return lesson.id;
+  }
+
+  it("copies within a lesson when the new video reuses the source's title", async () => {
+    const lessonId = await createLessonId();
+    const source = await createVideo({ title: "Explainer", lessonId });
+
+    const newVideoId = await run(
+      copyVideoImpl(db(), {
+        sourceVideoId: source.id,
+        newTitle: "Explainer",
+        copyClips: false,
+        copyBeats: false,
+        renameOld: true,
+      })
+    );
+
+    expect((await getVideo(source.id))!.title).toBe("Explainer (old)");
+    expect((await getVideo(newVideoId))!.title).toBe("Explainer");
+  });
+
+  it("disambiguates the (old) title when the lesson already has one", async () => {
+    const lessonId = await createLessonId();
+    await createVideo({ title: "Explainer (old)", lessonId });
+    const source = await createVideo({ title: "Explainer", lessonId });
+
+    const newVideoId = await run(
+      copyVideoImpl(db(), {
+        sourceVideoId: source.id,
+        newTitle: "Explainer",
+        copyClips: false,
+        copyBeats: false,
+        renameOld: true,
+      })
+    );
+
+    expect((await getVideo(source.id))!.title).toBe("Explainer (old) (2)");
+    expect((await getVideo(newVideoId))!.title).toBe("Explainer");
+  });
+
+  it("ignores archived siblings when disambiguating the (old) title", async () => {
+    const lessonId = await createLessonId();
+    await createVideo({
+      title: "Explainer (old)",
+      lessonId,
+      archived: true,
+    });
+    const source = await createVideo({ title: "Explainer", lessonId });
+
+    await run(
+      copyVideoImpl(db(), {
+        sourceVideoId: source.id,
+        newTitle: "Explainer",
+        copyClips: false,
+        copyBeats: false,
+        renameOld: true,
+      })
+    );
+
+    expect((await getVideo(source.id))!.title).toBe("Explainer (old)");
   });
 
   it("does not rename the source when renameOld is false", async () => {


### PR DESCRIPTION
## The bug

Copying a video with **"Rename old video to (old)"** checked crashed with:

```
duplicate key value violates unique constraint "video_lesson_title_uniq"
Key (lesson_id, title)=(da7ee785-…, Explainer) already exists.
```

The modal defaults the new video's name to the source's *exact* title when `renameOld` is checked (`copy-video-modal.tsx:43-45`). But `copyVideoImpl` inserted the new row **first** and renamed the source **afterwards** — so the insert hit `video_lesson_title_uniq` (unique on `(lesson_id, title)` where not archived) while the source still held that title.

## The fix

- Rename the source **before** inserting the new row.
- Pick a free `(old)` title (` (2)`, ` (3)`, …) so copying the same video twice doesn't collide with an existing `<title> (old)`. Archived siblings are ignored, matching the partial index.

## Why the existing tests missed it

The three existing `renameOld` tests create videos with a **null** `lessonId`, so the partial unique index never fires. The three new tests use a real lesson; all three fail on `main` and pass here.

## Verification

- `vitest run app/services` — 753 passed (70 files)
- `pnpm typecheck` — clean
- Confirmed the new tests fail with the fix reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)