### PR TITLE
Close the clips-during-publish race (version-row lock + terminal VersionNotDraftError)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,7 +7,7 @@ A tool for authoring courses as structured collections of sections, lessons, and
 ### Course structure
 
 **Course**:
-The primary domain entity: a structured collection of versions, sections, lessons, and videos, held entirely in the database. Not backed by any on-disk repository — courses were once backed by a local git repo, but that backing was retired (see ADR 0018).
+The primary domain entity: a structured collection of versions, sections, lessons, and videos, held entirely in the database. Not backed by any on-disk repository — the former git-repo backing was retired (ADR 0018).
 _Avoid_: Repo, Project
 
 **Section**:
@@ -29,7 +29,7 @@ The single mutable CourseVersion being edited — the only state accepting secti
 _Avoid_: Current version, Working version
 
 **Pending Version**:
-A Submitted CourseVersion whose Dropbox commit receipt has not yet landed. Immutable, named, short-lived: either Promoted (receipt landed) or Discarded (commit failed). At most one per course; one found at rest means exactly one thing — a crash between receipt and Promote.
+A Submitted CourseVersion whose Dropbox commit receipt has not yet landed. Immutable, named, short-lived: either Promoted (receipt landed) or Discarded (commit failed). At most one per course; one found at rest means a crash between receipt and Promote.
 _Avoid_: Frozen version (ambiguous with Published), In-flight version
 
 **Published Version**:
@@ -37,7 +37,7 @@ An immutable CourseVersion with a name and description, created by Promoting a P
 _Avoid_: Released version, Committed version
 
 **Submit**:
-The Draft → Pending transition: stamps the publish name/description, marks the Draft Pending, and clones a fresh Draft. Refused while a Pending Version exists.
+The Draft → Pending transition: stamps the publish name/description, marks the Draft Pending, and clones a fresh Draft. Refused while a Pending Version exists. In-flight writes serialize with it: each lands before the clone or is refused terminally — never stranded on the frozen version.
 _Avoid_: Freeze (only half the story), Snapshot
 
 **Promote**:
@@ -49,7 +49,7 @@ Deletes a Pending Version whose commit did not land — never a Draft or Publish
 _Avoid_: Rollback, Delete version
 
 **Publish**:
-The release flow: Submit, then the Dropbox commit (upload culminating in the atomic `course.json` rename — the sole commit receipt), then Promote. Structure is derived from the database (never parsed from disk); the Dropbox output is exclusively `.mp4` files plus one `course.json` and its companion `course.schema.json` (its JSON Schema, referenced via `$schema`) — no authoring sidecars (`.transcript.md`, `.body.md`, `.meta.json`, `TODO.md`), no `changelog.md`. Every shipping **Video** must be complete — exportable **Clips** (hence an `.mp4` and an **Export Hash**), a `body`, and a `description` — so no `course.json` field is ever null; an incomplete Video fails the Publish (ADR 0019).
+The release flow: Submit, then the Dropbox commit (upload culminating in the atomic `course.json` rename — the sole commit receipt), then Promote. Structure is derived from the database (never parsed from disk); the Dropbox output is exclusively `.mp4` files plus one `course.json` and its companion `course.schema.json` (referenced via `$schema`) — no authoring sidecars, no `changelog.md`. Every shipping **Video** must be complete — exportable **Clips** (hence an `.mp4` and an **Export Hash**), a `body`, and a `description` — so no `course.json` field is ever null; an incomplete Video fails the Publish (ADR 0019).
 _Avoid_: Commit (that is one phase of it), Deploy, Push
 
 **Export Version Key**:

--- a/app/cli/commands/course-publish.ts
+++ b/app/cli/commands/course-publish.ts
@@ -129,6 +129,10 @@ FAILURE HANDLING
   Draft, so fix the cause and publish again. The upload is content-addressed,
   so a re-publish re-uploads nothing that already landed.
 
+  Edits racing a publish are safe: a write serializes with Submit and either
+  lands before the freeze (carried into the new Draft) or is refused with
+  VersionNotDraftError (exit 3) — retry it against the new Draft.
+
 FLAGS
   --name <vX.Y.Z>     (required) the Published Version name.
   --description <text> (required) description for the Published Version.

--- a/app/features/course-view/use-optimistic-course.ts
+++ b/app/features/course-view/use-optimistic-course.ts
@@ -3,6 +3,7 @@ import { useFetchers } from "react-router";
 import { toast } from "sonner";
 import type { CourseEditorEvent } from "@/services/course-editor-service";
 import type { LoaderData } from "./course-view-types";
+import { VERSION_NOT_DRAFT_MESSAGE } from "@/services/version-not-draft-message";
 import {
   applyOptimisticEvent,
   applyOptimisticDeleteVideo,
@@ -71,12 +72,22 @@ export function useCourseEditorFailureToast() {
             .clone()
             .text()
             .then((body) => {
+              let message = body;
               try {
                 const parsed = JSON.parse(body);
-                setDivergenceReport(typeof parsed === "string" ? parsed : body);
+                if (typeof parsed === "string") message = parsed;
               } catch {
-                setDivergenceReport(body);
+                // keep raw body
               }
+              // Terminal (#1403): the Draft was Submitted while this change
+              // was in flight. Surface it and force a reload into the new
+              // Draft — the write can never succeed against this version.
+              if (message === VERSION_NOT_DRAFT_MESSAGE) {
+                toast.error(message);
+                setTimeout(() => window.location.reload(), 1500);
+                return;
+              }
+              setDivergenceReport(message);
             });
         } else {
           toast.error("Action failed — your change was reverted.");

--- a/app/features/video-editor/edit-effect-handlers.ts
+++ b/app/features/video-editor/edit-effect-handlers.ts
@@ -10,6 +10,7 @@ import {
   RECORDING_SESSION_PANELS_ID,
 } from "@/features/video-editor/constants";
 import type { ClipService } from "@/services/clip-service";
+import { VERSION_NOT_DRAFT_MESSAGE } from "@/services/version-not-draft-message";
 import type { EffectsMap } from "use-effect-reducer";
 import type React from "react";
 import { sendToChild, subscribeParent } from "@/lib/diagram-protocol";
@@ -276,7 +277,18 @@ export function createEditEffectHandlers(
               });
             }
           } catch (e) {
-            // Errors are swallowed; polling continues
+            // Terminal (#1403): the version was Submitted mid-session — stop
+            // polling and surface the reload overlay instead of silently
+            // retrying against a frozen version forever.
+            if (e instanceof Error && e.message === VERSION_NOT_DRAFT_MESSAGE) {
+              dispatch({
+                type: "effect-failed",
+                effectType: "start-session-polling",
+                message: e.message,
+              });
+              break;
+            }
+            // Other errors are swallowed; polling continues
           }
           await new Promise((resolve) => setTimeout(resolve, 500));
         }

