### PR TITLE
fix: add-video modals submit 'title' to match the renamed action field

### DIFF
--- a/app/components/add-video-modal.tsx
+++ b/app/components/add-video-modal.tsx
@@ -23,7 +23,8 @@ export function AddVideoModal(props: {
 
   // No redirect fires on success anymore, so close the modal once the submit
   // round-trip completes. Track that we actually submitted so a stale
-  // fetcher.data doesn't re-close the modal the next time it opens.
+  // fetcher.data doesn't re-close the modal the next time it opens. Action
+  // errors are not handled here — they propagate to the route error boundary.
   const didSubmit = useRef(false);
   const { onOpenChange } = props;
   useEffect(() => {
@@ -59,15 +60,15 @@ export function AddVideoModal(props: {
           className="space-y-4 py-4"
         >
           <div className="space-y-2">
-            <Label htmlFor="video-path">Video Name</Label>
+            <Label htmlFor="video-title">Video Name</Label>
             <Input
-              id="video-path"
+              id="video-title"
               placeholder="Problem, Solution, Explainer..."
               defaultValue={getVideoPath({
                 videoCount: props.videoCount,
                 hasExplainerFolder: props.hasExplainerFolder,
               })}
-              name="path"
+              name="title"
             />
           </div>
           <div className="flex justify-end space-x-2">

--- a/app/components/add-video-to-next-lesson-modal.tsx
+++ b/app/components/add-video-to-next-lesson-modal.tsx
@@ -38,15 +38,15 @@ export function AddVideoToNextLessonModal(props: {
         >
           <input type="hidden" name="lessonId" value={props.lessonId} />
           <div className="space-y-2">
-            <Label htmlFor="video-path">Video Name</Label>
+            <Label htmlFor="video-title">Video Name</Label>
             <Input
-              id="video-path"
+              id="video-title"
               placeholder="Problem, Solution, Explainer..."
               defaultValue={getVideoPath({
                 videoCount: 0,
                 hasExplainerFolder: props.hasExplainerFolder,
               })}
-              name="path"
+              name="title"
             />
           </div>
           <div className="flex justify-end space-x-2">


### PR DESCRIPTION
## Problem

Creating a video from the UI (lesson right-click → Add Video, and the article-writer's "Add Video to Next Lesson" modal) silently stopped working.

## Cause

PR #1220 retired the `path` concept and renamed the add-video action's expected form field from `path` to `title` in `app/routes/api.lessons.$lessonId.add-video.ts`, but both submitting modals still posted the input as `name="path"`. The action's schema decode failed on every submit.

## Fix

Rename the input (`name`, `id`, label `htmlFor`) from `path` to `title` in both modals. No error handling added in the modals — action errors intentionally propagate to the root error boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)