### PR TITLE
fix(video-editor): keep the live preview alive while recording

### DIFF
--- a/app/features/video-editor/use-ensure-obs-profile.test.ts
+++ b/app/features/video-editor/use-ensure-obs-profile.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { resolveProfileGateAction } from "./use-ensure-obs-profile";
+import { OBS_PROFILE_LANDSCAPE, OBS_PROFILE_TIKTOK } from "./ensure-obs-profile";
+
+describe("resolveProfileGateAction", () => {
+  it("switches when the active profile is not the one we want", () => {
+    expect(
+      resolveProfileGateAction({
+        obsStateType: "obs-connected",
+        currentProfile: OBS_PROFILE_TIKTOK,
+        targetProfile: OBS_PROFILE_LANDSCAPE,
+        hasEnsured: false,
+      })
+    ).toEqual({ type: "switch-profile" });
+  });
+
+  it("is ready immediately when the active profile already matches", () => {
+    expect(
+      resolveProfileGateAction({
+        obsStateType: "obs-connected",
+        currentProfile: OBS_PROFILE_LANDSCAPE,
+        targetProfile: OBS_PROFILE_LANDSCAPE,
+        hasEnsured: false,
+      })
+    ).toEqual({ type: "ready" });
+  });
+
+  it("resets when OBS goes away, so the next connection ensures again", () => {
+    expect(
+      resolveProfileGateAction({
+        obsStateType: "obs-not-running",
+        currentProfile: null,
+        targetProfile: OBS_PROFILE_LANDSCAPE,
+        hasEnsured: true,
+      })
+    ).toEqual({ type: "reset" });
+  });
+
+  // Regression: hitting record moved OBS from "obs-connected" to
+  // "obs-recording", which the old gate treated as a disconnect. That cleared
+  // profileReady, which tore down the virtual camera — the live preview cut out
+  // for the whole take, and speech detection got a null stream so no clips were
+  // detected. Starting a recording must not disturb a settled gate.
+  it("stays settled when a recording starts", () => {
+    expect(
+      resolveProfileGateAction({
+        obsStateType: "obs-recording",
+        currentProfile: OBS_PROFILE_LANDSCAPE,
+        targetProfile: OBS_PROFILE_LANDSCAPE,
+        hasEnsured: true,
+      })
+    ).toEqual({ type: "already-settled" });
+  });
+
+  it("stays settled when a recording starts on a mismatched profile", () => {
+    expect(
+      resolveProfileGateAction({
+        obsStateType: "obs-recording",
+        currentProfile: OBS_PROFILE_TIKTOK,
+        targetProfile: OBS_PROFILE_LANDSCAPE,
+        hasEnsured: true,
+      })
+    ).toEqual({ type: "already-settled" });
+  });
+
+  it("never switches profile mid-recording, even when the profile is wrong", () => {
+    expect(
+      resolveProfileGateAction({
+        obsStateType: "obs-recording",
+        currentProfile: OBS_PROFILE_TIKTOK,
+        targetProfile: OBS_PROFILE_LANDSCAPE,
+        hasEnsured: false,
+      })
+    ).toEqual({ type: "ready-without-settling" });
+  });
+
+  it("switches once a recording it arrived during has stopped", () => {
+    // "ready-without-settling" leaves hasEnsured false, so the transition back
+    // to obs-connected picks the profile switch back up.
+    expect(
+      resolveProfileGateAction({
+        obsStateType: "obs-connected",
+        currentProfile: OBS_PROFILE_TIKTOK,
+        targetProfile: OBS_PROFILE_LANDSCAPE,
+        hasEnsured: false,
+      })
+    ).toEqual({ type: "switch-profile" });
+  });
+});

--- a/app/features/video-editor/use-ensure-obs-profile.ts
+++ b/app/features/video-editor/use-ensure-obs-profile.ts
@@ -2,6 +2,47 @@ import { useEffect, useRef, useState } from "react";
 import type { OBSConnectionOuterState } from "./obs-connector";
 import type { EnsureProfileResult } from "./ensure-obs-profile";
 