--- a/app/services/clip-service-handler.helpers.ts
+++ b/app/services/clip-service-handler.helpers.ts
@@ -11,7 +11,9 @@ import type {
   ClipServiceEvent,
   CreateVideoFromSelectionInput,
 } from "./clip-service";
-import type { DrizzleService } from "./drizzle-service.server";
+import type { Database } from "./drizzle-service.server";
+import { requireDraftVersionForVideo } from "./draft-guard.server";
+import { withDbTransaction } from "./with-db-transaction.server";
 import type { LogEvent } from "./video-editor-logger-service";
 import type { SilenceLength } from "@/silence-detection-constants";
 
@@ -69,7 +71,7 @@ export function windowsToWSL(windowsPath: string): string {
 // ============================================================================
 
 export const getOrderedItems = Effect.fn("getOrderedItems")(function* (
-  db: DrizzleService,
+  db: Database,
   videoId: string
 ) {
   const allClips = yield* Effect.promise(() =>
@@ -101,7 +103,7 @@ export const getOrderedItems = Effect.fn("getOrderedItems")(function* (
 // Helper: Touch video updatedAt timestamp
 // ============================================================================
 
-export const touchVideoUpdatedAt = (db: DrizzleService, videoId: string) =>
+export const touchVideoUpdatedAt = (db: Database, videoId: string) =>
   Effect.promise(() =>
     db
       .update(videos)
@@ -116,7 +118,7 @@ export const touchVideoUpdatedAt = (db: DrizzleService, videoId: string) =>
 export const appendClipsAtInsertionPoint = Effect.fn(
   "appendClipsAtInsertionPoint"
 )(function* (
-  db: DrizzleService,
+  db: Database,
   input: Extract<ClipServiceEvent, { type: "append-clips" }>["input"]
 ) {
   const { videoId, insertionPoint, clips: inputClips } = input;
@@ -216,7 +218,7 @@ export async function withVideoMutex<T>(
 // ============================================================================
 
 export const appendFromObsImpl = (
-  db: DrizzleService,
+  db: Database,
   event: Extract<ClipServiceEvent, { type: "append-from-obs" }>,
   videoProcessing: VideoProcessingAdapter,
   logger: LoggerAdapter
@@ -304,13 +306,21 @@ export const appendFromObsImpl = (
       return [];
     }
 
-    const result = yield* appendClipsAtInsertionPoint(db, {
-      videoId,
-      insertionPoint,
-      clips: clipsToAdd,
-    });
-
-    yield* touchVideoUpdatedAt(db, videoId);
+    // #1403: the Draft may have been Submitted while OBS detection ran above.
+    // Re-check under the version-row lock, in the same transaction as the
+    // insert, so a clip can never land on a version that is no longer a Draft.
+    const result = yield* withDbTransaction(db, (tx) =>
+      Effect.gen(function* () {
+        yield* requireDraftVersionForVideo(tx, videoId);
+        const inserted = yield* appendClipsAtInsertionPoint(tx, {
+          videoId,
+          insertionPoint,
+          clips: clipsToAdd,
+        });
+        yield* touchVideoUpdatedAt(tx, videoId);
+        return inserted;
+      })
+    );
 
     const totalDuplicatesSkipped =
       latestOBSVideoClips.clips.length - result.length;
@@ -332,13 +342,101 @@ export const appendFromObsImpl = (
   });
 
 // ============================================================================
+// Handler: create-effect-clip-at-position
+// ============================================================================
+
+export const createEffectClipAtPositionImpl = Effect.fn(
+  "createEffectClipAtPositionImpl"
+)(function* (
+  db: Database,
+  input: Extract<
+    ClipServiceEvent,
+    { type: "create-effect-clip-at-position" }
+  >["input"],
+  logger: LoggerAdapter
+) {
+  const {
+    videoId,
+    position,
+    targetItemId,
+    targetItemType,
+    videoFilename,
+    sourceStartTime,
+    sourceEndTime,
+    text,
+    scene,
+    profile,
+    pauseType,
+  } = input;
+  const allItems = yield* getOrderedItems(db, videoId);
+
+  const targetIndex = allItems.findIndex(
+    (item) => item.type === targetItemType && item.id === targetItemId
+  );
+
+  if (targetIndex === -1) {
+    throw new Error(`Could not find target ${targetItemType}: ${targetItemId}`);
+  }
+
+  let prevOrder: string | null = null;
+  let nextOrder: string | null = null;
+
+  if (position === "before") {
+    nextOrder = allItems[targetIndex]?.order ?? null;
+    const prevItem = allItems[targetIndex - 1];
+    prevOrder = prevItem?.order ?? null;
+  } else {
+    prevOrder = allItems[targetIndex]?.order ?? null;
+    const nextItem = allItems[targetIndex + 1];
+    nextOrder = nextItem?.order ?? null;
+  }
+
+  const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
+
+  const [clip] = yield* Effect.promise(() =>
+    db
+      .insert(clips)
+      .values({
+        videoId,
+        videoFilename,
+        sourceStartTime,
+        sourceEndTime,
+        text,
+        scene,
+        profile,
+        pauseType,
+        order: order!,
+        archived: false,
+        transcribedAt: new Date(),
+      })
+      .returning()
+  );
+
+  if (!clip) {
+    throw new Error("Failed to create effect clip");
+  }
+
+  yield* touchVideoUpdatedAt(db, videoId);
+
+  logger.log(videoId, {
+    type: "effect-clip-created",
+    clipId: clip.id,
+    text,
+    scene,
+    order: order!,
+  });
+
+  return clip;
+});
+
+// ============================================================================
 // Handler: create-video-from-selection
 // ============================================================================
 
 export const handleCreateVideoFromSelection = Effect.fn(
   "handleCreateVideoFromSelection"
 )(function* (
-  db: DrizzleService,
+  db: Database,
   input: CreateVideoFromSelectionInput,
   logger: LoggerAdapter
 ) {

--- a/app/services/clip-service-handler.ts
+++ b/app/services/clip-service-handler.ts
@@ -27,10 +27,11 @@ import {
   appendClipsAtInsertionPoint,
   withVideoMutex,
   appendFromObsImpl,
+  createEffectClipAtPositionImpl,
   handleCreateVideoFromSelection,
 } from "./clip-service-handler.helpers";
-import type { DrizzleService } from "./drizzle-service.server";
-import { requireDraftForClipServiceEvent } from "./draft-guard.server";
+import type { Database } from "./drizzle-service.server";
+import { withClipServiceWriteClosure } from "./draft-guard.server";
 
 export type { VideoProcessingAdapter, LoggerAdapter };
 
@@ -42,21 +43,31 @@ export type { VideoProcessingAdapter, LoggerAdapter };
  * Handles a ClipServiceEvent by dispatching to the appropriate database operation.
  * This is the core business logic that both HTTP and direct transports use.
  *
+ * Write-closure (issues #1348/#1403): guarded write events dispatch inside one
+ * transaction holding the owning version row FOR UPDATE, so the draft check
+ * and the write commit atomically (see draft-guard.server.ts).
+ *
  * @param db - Drizzle database instance
  * @param event - The event to handle
  * @param videoProcessing - VideoProcessingService adapter (required for append-from-obs)
  */
-export const handleClipServiceEvent = Effect.fn("handleClipServiceEvent")(
+export const handleClipServiceEvent = (
+  db: Database,
+  event: ClipServiceEvent,
+  videoProcessing: VideoProcessingAdapter,
+  logger: LoggerAdapter = noopLogger
+) =>
+  withClipServiceWriteClosure(db, event, (tx) =>
+    dispatchClipServiceEvent(tx, event, videoProcessing, logger)
+  );
+
+const dispatchClipServiceEvent = Effect.fn("dispatchClipServiceEvent")(
   function* (
-    db: DrizzleService,
+    db: Database,
     event: ClipServiceEvent,
     videoProcessing: VideoProcessingAdapter,
-    logger: LoggerAdapter = noopLogger
+    logger: LoggerAdapter
   ) {
-    // Write-closure (issue #1348): refuse write events whose target lives in
-    // a non-Draft version before dispatching (see draft-guard.server.ts).
-    yield* requireDraftForClipServiceEvent(db, event);
-
     switch (event.type) {
       case "create-video": {
         const [video] = yield* Effect.promise(() =>
@@ -121,14 +132,17 @@ export const handleClipServiceEvent = Effect.fn("handleClipServiceEvent")(
         }
 
         // Serialize concurrent append-from-obs calls for the same video
-        // via an in-memory mutex to prevent duplicate clip inserts
-        return yield* Effect.promise(() =>
+        // via an in-memory mutex to prevent duplicate clip inserts.
+        // runPromiseExit + re-yield keeps typed failures (VersionNotDraftError
+        // from the post-detection guard, #1403) in the error channel.
+        const exit = yield* Effect.promise(() =>
           withVideoMutex(event.input.videoId, () =>
-            Effect.runPromise(
+            Effect.runPromiseExit(
               appendFromObsImpl(db, event, videoProcessing, logger)
             )
           )
         );
+        return yield* exit;
       }
 
       case "archive-clips": {
@@ -543,80 +557,7 @@ export const handleClipServiceEvent = Effect.fn("handleClipServiceEvent")(
       }
 
       case "create-effect-clip-at-position": {
-        const {
-          videoId,
-          position,
-          targetItemId,
-          targetItemType,
-          videoFilename,
-          sourceStartTime,
-          sourceEndTime,
-          text,
-          scene,
-          profile,
-          pauseType,
-        } = event.input;
-        const allItems = yield* getOrderedItems(db, videoId);
-
-        const targetIndex = allItems.findIndex(
-          (item) => item.type === targetItemType && item.id === targetItemId
-        );
-
-        if (targetIndex === -1) {
-          throw new Error(
-            `Could not find target ${targetItemType}: ${targetItemId}`
-          );
-        }
-
-        let prevOrder: string | null = null;
-        let nextOrder: string | null = null;
-
-        if (position === "before") {
-          nextOrder = allItems[targetIndex]?.order ?? null;
-          const prevItem = allItems[targetIndex - 1];
-          prevOrder = prevItem?.order ?? null;
-        } else {
-          prevOrder = allItems[targetIndex]?.order ?? null;
-          const nextItem = allItems[targetIndex + 1];
-          nextOrder = nextItem?.order ?? null;
-        }
-
-        const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
-
-        const [clip] = yield* Effect.promise(() =>
-          db
-            .insert(clips)
-            .values({
-              videoId,
-              videoFilename,
-              sourceStartTime,
-              sourceEndTime,
-              text,
-              scene,
-              profile,
-              pauseType,
-              order: order!,
-              archived: false,
-              transcribedAt: new Date(),
-            })
-            .returning()
-        );
-
-        if (!clip) {
-          throw new Error("Failed to create effect clip");
-        }
-
-        yield* touchVideoUpdatedAt(db, videoId);
-
-        logger.log(videoId, {
-          type: "effect-clip-created",
-          clipId: clip.id,
-          text,
-          scene,
-          order: order!,
-        });
-
-        return clip;
+        return yield* createEffectClipAtPositionImpl(db, event.input, logger);
       }
 
       case "create-video-from-selection": {
@@ -715,7 +656,7 @@ export const handleClipServiceEvent = Effect.fn("handleClipServiceEvent")(
  * @param videoProcessing - VideoProcessingService adapter for OBS functionality
  */
 export function createDirectClipService(
-  db: DrizzleService,
+  db: Database,
   videoProcessing: VideoProcessingAdapter,
   logger?: LoggerAdapter
 ): ClipService {

--- a/app/services/clip-service.ts
+++ b/app/services/clip-service.ts
@@ -51,8 +51,7 @@ export type TargetItemType = "clip" | "chapter";
  * Returned by getTimeline, sorted by order.
  */
 export type TimelineItem =
-  | { type: "clip"; data: Clip }
-  | { type: "chapter"; data: Chapter };
+  { type: "clip"; data: Clip } | { type: "chapter"; data: Chapter };
 
 // ============================================================================
 // Direction Types
@@ -572,6 +571,19 @@ export function createHttpClipService(): ClipService {
 
     if (!response.ok) {
       const text = await response.text();
+      // A 409 body is the server error's message (e.g. VersionNotDraftError's
+      // terminal "reload into the new Draft" message, #1403) — surface it
+      // verbatim so the error overlay reads as guidance, not a status dump.
+      if (response.status === 409) {
+        let message = text;
+        try {
+          const parsed = JSON.parse(text);
+          if (typeof parsed === "string") message = parsed;
+        } catch {
+          // keep raw text
+        }
+        throw new Error(message);
+      }
       throw new Error(`ClipService request failed: ${response.status} ${text}`);
     }
 

--- a/app/services/clips-race.test.ts
+++ b/app/services/clips-race.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression tests for the clips-during-publish race (issues #1349/#1403),
+ * deliberately independent of the Dropbox publish path: "publish" here is just
+ * Submit (freezeAndCloneVersion), which is the only step a clip write can race.
+ *
+ * The locked design: every guarded write runs its draft-guard check and its
+ * insert in ONE transaction holding `SELECT … FOR UPDATE` on the owning
+ * CourseVersion row, and Submit takes the same row lock before cloning — so a
+ * write either lands before the clone (and is carried into the new Draft) or
+ * fails with the terminal VersionNotDraftError. Never a stranded clip.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { Effect, Exit, Layer } from "effect";
+import { drizzle } from "drizzle-orm/pglite";
+import type { PGlite } from "@electric-sql/pglite";
+import * as schema from "@/db/schema";
+import {
+  createTestDb,
+  truncateAllTables,
+  type TestDb,
+} from "@/test-utils/pglite";
+import { CourseOperationsService } from "@/services/db-course-operations.server";
+import { VideoOperationsService } from "@/services/db-video-operations.server";
+import { VersionOperationsService } from "@/services/db-version-operations.server";
+import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
+import { ClipOperationsService } from "@/services/db-clip-operations.server";
+import { DrizzleService } from "@/services/drizzle-service.server";
+import { handleClipServiceEvent } from "@/services/clip-service-handler";
+import { createClipOperations } from "@/services/db-clip-operations.server";
+import { clips as clipsTable } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+let testDb: TestDb;
+let pglite: PGlite;
+
+beforeAll(async () => {
+  const result = await createTestDb();
+  testDb = result.testDb;
+  pglite = result.pglite as PGlite;
+});
+
+const makeRunner = (db: TestDb) => {
+  const drizzleLayer = Layer.succeed(DrizzleService, db as any);
+  const dbLayer = Layer.mergeAll(
+    CourseOperationsService.Default,
+    VideoOperationsService.Default,
+    VersionOperationsService.Default,
+    LessonSectionOperationsService.Default,
+    ClipOperationsService.Default
+  ).pipe(Layer.provide(drizzleLayer));
+
+  return <A, E>(effect: Effect.Effect<A, E, any>) =>
+    Effect.runPromise(
+      effect.pipe(Effect.provide(dbLayer) as any)
+    ) as Promise<A>;
+};
+
+const setup = async () => {
+  await truncateAllTables(testDb);
+  const run = makeRunner(testDb);
+
+  const seeded = await run(
+    Effect.gen(function* () {
+      const courseOps = yield* CourseOperationsService;
+      const versionOps = yield* VersionOperationsService;
+      const lsOps = yield* LessonSectionOperationsService;
+      const videoOps = yield* VideoOperationsService;
+
+      const course = yield* courseOps.createCourse({ name: "race-course" });
+      const version = yield* versionOps.createCourseVersion({
+        repoId: course.id,
+        name: "",
+      });
+      const [section] = yield* lsOps.createSections({
+        repoVersionId: version.id,
+        sections: [{ sectionPathWithNumber: "01-intro", sectionNumber: 1 }],
+      });
+      const [lesson] = yield* lsOps.createLessons(section!.id, [
+        { lessonPathWithNumber: "01.01-welcome", lessonNumber: 1 },
+      ]);
+      const video = yield* videoOps.createVideo(lesson!.id, {
+        title: "Problem",
+        originalFootagePath: "/tmp/footage.mp4",
+      });
+      return { course, version, video };
+    })
+  );
+
+  const submit = () =>
+    run(
+      Effect.gen(function* () {
+        const versionOps = yield* VersionOperationsService;
+        return yield* versionOps.freezeAndCloneVersion({
+          sourceVersionId: seeded.version.id,
+          repoId: seeded.course.id,
+          newVersionName: "",
+          sourceName: "v1.0.0",
+          sourceDescription: "First release",
+        });
+      })
+    );
+
+  const clipCountForVideo = async (videoId: string) =>
+    (
+      await testDb.query.clips.findMany({
+        where: eq(clipsTable.videoId, videoId),
+      })
+    ).length;
+
+  return { ...seeded, run, submit, clipCountForVideo };
+};
+
+const failureTagOfExit = (exit: Exit.Exit<unknown, unknown>) =>
+  Exit.isFailure(exit)
+    ? Exit.match(exit, {
+        onFailure: (cause) =>
+          (cause as any).error?._tag ??
+          JSON.stringify(cause, null, 2).match(/"_tag":\s*"(\w+)"/)?.[1],
+        onSuccess: () => "no-error",
+      })
+    : "no-error";
+
+describe("clips-during-publish race (#1403)", () => {
+  it("an OBS append whose detection straddles Submit fails terminally and strands no clip", async () => {
+    const { video, submit, clipCountForVideo } = await setup();
+    const before = await clipCountForVideo(video.id);
+
+    // The real race shape: OBS silence detection is slow, and the publish
+    // (Submit) lands while it runs. The adapter performs the Submit *inside*
+    // getLatestOBSVideoClips — after the handler's pre-flight resolution,
+    // before the insert.
+    const exit = await Effect.runPromiseExit(
+      handleClipServiceEvent(
+        testDb as any,
+        {
+          type: "append-from-obs",
+          input: {
+            videoId: video.id,
+            filePath: "C:\\rec\\session.mp4",
+            insertionPoint: { type: "start" },
+          },
+        },
+        {
+          getLatestOBSVideoClips: async () => {
+            await submit();
+            return {
+              clips: [
+                {
+                  inputVideo: "/mnt/c/rec/session.mp4",
+                  startTime: 0,
+                  endTime: 5,
+                },
+              ],
+            };
+          },
+        }
+      )
+    );
+
+    expect(failureTagOfExit(exit)).toBe("VersionNotDraftError");
+    // The frozen (now Pending) version's video gained no clip.
+    expect(await clipCountForVideo(video.id)).toBe(before);
+  });
+
+  it("a guarded handler write after Submit fails with VersionNotDraftError and inserts nothing", async () => {
+    const { video, submit, clipCountForVideo } = await setup();
+    await submit();
+    const before = await clipCountForVideo(video.id);
+
+    const exit = await Effect.runPromiseExit(
+      handleClipServiceEvent(
+        testDb as any,
+        {
+          type: "append-clips",
+          input: {
+            videoId: video.id,
+            insertionPoint: { type: "start" },
+            clips: [{ inputVideo: "x.mp4", startTime: 0, endTime: 1 }],
+          },
+        },
+        { getLatestOBSVideoClips: async () => ({ clips: [] }) }
+      )
+    );
+
+    expect(failureTagOfExit(exit)).toBe("VersionNotDraftError");
+    expect(await clipCountForVideo(video.id)).toBe(before);
+  });
+
+  // The same-transaction guarantee itself is structural (transactionalizeWrites
+  // re-instantiates the ops factory with the transaction handle), so these two
+  // assert the SQL the mechanism depends on: the version-row FOR UPDATE is
+  // emitted, and on the right side of the write / the clone.
+  it("the draft-guard takes FOR UPDATE on the version row before the clip insert", async () => {
+    const { video } = await setup();
+
+    // A second drizzle handle over the same PGlite, with a query logger:
+    // the mechanism assertion is on the emitted SQL, not on timing.
+    const queries: string[] = [];
+    const loggedDb = drizzle(pglite, {
+      schema,
+      logger: { logQuery: (q) => queries.push(q.toLowerCase()) },
+    });
+
+    await Effect.runPromise(
+      createClipOperations(loggedDb as any).appendClips({
+        videoId: video.id,
+        insertionPoint: { type: "start" },
+        clips: [{ inputVideo: "y.mp4", startTime: 0, endTime: 2 }],
+      }) as Effect.Effect<unknown, never, never>
+    );
+
+    const idxLock = queries.findIndex(
+      (q) => q.includes(`course_version"`) && q.includes("for update")
+    );
+    const idxInsert = queries.findIndex(
+      (q) => q.startsWith("insert") && q.includes(`_clip"`)
+    );
+    expect(idxLock).toBeGreaterThanOrEqual(0);
+    expect(idxInsert).toBeGreaterThan(idxLock);
+  });
+
+  it("Submit locks the version row FOR UPDATE before cloning", async () => {
+    const { course, version } = await setup();
+
+    const queries: string[] = [];
+    const loggedDb = drizzle(pglite, {
+      schema,
+      logger: { logQuery: (q) => queries.push(q.toLowerCase()) },
+    });
+    const runLogged = makeRunner(loggedDb as any);
+
+    await runLogged(
+      Effect.gen(function* () {
+        const versionOps = yield* VersionOperationsService;
+        return yield* versionOps.freezeAndCloneVersion({
+          sourceVersionId: version.id,
+          repoId: course.id,
+          newVersionName: "",
+          sourceName: "v1.0.0",
+          sourceDescription: "First release",
+        });
+      })
+    );
+
+    const idxLock = queries.findIndex(
+      (q) => q.includes(`course_version"`) && q.includes("for update")
+    );
+    const idxCloneInsert = queries.findIndex(
+      (q) => q.startsWith("insert") && q.includes(`_section"`)
+    );
+    expect(idxLock).toBeGreaterThanOrEqual(0);
+    expect(idxCloneInsert).toBeGreaterThan(idxLock);
+  });
+});

--- a/app/services/db-clip-operations.server.ts
+++ b/app/services/db-clip-operations.server.ts
@@ -16,6 +16,7 @@ import {
   requireDraftVersionForClipWebLink,
   requireDraftVersionForVideo,
 } from "./draft-guard.server";
+import { transactionalizeWrites } from "./with-db-transaction.server";
 import { compareOrderStrings } from "@/lib/sort-by-order";
 
 const makeDbCall = <T>(fn: () => Promise<T>) => {
@@ -25,7 +26,7 @@ const makeDbCall = <T>(fn: () => Promise<T>) => {
   });
 };
 
-export const createClipOperations = (db: Database) => {
+const createClipOperationsUnwrapped = (db: Database) => {
   const getClipById = Effect.fn("getClipById")(function* (clipId: string) {
     const clip = yield* makeDbCall(() =>
       db.query.clips.findFirst({
@@ -731,6 +732,23 @@ export const createClipOperations = (db: Database) => {
     deleteClipWebLink,
   };
 };
+
+/** Each write runs in one txn with its draft-guard's version-row lock (#1403). */
+export const createClipOperations = (db: Database) =>
+  transactionalizeWrites(db, createClipOperationsUnwrapped, [
+    "updateClip",
+    "archiveClip",
+    "reorderClip",
+    "createChapter",
+    "createChapterAtInsertionPoint",
+    "createChapterAtPosition",
+    "updateChapter",
+    "archiveChapter",
+    "reorderChapter",
+    "appendClips",
+    "createClipWebLinks",
+    "deleteClipWebLink",
+  ]);
 
 export class ClipOperationsService extends Effect.Service<ClipOperationsService>()(
   "ClipOperationsService",

--- a/app/services/db-lesson-section-operations.server.ts
+++ b/app/services/db-lesson-section-operations.server.ts
@@ -19,6 +19,7 @@ import {
   requireDraftVersionForLesson,
   requireDraftVersionForSection,
 } from "./draft-guard.server";
+import { transactionalizeWrites } from "./with-db-transaction.server";
 
 const makeDbCall = <T>(fn: () => Promise<T>) => {
   return Effect.tryPromise({
@@ -40,7 +41,7 @@ const titleFromSectionPathWithNumber = (pathWithNumber: string): string =>
 const titleFromLessonPathWithNumber = (pathWithNumber: string): string =>
   parseLessonPath(pathWithNumber)?.slug ?? pathWithNumber;
 
-export const createLessonSectionOperations = (db: Database) => {
+const createLessonSectionOperationsUnwrapped = (db: Database) => {
   const getLessonById = Effect.fn("getLessonById")(function* (id: string) {
     const lesson = yield* makeDbCall(() =>
       db.query.lessons.findFirst({
@@ -485,6 +486,24 @@ export const createLessonSectionOperations = (db: Database) => {
     batchUpdateSectionOrders,
   };
 };
+
+/** Each write runs in one txn with its draft-guard's version-row lock (#1403). */
+export const createLessonSectionOperations = (db: Database) =>
+  transactionalizeWrites(db, createLessonSectionOperationsUnwrapped, [
+    "createSections",
+    "createLessons",
+    "createLesson",
+    "updateLesson",
+    "deleteLesson",
+    "deleteSection",
+    "archiveSection",
+    "updateSectionOrder",
+    "updateSectionTitle",
+    "updateSectionDescription",
+    "updateLessonOrder",
+    "batchUpdateLessonOrders",
+    "batchUpdateSectionOrders",
+  ]);
 
 export class LessonSectionOperationsService extends Effect.Service<LessonSectionOperationsService>()(
   "LessonSectionOperationsService",

--- a/app/services/db-service-errors.ts
+++ b/app/services/db-service-errors.ts
@@ -1,4 +1,5 @@
 import { Data } from "effect";
+import { VERSION_NOT_DRAFT_MESSAGE } from "./version-not-draft-message";
 
 export class NotFoundError extends Data.TaggedError("NotFoundError")<{
   type: string;
@@ -35,7 +36,13 @@ export class VersionNotDraftError extends Data.TaggedError(
 )<{
   versionId: string;
   commitState: string;
-}> {}
+}> {
+  // Serialized as the 409 body; browsers match on it to treat the failure as
+  // terminal (surface + force reload into the new Draft — issue #1403).
+  override get message() {
+    return VERSION_NOT_DRAFT_MESSAGE;
+  }
+}
 
 /**
  * Promote and Discard act only on a Pending Version — Promote marks it

--- a/app/services/db-version-mutation.server.ts
+++ b/app/services/db-version-mutation.server.ts
@@ -6,6 +6,7 @@ import {
   UnknownDBServiceError,
   VersionNotDraftError,
 } from "@/services/db-service-errors";
+import { requireDraftVersion } from "@/services/draft-guard.server";
 import { withDbTransaction } from "@/services/with-db-transaction.server";
 import { and, eq, sql } from "drizzle-orm";
 import { Effect } from "effect";
@@ -64,6 +65,11 @@ export const freezeAndCloneVersion = <A, E>(
   withDbTransaction(db, (transaction) =>
     Effect.gen(function* () {
       yield* lockCourseForVersionMutation(transaction, input.repoId);
+      // #1403: take the version-row lock that guarded writes contend on
+      // BEFORE cloning. A write committing after this point blocks on the row
+      // and re-reads commitState (→ VersionNotDraftError); one committing
+      // before it is visible to the clone. No clip can straddle the freeze.
+      yield* requireDraftVersion(transaction, input.sourceVersionId);
       const existingPending = yield* makeDbCall(() =>
         transaction.query.courseVersions.findFirst({
           where: and(

--- a/app/services/db-version-operations.server.ts
+++ b/app/services/db-version-operations.server.ts
@@ -27,6 +27,7 @@ import {
   projectVersionPaths,
   attachDerivedPaths,
 } from "@/services/path-projection";
+import { requireDraftVersion } from "@/services/draft-guard.server";
 import { withDbTransaction } from "@/services/with-db-transaction.server";
 import {
   freezeAndCloneVersion as freezeAndCloneVersionTransaction,
@@ -524,6 +525,9 @@ export const createVersionOperations = (db: Database) => {
   ) {
     return yield* withDbTransaction(db, (transaction) =>
       Effect.gen(function* () {
+        // #1403: hold the version-row lock guarded writes contend on while
+        // cloning, so no write can land on the source mid-freeze.
+        yield* requireDraftVersion(transaction, input.sourceVersionId);
         const result = yield* copyVersionStructureInDb(transaction, input);
         // Manual create-version freezes its source without a Dropbox commit:
         // the old Draft becomes an immutable `published` snapshot (that is what

--- a/app/services/db-video-operations.server.ts
+++ b/app/services/db-video-operations.server.ts
@@ -13,7 +13,11 @@ import {
 import { and, asc, desc, eq, isNull, ne } from "drizzle-orm";
 import { Effect } from "effect";
 import { copyVideoImpl } from "@/services/db-video-operations.copy.server";
-import { createVideoWriteOps } from "@/services/db-video-operations.write.server";
+import {
+  createVideoWriteOps,
+  videoWriteMethods,
+} from "@/services/db-video-operations.write.server";
+import { transactionalizeWrites } from "@/services/with-db-transaction.server";
 import type { VideoFormat } from "@/features/videos/video-format";
 import {
   requireDraftVersionForLesson,
@@ -27,12 +31,11 @@ const makeDbCall = <T>(fn: () => Promise<T>) => {
   });
 };
 
-export const createVideoOperations = (
-  db: Database,
-  deps: {
-    getCourseNavigationData: (id: string) => Effect.Effect<any, any>;
-  }
-) => {
+type VideoOpsDeps = {
+  getCourseNavigationData: (id: string) => Effect.Effect<any, any>;
+};
+
+const createVideoOperationsUnwrapped = (db: Database, deps: VideoOpsDeps) => {
   const { getCourseNavigationData } = deps;
 
   const assertVideoTitleAvailable = Effect.fn("assertVideoTitleAvailable")(
@@ -487,7 +490,6 @@ export const createVideoOperations = (
     if (!currentLesson) return null; // Standalone videos have no next/prev
     const repo = currentLesson.section.repoVersion.repo;
 
-    // Get all videos in current lesson sorted by title
     const videosInLesson = [...currentLesson.videos].sort((a, b) =>
       a.title.localeCompare(b.title)
     );
@@ -495,16 +497,13 @@ export const createVideoOperations = (
       (v) => v.id === currentVideo.id
     );
 
-    // Try next video in current lesson
     if (currentVideoIndex < videosInLesson.length - 1) {
       return videosInLesson[currentVideoIndex + 1]?.id ?? null;
     }
 
-    // Need to get all sections and lessons to find next
     const courseNav = yield* getCourseNavigationData(repo.id);
     const latestVersionSections = courseNav.versions[0]?.sections ?? [];
 
-    // Build a flat list of real lessons in order
     const allRealLessons = latestVersionSections.flatMap(
       (s: (typeof latestVersionSections)[number]) => s.lessons
     );
@@ -538,7 +537,6 @@ export const createVideoOperations = (
       if (!currentLesson) return null; // Standalone videos have no next/prev
       const repo = currentLesson.section.repoVersion.repo;
 
-      // Get all videos in current lesson sorted by title
       const videosInLesson = [...currentLesson.videos].sort((a, b) =>
         a.title.localeCompare(b.title)
       );
@@ -546,12 +544,10 @@ export const createVideoOperations = (
         (v) => v.id === currentVideo.id
       );
 
-      // Try previous video in current lesson
       if (currentVideoIndex > 0) {
         return videosInLesson[currentVideoIndex - 1]?.id ?? null;
       }
 
-      // Need to get all sections and lessons to find previous
       const courseNav = yield* getCourseNavigationData(repo.id);
       const latestVersionSections = courseNav.versions[0]?.sections ?? [];
 
@@ -563,7 +559,6 @@ export const createVideoOperations = (
         (l: (typeof allRealLessons)[number]) => l.id === currentLesson.id
       );
 
-      // Find previous real lesson with videos
       for (let i = currentIndex - 1; i >= 0; i--) {
         const prevLesson = allRealLessons[i]!;
         const videos = prevLesson.videos.sort(
@@ -749,6 +744,14 @@ export const createVideoOperations = (
     getVideosForFewShotExamples,
   };
 };
+
+/** Each write runs in one txn with its draft-guard's version-row lock (#1403). */
+export const createVideoOperations = (db: Database, deps: VideoOpsDeps) =>
+  transactionalizeWrites(
+    db,
+    (d) => createVideoOperationsUnwrapped(d, deps),
+    videoWriteMethods
+  );
 
 export class VideoOperationsService extends Effect.Service<VideoOperationsService>()(
   "VideoOperationsService",

--- a/app/services/db-video-operations.write.server.ts
+++ b/app/services/db-video-operations.write.server.ts
@@ -239,3 +239,24 @@ export const createVideoWriteOps = (db: Database) => {
     updateVideoFormat,
   };
 };
+
+/**
+ * The guarded Video write verbs (from both this file and
+ * db-video-operations.server.ts) that transactionalizeWrites wraps so guard +
+ * write share one transaction (issue #1403). Standalone-only writes
+ * (createStandaloneVideo, unlinkVideoFromPitch, updateVideoArchiveStatus)
+ * touch no CourseVersion and stay unwrapped.
+ */
+export const videoWriteMethods = [
+  "createVideo",
+  "updateVideo",
+  "deleteVideo",
+  "updateVideoTitle",
+  "copyVideo",
+  "updateVideoLesson",
+  "linkVideoToPitch",
+  "moveVideoToLesson",
+  "updateVideoBody",
+  "updateVideoDescription",
+  "updateVideoFormat",
+] as const;

--- a/app/services/draft-guard.server.ts
+++ b/app/services/draft-guard.server.ts
@@ -12,18 +12,26 @@ import {
   UnknownDBServiceError,
   VersionNotDraftError,
 } from "@/services/db-service-errors";
+import { withDbTransaction } from "@/services/with-db-transaction.server";
 import { eq } from "drizzle-orm";
 import { Effect } from "effect";
 import type { ClipServiceEvent } from "@/services/clip-service";
 
 /**
- * Write-closure guards for the CourseVersion lifecycle (issue #1348).
+ * Write-closure guards for the CourseVersion lifecycle (issues #1348/#1403).
  *
  * Only a Draft Version (`commitState === "draft"`) accepts section / lesson /
  * video / clip writes; Pending and Published Versions are immutable. Each DB
  * write entry point resolves its target's owning CourseVersion through one of
  * these guards and fails with a typed VersionNotDraftError when the version is
  * not a Draft.
+ *
+ * The commitState read is a `SELECT … FOR UPDATE` on the version row, held
+ * until the enclosing transaction commits — so a guard is only race-safe when
+ * it runs in the SAME transaction as the write it protects (see
+ * transactionalizeWrites / withClipServiceWriteClosure). Submit takes the same
+ * row lock before cloning, so check + write commit atomically on one side of
+ * the Draft → Pending transition, never straddling it.
  *
  * Resolution rules:
  * - A target that does not exist passes through — the write itself no-ops or
@@ -38,31 +46,35 @@ const makeDbCall = <T>(fn: () => Promise<T>) =>
     catch: (cause) => new UnknownDBServiceError({ cause }),
   });
 
-const assertDraft = (
-  version: { id: string; commitState: string } | null | undefined
-) =>
-  version && version.commitState !== "draft"
-    ? Effect.fail(
-        new VersionNotDraftError({
-          versionId: version.id,
-          commitState: version.commitState,
-        })
-      )
-    : Effect.void;
-
-/** Guard a write scoped directly to a CourseVersion id. */
-export const requireDraftVersion = Effect.fn("requireDraftVersion")(function* (
+/**
+ * Lock the version row FOR UPDATE and assert it is a Draft. A missing row
+ * passes through (see resolution rules above).
+ */
+const lockAndAssertDraft = Effect.fn("lockAndAssertDraft")(function* (
   db: Database,
   versionId: string
 ) {
-  const version = yield* makeDbCall(() =>
-    db.query.courseVersions.findFirst({
-      where: eq(courseVersions.id, versionId),
-      columns: { id: true, commitState: true },
-    })
+  const [version] = yield* makeDbCall(() =>
+    db
+      .select({
+        id: courseVersions.id,
+        commitState: courseVersions.commitState,
+      })
+      .from(courseVersions)
+      .where(eq(courseVersions.id, versionId))
+      .for("update")
   );
-  yield* assertDraft(version);
+  if (version && version.commitState !== "draft") {
+    return yield* new VersionNotDraftError({
+      versionId: version.id,
+      commitState: version.commitState,
+    });
+  }
 });
+
+/** Guard a write scoped directly to a CourseVersion id. */
+export const requireDraftVersion = (db: Database, versionId: string) =>
+  lockAndAssertDraft(db, versionId);
 
 /** Guard a write scoped to a Section. */
 export const requireDraftVersionForSection = Effect.fn(
@@ -71,11 +83,11 @@ export const requireDraftVersionForSection = Effect.fn(
   const section = yield* makeDbCall(() =>
     db.query.sections.findFirst({
       where: eq(sections.id, sectionId),
-      columns: { id: true },
-      with: { repoVersion: { columns: { id: true, commitState: true } } },
+      columns: { repoVersionId: true },
     })
   );
-  yield* assertDraft(section?.repoVersion);
+  if (!section) return;
+  yield* lockAndAssertDraft(db, section.repoVersionId);
 });
 
 /** Guard a write scoped to a Lesson. */
@@ -86,15 +98,11 @@ export const requireDraftVersionForLesson = Effect.fn(
     db.query.lessons.findFirst({
       where: eq(lessons.id, lessonId),
       columns: { id: true },
-      with: {
-        section: {
-          columns: { id: true },
-          with: { repoVersion: { columns: { id: true, commitState: true } } },
-        },
-      },
+      with: { section: { columns: { repoVersionId: true } } },
     })
   );
-  yield* assertDraft(lesson?.section?.repoVersion);
+  if (!lesson?.section) return;
+  yield* lockAndAssertDraft(db, lesson.section.repoVersionId);
 });
 
 /** Guard a write scoped to a Video (passes for standalone/pitch videos). */
@@ -108,19 +116,13 @@ export const requireDraftVersionForVideo = Effect.fn(
       with: {
         lesson: {
           columns: { id: true },
-          with: {
-            section: {
-              columns: { id: true },
-              with: {
-                repoVersion: { columns: { id: true, commitState: true } },
-              },
-            },
-          },
+          with: { section: { columns: { repoVersionId: true } } },
         },
       },
     })
   );
-  yield* assertDraft(video?.lesson?.section?.repoVersion);
+  if (!video?.lesson?.section) return;
+  yield* lockAndAssertDraft(db, video.lesson.section.repoVersionId);
 });
 
 /** Guard a write scoped to a Clip. */
@@ -151,6 +153,20 @@ export const requireDraftVersionForChapter = Effect.fn(
   yield* requireDraftVersionForVideo(db, chapter.videoId);
 });
 
+/** Guard a write scoped to a Clip web link. */
+export const requireDraftVersionForClipWebLink = Effect.fn(
+  "requireDraftVersionForClipWebLink"
+)(function* (db: Database, linkId: string) {
+  const link = yield* makeDbCall(() =>
+    db.query.clipWebLinks.findFirst({
+      where: eq(clipWebLinks.id, linkId),
+      columns: { id: true, clipId: true },
+    })
+  );
+  if (!link) return;
+  yield* requireDraftVersionForClip(db, link.clipId);
+});
+
 /**
  * Write-closure for the clip-service handler, which writes to the DB directly
  * instead of going through the guarded ops services: resolve a write event's
@@ -168,6 +184,10 @@ export const requireDraftForClipServiceEvent = Effect.fn(
     case "create-effect-clip-at-position":
     case "regenerate-chapters":
       return yield* requireDraftVersionForVideo(db, event.input.videoId);
+    case "create-video-from-selection":
+      // Copies always join the source video's lesson (and thus its version);
+      // move mode additionally archives the source clips.
+      return yield* requireDraftVersionForVideo(db, event.input.sourceVideoId);
     case "archive-clips":
     case "unarchive-clips":
       // A batch always targets one video; resolve via the first clip.
@@ -196,16 +216,29 @@ export const requireDraftForClipServiceEvent = Effect.fn(
   }
 });
 
-/** Guard a write scoped to a Clip web link. */
-export const requireDraftVersionForClipWebLink = Effect.fn(
-  "requireDraftVersionForClipWebLink"
-)(function* (db: Database, linkId: string) {
-  const link = yield* makeDbCall(() =>
-    db.query.clipWebLinks.findFirst({
-      where: eq(clipWebLinks.id, linkId),
-      columns: { id: true, clipId: true },
-    })
-  );
-  if (!link) return;
-  yield* requireDraftVersionForClip(db, link.clipId);
-});
+/**
+ * Guarded clip-service write events run inside one transaction: guard (with
+ * its version-row lock) + dispatch, committed atomically (issue #1403).
+ * Reads, standalone-video creation, and append-from-obs (which re-guards
+ * around its insert AFTER the slow OBS detection — see appendFromObsImpl)
+ * dispatch outside a transaction.
+ */
+export const withClipServiceWriteClosure = <A, E>(
+  db: Database,
+  event: ClipServiceEvent,
+  run: (db: Database) => Effect.Effect<A, E>
+): Effect.Effect<A, E | VersionNotDraftError | UnknownDBServiceError> => {
+  switch (event.type) {
+    case "create-video":
+    case "get-timeline":
+    case "append-from-obs":
+      return run(db);
+    default:
+      return withDbTransaction(db, (tx) =>
+        Effect.gen(function* () {
+          yield* requireDraftForClipServiceEvent(tx, event);
+          return yield* run(tx);
+        })
+      );
+  }
+};

--- a/app/services/version-not-draft-message.ts
+++ b/app/services/version-not-draft-message.ts
@@ -1,0 +1,11 @@
+/**
+ * The user-facing message carried by VersionNotDraftError (issue #1403).
+ *
+ * Shared between the server (db-service-errors sets it as the error's
+ * `message`, which route-action serializes as the 409 body) and the browser
+ * (clients match on it to tell the terminal "version was published while you
+ * were editing" 409 apart from other 409s, then surface it and force a reload
+ * into the new Draft).
+ */
+export const VERSION_NOT_DRAFT_MESSAGE =
+  "This version was published while you were editing — reload to continue in the new Draft.";

--- a/app/services/with-db-transaction.server.ts
+++ b/app/services/with-db-transaction.server.ts
@@ -1,9 +1,9 @@
-import type { DrizzleDB, Database } from "@/services/drizzle-service.server";
+import type { Database } from "@/services/drizzle-service.server";
 import { UnknownDBServiceError } from "@/services/db-service-errors";
 import { Cause, Effect, Exit } from "effect";
 
 export const withDbTransaction = <A, E>(
-  db: DrizzleDB,
+  db: Database,
   fn: (tx: Database) => Effect.Effect<A, E>
 ): Effect.Effect<A, E | UnknownDBServiceError> =>
   Effect.async<A, E | UnknownDBServiceError>((resume) => {
@@ -26,3 +26,32 @@ export const withDbTransaction = <A, E>(
         }
       });
   });
+
+/**
+ * Wraps the named write methods of an ops factory so that each call runs in
+ * its own transaction: the factory is re-instantiated with the transaction
+ * handle, so the method's draft-guard (SELECT … FOR UPDATE on the owning
+ * CourseVersion row) and its writes commit atomically. This closes the
+ * clips-during-publish race (issue #1403): a write serializes against
+ * Submit's version-row lock instead of check-then-writing around it.
+ * Read methods are returned untouched, bound to the original handle.
+ */
+export const transactionalizeWrites = <T extends object>(
+  db: Database,
+  factory: (db: Database) => T,
+  writeMethods: readonly (keyof T & string)[]
+): T => {
+  const ops = factory(db);
+  for (const name of writeMethods) {
+    const wrapped = (...args: unknown[]) =>
+      withDbTransaction(db, (tx) =>
+        (
+          factory(tx)[name] as unknown as (
+            ...a: unknown[]
+          ) => Effect.Effect<unknown, UnknownDBServiceError>
+        )(...args)
+      );
+    (ops as Record<string, unknown>)[name] = wrapped;
+  }
+  return ops;
+};


### PR DESCRIPTION
Closes #1403. Part of #1347. **Stacked on #1406** (targets `agent/issue-1402-commitstate-lifecycle`, since it builds directly on `commitState` + `VersionNotDraftError`).

Executes the design locked in #1349 that PR #1346 never landed: the merged code had only the courses-row `FOR UPDATE`, which serialized publish-vs-publish but let a mid-clone clip strand on the frozen version.

## What changed

**One transaction, one lock.** Every guarded write now runs its draft-guard check and its write in a single transaction, and the guard's commitState read is a `SELECT … FOR UPDATE` on the version row at the head of the `clip→video→lesson→section→version` chain (`draft-guard.server.ts`). Submit (`freezeAndCloneVersion`) and the manual `copyVersionStructure` path take the **same row lock before cloning** — so a racing write either commits before the clone (and is carried into the new Draft) or blocks, re-reads `pending`, and fails. A clip can never straddle the freeze.

**Uniform across all write types, without editing 30 method bodies:** `transactionalizeWrites` (in `with-db-transaction.server.ts`) wraps an ops factory's write methods by re-instantiating the factory with the transaction handle per call. Applied to clip, lesson-section, and video ops; standalone-only writes (`createStandaloneVideo`, `unlinkVideoFromPitch`, `updateVideoArchiveStatus`) stay unwrapped. The clip-service handler's direct writes dispatch inside one txn via `withClipServiceWriteClosure`; `create-video-from-selection` joined the guarded set.

**append-from-obs** (the original #1349 shape — slow OBS detection racing publish) keeps detection **outside** the lock, then re-guards around the dedup'd insert in the same transaction. The per-video mutex now round-trips an `Exit` so `VersionNotDraftError` stays a typed failure instead of a defect.

**Hard-fail, no lineage remap (client).** `VersionNotDraftError` carries a stable terminal message (shared `version-not-draft-message.ts` constant, serialized as the 409 body):
- clip-service transport surfaces the 409 body verbatim → the existing fatal overlay with its Refresh-reload button
- OBS session polling stops swallowing it and halts (previously it would silently retry against a frozen version forever)
- the course-editor 409 handler distinguishes it from divergence reports: toast + forced `window.location.reload()` into the new Draft

Re-appending after reload stays idempotent (content-keyed dedup, OBS footage persists) — no schema change to `clips`/`chapters`.

## Regression tests (independent of the Dropbox publish path)

`app/services/clips-race.test.ts` — "publish" is just Submit, the only step a write can race:
- **the real race, deterministically**: a `videoProcessing` adapter performs Submit *inside* OBS clip detection → the append fails `VersionNotDraftError` and strands nothing
- guarded handler write after Submit → typed failure, zero inserts
- SQL-capture (drizzle logger over PGlite): the version-row `FOR UPDATE` is emitted before the clip insert, and before Submit's clone inserts

Docs: CONTEXT.md's **Submit** entry and `cvm course publish` FAILURE HANDLING now state the serialization contract.

## Verification

- typecheck, lint:boundaries, file-token budget: clean
- full suite: 2342 passed; the only failures are the 20 pre-existing `segment`-noun tests that fail identically on clean main (unrelated, predate this stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)