+export type ProfileGateAction =
+  /** OBS is gone — hide the camera and allow ensuring again on reconnect. */
+  | { type: "reset" }
+  /** The profile has already been ensured for this connection. */
+  | { type: "already-settled" }
+  /**
+   * Show the camera, but don't mark the profile as ensured. Used while OBS is
+   * recording: switching profiles mid-recording would break the output file,
+   * so the check is deferred until the recording stops.
+   */
+  | { type: "ready-without-settling" }
+  /** The active profile is already the one we want. */
+  | { type: "ready" }
+  /** The active profile is wrong and it's safe to switch. */
+  | { type: "switch-profile" };
+
+export function resolveProfileGateAction(opts: {
+  obsStateType: OBSConnectionOuterState["type"];
+  currentProfile: string | null;
+  targetProfile: string;
+  hasEnsured: boolean;
+}): ProfileGateAction {
+  if (opts.obsStateType === "obs-not-running") {
+    return { type: "reset" };
+  }
+
+  if (opts.hasEnsured) {
+    return { type: "already-settled" };
+  }
+
+  if (opts.obsStateType === "obs-recording") {
+    return { type: "ready-without-settling" };
+  }
+
+  if (opts.currentProfile === opts.targetProfile) {
+    return { type: "ready" };
+  }
+
+  return { type: "switch-profile" };
+}
+
 export function useEnsureOBSProfile(opts: {
   obsState: OBSConnectionOuterState;
   targetProfile: string;
@@ -12,28 +53,39 @@ export function useEnsureOBSProfile(opts: {
   const hasEnsuredRef = useRef(false);
 
   useEffect(() => {
-    if (opts.obsState.type !== "obs-connected") {
-      hasEnsuredRef.current = false;
-      setProfileReady(false);
-      return;
-    }
-
-    if (hasEnsuredRef.current) return;
-
-    if (opts.obsState.profile === opts.targetProfile) {
-      hasEnsuredRef.current = true;
-      setProfileReady(true);
-      return;
-    }
-
-    hasEnsuredRef.current = true;
-    opts.ensureProfile(opts.targetProfile).then((result) => {
-      if (result.type === "error") {
-        opts.onError(result.message);
-        return;
-      }
-      setProfileReady(true);
+    const action = resolveProfileGateAction({
+      obsStateType: opts.obsState.type,
+      currentProfile:
+        opts.obsState.type === "obs-not-running" ? null : opts.obsState.profile,
+      targetProfile: opts.targetProfile,
+      hasEnsured: hasEnsuredRef.current,
     });
+
+    switch (action.type) {
+      case "reset":
+        hasEnsuredRef.current = false;
+        setProfileReady(false);
+        return;
+      case "already-settled":
+        return;
+      case "ready-without-settling":
+        setProfileReady(true);
+        return;
+      case "ready":
+        hasEnsuredRef.current = true;
+        setProfileReady(true);
+        return;
+      case "switch-profile":
+        hasEnsuredRef.current = true;
+        opts.ensureProfile(opts.targetProfile).then((result) => {
+          if (result.type === "error") {
+            opts.onError(result.message);
+            return;
+          }
+          setProfileReady(true);
+        });
+        return;
+    }
   }, [opts.obsState.type, opts.targetProfile]);
 
   return { profileReady };


### PR DESCRIPTION
## The bug

Hitting record (or OBS receiving a record event) killed the live preview for the whole take. It came back on stop.

Introduced by #1382 / `8bc091f3`. `useEnsureOBSProfile`'s effect guard was:

```ts
if (opts.obsState.type !== "obs-connected") {
  hasEnsuredRef.current = false;
  setProfileReady(false);
  return;
}
```

with deps `[opts.obsState.type, opts.targetProfile]`. Recording moves the connector `obs-connected` → `obs-recording`, so the effect re-ran and the guard classified *recording* as *disconnected*, flipping `profileReady` back to `false`. That made `shouldShowMediaStream` false, so `useConnectToOBSVirtualCamera` stopped every track and scheduled a `StopVirtualCam`. Nothing could set `profileReady` back to `true` until recording stopped, because every path that does requires `type === "obs-connected"`.

That guard was harmless before #1382 — the hook had no state, so resetting the ref was idempotent. Adding `setProfileReady(false)` turned a re-entry guard into a teardown trigger.

**Collateral damage:** `useSpeechDetector` is fed `mediaStream`, which was `null` for the entire recording — so silence-based clip splitting silently detected nothing while recording.

## The fix

The gate is a property of the *connection*, not of the recording. The decision is extracted into a pure `resolveProfileGateAction` (no DOM needed, matching how the rest of this feature is tested) which encodes:

- `obs-not-running` → reset
- already settled → do nothing, **including when a recording starts**
- arrived while already recording → show the camera but leave the gate unsettled, so the profile gets ensured once recording stops
- profile matches → ready; otherwise switch

A profile switch is never attempted mid-recording — it would break the output file.

## Testing

- 7 new tests on the pure gate, including a named regression test for the record transition
- `app/features/video-editor/` suite: 314 passed
- `npm run typecheck` clean

## Follow-up

Deliberately out of scope, tracked separately: consolidating the connection/profile/camera state machines into one reducer, the two owners of the virtual camera, and the permanent-brick error path from `7a8005af`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)