### PR TITLE
Reconcile a crash-stranded Pending Version on publish-page load

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,7 +29,7 @@ The single mutable CourseVersion being edited — the only state accepting secti
 _Avoid_: Current version, Working version
 
 **Pending Version**:
-A Submitted CourseVersion whose Dropbox commit receipt has not yet landed. Immutable, named, short-lived: either Promoted (receipt landed) or Discarded (commit failed). At most one per course; one found at rest means a crash between receipt and Promote.
+A Submitted CourseVersion whose Dropbox commit receipt has not yet landed. Immutable, named, short-lived: either Promoted (receipt landed) or Discarded (commit failed). At most one per course; one at rest means a crash between receipt and Promote — the publish page reconciles it on load: Promote if the receipt committed, else one-click Discard.
 _Avoid_: Frozen version (ambiguous with Published), In-flight version
 
 **Published Version**:
@@ -37,7 +37,7 @@ An immutable CourseVersion with a name and description, created by Promoting a P
 _Avoid_: Released version, Committed version
 
 **Submit**:
-The Draft → Pending transition: stamps the publish name/description, marks the Draft Pending, and clones a fresh Draft. Refused while a Pending Version exists. In-flight writes serialize with it: each lands before the clone or is refused terminally — never stranded on the frozen version.
+The Draft → Pending transition: stamps the publish name/description, marks the Draft Pending, and clones a fresh Draft. Refused while a Pending Version exists. In-flight writes serialize with it: each lands before the clone or is refused terminally.
 _Avoid_: Freeze (only half the story), Snapshot
 
 **Promote**:
@@ -45,7 +45,7 @@ The Pending → Published transition, recorded once the Dropbox commit receipt (
 _Avoid_: Finalize, Confirm
 
 **Discard**:
-Deletes a Pending Version whose commit did not land — never a Draft or Published one. Loses nothing: the Submitted content lives on in the Draft that Submit cloned. A caught commit failure auto-Discards (sync failures get one in-flight retry first; missing assets Discard immediately).
+Deletes a Pending Version whose commit did not land — never a Draft or Published one. Loses nothing: the content lives on in the cloned Draft. A caught commit failure auto-Discards (sync failures get one in-flight retry first; missing assets Discard immediately).
 _Avoid_: Rollback, Delete version
 
 **Publish**:

--- a/app/cli/commands/course-publish.ts
+++ b/app/cli/commands/course-publish.ts
@@ -133,6 +133,10 @@ FAILURE HANDLING
   lands before the freeze (carried into the new Draft) or is refused with
   VersionNotDraftError (exit 3) — retry it against the new Draft.
 
+  A crash between the course.json rename and Promote strands the Pending
+  Version at rest; the web publish page reconciles it on load (Promote if the
+  receipt committed, else one-click Discard). No CLI recovery verb exists.
+
 FLAGS
   --name <vX.Y.Z>     (required) the Published Version name.
   --description <text> (required) description for the Published Version.

--- a/app/db/migrations/0006_one_pending_uniq.sql
+++ b/app/db/migrations/0006_one_pending_uniq.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "course_version_one_pending_uniq" ON "course-video-manager_course_version" USING btree ("course_id") WHERE "course-video-manager_course_version"."commit_state" = 'pending';

--- a/app/db/migrations/meta/0006_snapshot.json
+++ b/app/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1585 @@
+{
+  "id": "91dad6c5-623d-4e40-a905-17ffc6f37618",
+  "prevId": "a1728ab7-d99e-46fc-83a2-12509b5b7fd6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.course-video-manager_ai_hero_auth": {
+      "name": "course-video-manager_ai_hero_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_beat": {
+      "name": "course-video-manager_beat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'definition'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "order": {
+          "name": "order",
+          "type": "varchar(255) COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_beat_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_beat_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_beat",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": ["video_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_chapter": {
+      "name": "course-video-manager_chapter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "varchar(255) COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_chapter_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_chapter_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_chapter",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": ["video_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_clip_web_link": {
+      "name": "course-video-manager_clip_web_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clip_id": {
+          "name": "clip_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_clip_web_link_clip_id_course-video-manager_clip_id_fk": {
+          "name": "course-video-manager_clip_web_link_clip_id_course-video-manager_clip_id_fk",
+          "tableFrom": "course-video-manager_clip_web_link",
+          "tableTo": "course-video-manager_clip",
+          "columnsFrom": ["clip_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_clip": {
+      "name": "course-video-manager_clip",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video_filename": {
+          "name": "video_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_start_time": {
+          "name": "source_start_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_end_time": {
+          "name": "source_end_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order": {
+          "name": "order",
+          "type": "varchar(255) COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcribed_at": {
+          "name": "transcribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene": {
+          "name": "scene",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_type": {
+          "name": "pause_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "diagram_snapshot_id": {
+          "name": "diagram_snapshot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_clip_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_clip_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_clip",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": ["video_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course-video-manager_clip_diagram_snapshot_id_course-video-manager_diagram_snapshot_id_fk": {
+          "name": "course-video-manager_clip_diagram_snapshot_id_course-video-manager_diagram_snapshot_id_fk",
+          "tableFrom": "course-video-manager_clip",
+          "tableTo": "course-video-manager_diagram_snapshot",
+          "columnsFrom": ["diagram_snapshot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_course_version": {
+      "name": "course-video-manager_course_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "commit_state": {
+          "name": "commit_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "course_version_one_pending_uniq": {
+          "name": "course_version_one_pending_uniq",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course-video-manager_course_version\".\"commit_state\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_course_version_course_id_course-video-manager_course_id_fk": {
+          "name": "course-video-manager_course_version_course_id_course-video-manager_course_id_fk",
+          "tableFrom": "course-video-manager_course_version",
+          "tableTo": "course-video-manager_course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_course": {
+      "name": "course-video-manager_course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory": {
+          "name": "memory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "course_slug_uniq": {
+          "name": "course_slug_uniq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "NOT \"course-video-manager_course\".\"archived\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_deliverable": {
+      "name": "course-video-manager_deliverable",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_deliverable_course": {
+      "name": "course-video-manager_deliverable_course",
+      "schema": "",
+      "columns": {
+        "deliverable_id": {
+          "name": "deliverable_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_deliverable_course_deliverable_id_course-video-manager_deliverable_id_fk": {
+          "name": "course-video-manager_deliverable_course_deliverable_id_course-video-manager_deliverable_id_fk",
+          "tableFrom": "course-video-manager_deliverable_course",
+          "tableTo": "course-video-manager_deliverable",
+          "columnsFrom": ["deliverable_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course-video-manager_deliverable_course_course_id_course-video-manager_course_id_fk": {
+          "name": "course-video-manager_deliverable_course_course_id_course-video-manager_course_id_fk",
+          "tableFrom": "course-video-manager_deliverable_course",
+          "tableTo": "course-video-manager_course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course-video-manager_deliverable_course_deliverable_id_course_id_pk": {
+          "name": "course-video-manager_deliverable_course_deliverable_id_course_id_pk",
+          "columns": ["deliverable_id", "course_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_deliverable_pitch": {
+      "name": "course-video-manager_deliverable_pitch",
+      "schema": "",
+      "columns": {
+        "deliverable_id": {
+          "name": "deliverable_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pitch_id": {
+          "name": "pitch_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_deliverable_pitch_deliverable_id_course-video-manager_deliverable_id_fk": {
+          "name": "course-video-manager_deliverable_pitch_deliverable_id_course-video-manager_deliverable_id_fk",
+          "tableFrom": "course-video-manager_deliverable_pitch",
+          "tableTo": "course-video-manager_deliverable",
+          "columnsFrom": ["deliverable_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course-video-manager_deliverable_pitch_pitch_id_course-video-manager_pitch_id_fk": {
+          "name": "course-video-manager_deliverable_pitch_pitch_id_course-video-manager_pitch_id_fk",
+          "tableFrom": "course-video-manager_deliverable_pitch",
+          "tableTo": "course-video-manager_pitch",
+          "columnsFrom": ["pitch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course-video-manager_deliverable_pitch_deliverable_id_pitch_id_pk": {
+          "name": "course-video-manager_deliverable_pitch_deliverable_id_pitch_id_pk",
+          "columns": ["deliverable_id", "pitch_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_diagram_snapshot": {
+      "name": "course-video-manager_diagram_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "diagram_id": {
+          "name": "diagram_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene": {
+          "name": "scene",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preserved": {
+          "name": "preserved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(search_text, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "diagram_snapshot_diagram_id_content_hash_idx": {
+          "name": "diagram_snapshot_diagram_id_content_hash_idx",
+          "columns": [
+            {
+              "expression": "diagram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diagram_snapshot_search_vector_idx": {
+          "name": "diagram_snapshot_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_diagram_snapshot_diagram_id_course-video-manager_diagram_id_fk": {
+          "name": "course-video-manager_diagram_snapshot_diagram_id_course-video-manager_diagram_id_fk",
+          "tableFrom": "course-video-manager_diagram_snapshot",
+          "tableTo": "course-video-manager_diagram",
+          "columnsFrom": ["diagram_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_diagram": {
+      "name": "course-video-manager_diagram",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled 1'"
+        },
+        "head_scene": {
+          "name": "head_scene",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(search_text, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "diagram_search_vector_idx": {
+          "name": "diagram_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_lesson": {
+      "name": "course-video-manager_lesson",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_version_lesson_id": {
+          "name": "previous_version_lesson_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authoring_status": {
+          "name": "authoring_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order": {
+          "name": "order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "lesson_section_order_uniq": {
+          "name": "lesson_section_order_uniq",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "NOT \"course-video-manager_lesson\".\"archived\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_lesson_section_id_course-video-manager_section_id_fk": {
+          "name": "course-video-manager_lesson_section_id_course-video-manager_section_id_fk",
+          "tableFrom": "course-video-manager_lesson",
+          "tableTo": "course-video-manager_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_link": {
+      "name": "course-video-manager_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "course-video-manager_link_url_unique": {
+          "name": "course-video-manager_link_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_pitch": {
+      "name": "course-video-manager_pitch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_plan": {
+          "name": "content_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "youtube_title": {
+          "name": "youtube_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "youtube_thumbnail_description": {
+          "name": "youtube_thumbnail_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "newsletter_title": {
+          "name": "newsletter_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tweet": {
+          "name": "tweet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "effort": {
+          "name": "effort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_section": {
+      "name": "course-video-manager_section",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_version_id": {
+          "name": "course_version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_version_section_id": {
+          "name": "previous_version_section_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order": {
+          "name": "order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "section_version_order_uniq": {
+          "name": "section_version_order_uniq",
+          "columns": [
+            {
+              "expression": "course_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course-video-manager_section\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_section_course_version_id_course-video-manager_course_version_id_fk": {
+          "name": "course-video-manager_section_course_version_id_course-video-manager_course_version_id_fk",
+          "tableFrom": "course-video-manager_section",
+          "tableTo": "course-video-manager_course_version",
+          "columnsFrom": ["course_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_thumbnail": {
+      "name": "course-video-manager_thumbnail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layers": {
+          "name": "layers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_for_upload": {
+          "name": "selected_for_upload",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_thumbnail_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_thumbnail_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_thumbnail",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": ["video_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_video_post": {
+      "name": "course-video-manager_video_post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_video_post_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_video_post_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_video_post",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": ["video_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_video": {
+      "name": "course-video-manager_video",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pitch_id": {
+          "name": "pitch_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_footage_path": {
+          "name": "original_footage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_description": {
+          "name": "video_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'landscape'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "video_lesson_title_uniq": {
+          "name": "video_lesson_title_uniq",
+          "columns": [
+            {
+              "expression": "lesson_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "NOT \"course-video-manager_video\".\"archived\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_video_lesson_id_course-video-manager_lesson_id_fk": {
+          "name": "course-video-manager_video_lesson_id_course-video-manager_lesson_id_fk",
+          "tableFrom": "course-video-manager_video",
+          "tableTo": "course-video-manager_lesson",
+          "columnsFrom": ["lesson_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course-video-manager_video_pitch_id_course-video-manager_pitch_id_fk": {
+          "name": "course-video-manager_video_pitch_id_course-video-manager_pitch_id_fk",
+          "tableFrom": "course-video-manager_video",
+          "tableTo": "course-video-manager_pitch",
+          "columnsFrom": ["pitch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_youtube_auth": {
+      "name": "course-video-manager_youtube_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/db/migrations/meta/_journal.json
+++ b/app/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1784733343653,
       "tag": "0005_commit_state",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1784797202206,
+      "tag": "0006_one_pending_uniq",
+      "breakpoints": true
     }
   ]
 }

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -74,27 +74,37 @@ export const courses = createTable(
  */
 export type CourseVersionCommitState = "draft" | "pending" | "published";
 
-export const courseVersions = createTable("course_version", {
-  id: varchar("id", { length: 255 })
-    .notNull()
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  repoId: varchar("course_id", { length: 255 })
-    .references(() => courses.id, { onDelete: "cascade" })
-    .notNull(),
-  name: text("name").notNull(),
-  description: text("description").notNull().default(""),
-  commitState: text("commit_state")
-    .$type<CourseVersionCommitState>()
-    .notNull()
-    .default("draft"),
-  createdAt: timestamp("created_at", {
-    mode: "date",
-    withTimezone: true,
-  })
-    .notNull()
-    .default(sql`CURRENT_TIMESTAMP`),
-});
+export const courseVersions = createTable(
+  "course_version",
+  {
+    id: varchar("id", { length: 255 })
+      .notNull()
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    repoId: varchar("course_id", { length: 255 })
+      .references(() => courses.id, { onDelete: "cascade" })
+      .notNull(),
+    name: text("name").notNull(),
+    description: text("description").notNull().default(""),
+    commitState: text("commit_state")
+      .$type<CourseVersionCommitState>()
+      .notNull()
+      .default("draft"),
+    createdAt: timestamp("created_at", {
+      mode: "date",
+      withTimezone: true,
+    })
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => [
+    // At most one Pending Version per course (issue #1348) — Submit checks
+    // this in-transaction; the partial index makes the DB authoritative.
+    uniqueIndex("course_version_one_pending_uniq")
+      .on(table.repoId)
+      .where(sql`${table.commitState} = 'pending'`),
+  ]
+);
 
 export const sections = createTable(
   "section",

--- a/app/features/course-view/use-optimistic-course.ts
+++ b/app/features/course-view/use-optimistic-course.ts
@@ -3,7 +3,10 @@ import { useFetchers } from "react-router";
 import { toast } from "sonner";
 import type { CourseEditorEvent } from "@/services/course-editor-service";
 import type { LoaderData } from "./course-view-types";
-import { VERSION_NOT_DRAFT_MESSAGE } from "@/services/version-not-draft-message";
+import {
+  parse409Message,
+  VERSION_NOT_DRAFT_MESSAGE,
+} from "@/services/version-not-draft-message";
 import {
   applyOptimisticEvent,
   applyOptimisticDeleteVideo,
@@ -72,13 +75,7 @@ export function useCourseEditorFailureToast() {
             .clone()
             .text()
             .then((body) => {
-              let message = body;
-              try {
-                const parsed = JSON.parse(body);
-                if (typeof parsed === "string") message = parsed;
-              } catch {
-                // keep raw body
-              }
+              const message = parse409Message(body);
               // Terminal (#1403): the Draft was Submitted while this change
               // was in flight. Surface it and force a reload into the new
               // Draft — the write can never succeed against this version.

--- a/app/routes/_app.courses.$courseId.publish.tsx
+++ b/app/routes/_app.courses.$courseId.publish.tsx
@@ -16,11 +16,22 @@ import { VIDEO_WARNING_LABELS } from "@/features/course-view/video-warning-label
 import { CoursePublishService } from "@/services/course-publish-service";
 import { CourseOperationsService } from "@/services/db-course-operations.server";
 import { VersionOperationsService } from "@/services/db-version-operations.server";
-import { makeLoader } from "@/services/route-action.server";
+import {
+  classifyPendingRecovery,
+  type PendingRecovery,
+} from "@/services/pending-recovery.server";
+import { makeAction, makeLoader } from "@/services/route-action.server";
 import { Effect } from "effect";
 import { ArrowLeft, AlertTriangle, ChevronRight } from "lucide-react";
-import { useCallback, useContext, useMemo, useState } from "react";
-import { data, Link, useNavigate } from "react-router";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { data, Link, useFetcher, useNavigate } from "react-router";
 import type { Route } from "./+types/_app.courses.$courseId.publish";
 
 export const loader = makeLoader({
@@ -53,9 +64,18 @@ export const loader = makeLoader({
       const { withTodo, withoutTodo } =
         yield* publishService.validatePublishability(latestVersion.id);
 
+      // Reconcile-on-load (#1404): detect a crash-stranded Pending Version and
+      // classify it against the Dropbox course.json receipt. Read-only — the
+      // Promote / Discard transitions run in this route's action.
+      const pendingRecovery = yield* classifyPendingRecovery({
+        courseId: params.courseId!,
+        courseName: course.name,
+      });
+
       const { sections: _, ...latestVersionMeta } = latestVersion;
       return {
         course,
+        pendingRecovery,
         latestVersion: latestVersionMeta,
         previousVersionName: previousVersion?.name ?? null,
         withTodo: {
@@ -74,9 +94,45 @@ export const loader = makeLoader({
     }),
 });
 
+/**
+ * The Promote / Discard transitions for a crash-stranded Pending Version
+ * (#1404). Both lifecycle verbs act only on a `pending` row (compare-and-set
+ * in the DB), so a stale banner or double-click cannot touch a Draft or
+ * Published Version — it just gets a 409.
+ */
+export const action = makeAction({
+  input: "formData",
+  errors: { VersionNotPendingError: 409 },
+  effect: ({ payload }) =>
+    Effect.gen(function* () {
+      const { intent, versionId } = payload as {
+        intent?: unknown;
+        versionId?: unknown;
+      };
+      if (typeof versionId !== "string" || versionId === "") {
+        return yield* Effect.die(data("Missing versionId", { status: 400 }));
+      }
+      const versionOps = yield* VersionOperationsService;
+      if (intent === "promote-pending") {
+        const promoted = yield* versionOps.promotePendingVersion(versionId);
+        return { promotedVersionId: promoted.id };
+      }
+      if (intent === "discard-pending") {
+        const discarded = yield* versionOps.discardPendingVersion(versionId);
+        return { discardedVersionId: discarded.id };
+      }
+      return yield* Effect.die(data("Unknown intent", { status: 400 }));
+    }),
+});
+
 export default function Component(props: Route.ComponentProps) {
-  const { course, previousVersionName, withTodo, withoutTodo } =
-    props.loaderData;
+  const {
+    course,
+    pendingRecovery,
+    previousVersionName,
+    withTodo,
+    withoutTodo,
+  } = props.loaderData;
   const navigate = useNavigate();
   const { uploads, startPublish } = useContext(UploadContext);
 
@@ -129,7 +185,10 @@ export default function Component(props: Route.ComponentProps) {
     !hasInvalidLessonCombos &&
     !hasIncompleteVideos &&
     !publishStarted &&
-    !isOperationInProgress;
+    !isOperationInProgress &&
+    // A stranded Pending Version blocks publishing until reconciled — a second
+    // Submit would collide with the at-most-one-pending invariant anyway.
+    pendingRecovery === null;
 
   const handlePublish = useCallback(() => {
     setPublishStarted(true);
@@ -165,6 +224,14 @@ export default function Component(props: Route.ComponentProps) {
         </div>
 
         <h1 className="text-2xl font-bold mb-2">Publish {course.name}</h1>
+
+        {/* Reconcile-on-load banner (#1404). Suppressed while a publish from
+            this client is live — its Pending Version is in flight, not
+            stranded, and the publish process will Promote or Discard itself. */}
+        {!hasActivePublish && (
+          <PendingRecoveryBanner recovery={pendingRecovery} />
+        )}
+
         {previousVersionName && (
           <p className="text-sm text-muted-foreground mb-6">
             {previousVersionName} <ChevronRight className="inline w-3 h-3" />{" "}
@@ -364,6 +431,86 @@ export default function Component(props: Route.ComponentProps) {
           </Button>
         </div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * The durable recovery surface for a crash-stranded Pending Version (#1404).
+ * Receipt committed → the publish is already live externally, so Promote is
+ * auto-submitted on render (never discard a committed version) and the banner
+ * confirms recovery. Receipt absent → one-click Discard; the operator's edits
+ * are safe in the current Draft and they republish normally.
+ */
+function PendingRecoveryBanner({
+  recovery,
+}: {
+  recovery: PendingRecovery | null;
+}) {
+  const fetcher = useFetcher();
+  const promoteSubmitted = useRef(false);
+  // Held locally so the "recovered ✓" confirmation survives the revalidation
+  // that clears `recovery` after the Promote lands.
+  const [recoveredName, setRecoveredName] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (recovery?.receiptCommitted && !promoteSubmitted.current) {
+      promoteSubmitted.current = true;
+      setRecoveredName(recovery.versionName);
+      fetcher.submit(
+        { intent: "promote-pending", versionId: recovery.versionId },
+        { method: "post" }
+      );
+    }
+  }, [recovery, fetcher]);
+
+  if (recoveredName !== null) {
+    const done = fetcher.state === "idle" && fetcher.data !== undefined;
+    return (
+      <div className="mb-8 rounded-lg border border-green-500/30 bg-green-500/5 p-4 text-sm">
+        <span className="font-medium text-green-500">
+          {done
+            ? `Publish finished — recovered ✓ ${recoveredName} is live.`
+            : `Finalizing your interrupted publish of ${recoveredName}…`}
+        </span>
+        <p className="text-muted-foreground mt-1">
+          The last publish committed to Dropbox but was interrupted before it
+          was recorded here.{" "}
+          {done ? "It is now marked Published." : "Marking it Published…"}
+        </p>
+      </div>
+    );
+  }
+
+  if (!recovery) return null;
+
+  return (
+    <div className="mb-8 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <AlertTriangle className="w-5 h-5 text-amber-500" />
+        <span className="text-sm font-medium text-amber-500">
+          Your last publish ({recovery.versionName}) didn&apos;t finish
+        </span>
+      </div>
+      <p className="text-sm text-muted-foreground mb-3">
+        It was interrupted before anything reached Dropbox. Nothing is lost —
+        your edits are safe in the current draft. Discard the unfinished
+        version, then publish again normally.
+      </p>
+      <fetcher.Form method="post">
+        <input type="hidden" name="intent" value="discard-pending" />
+        <input type="hidden" name="versionId" value={recovery.versionId} />
+        <Button
+          type="submit"
+          variant="outline"
+          size="sm"
+          disabled={fetcher.state !== "idle"}
+        >
+          {fetcher.state !== "idle"
+            ? "Discarding…"
+            : "Discard unfinished publish"}
+        </Button>
+      </fetcher.Form>
     </div>
   );
 }

--- a/app/routes/_app.courses.$courseId.publish.tsx
+++ b/app/routes/_app.courses.$courseId.publish.tsx
@@ -454,7 +454,7 @@ function PendingRecoveryBanner({
   const [recoveredName, setRecoveredName] = useState<string | null>(null);
 
   useEffect(() => {
-    if (recovery?.receiptCommitted && !promoteSubmitted.current) {
+    if (recovery?.receiptState === "committed" && !promoteSubmitted.current) {
       promoteSubmitted.current = true;
       setRecoveredName(recovery.versionName);
       fetcher.submit(
@@ -465,7 +465,12 @@ function PendingRecoveryBanner({
   }, [recovery, fetcher]);
 
   if (recoveredName !== null) {
-    const done = fetcher.state === "idle" && fetcher.data !== undefined;
+    // Recovered only once the Promote actually landed — an errored action
+    // must not read as success.
+    const done =
+      fetcher.state === "idle" &&
+      (fetcher.data as { promotedVersionId?: string } | undefined)
+        ?.promotedVersionId !== undefined;
     return (
       <div className="mb-8 rounded-lg border border-green-500/30 bg-green-500/5 p-4 text-sm">
         <span className="font-medium text-green-500">
@@ -484,6 +489,26 @@ function PendingRecoveryBanner({
 
   if (!recovery) return null;
 
+  if (recovery.receiptState === "unreadable") {
+    // Never offer Discard on a receipt we could not read — the mount may be
+    // down while the receipt (and a committed publish) actually exists.
+    return (
+      <div className="mb-8 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <AlertTriangle className="w-5 h-5 text-amber-500" />
+          <span className="text-sm font-medium text-amber-500">
+            An interrupted publish ({recovery.versionName}) needs recovery
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          The Dropbox commit receipt (course.json) couldn&apos;t be read, so it
+          is unknown whether that publish committed. Check the Dropbox mount and
+          reload this page.
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="mb-8 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4">
       <div className="flex items-center gap-2 mb-2">
@@ -493,9 +518,10 @@ function PendingRecoveryBanner({
         </span>
       </div>
       <p className="text-sm text-muted-foreground mb-3">
-        It was interrupted before anything reached Dropbox. Nothing is lost —
-        your edits are safe in the current draft. Discard the unfinished
-        version, then publish again normally.
+        It never committed — the course.json receipt was never written, so
+        consumers still see the previous release. Your edits are safe in the
+        current draft. Discard the unfinished version, then publish again
+        normally.
       </p>
       <fetcher.Form method="post">
         <input type="hidden" name="intent" value="discard-pending" />

--- a/app/routes/api.courses.$courseId.publish-sse.ts
+++ b/app/routes/api.courses.$courseId.publish-sse.ts
@@ -68,15 +68,16 @@ export const action = async (args: Route.ActionArgs) => {
         // The Submitted content lives on unchanged in the new Draft.
         tag: "PublishCommitFailedError",
         handler: (e, sendEvent) => {
+          // #1401: name the missing Videos — the client surfaces only
+          // `message`, so the ids must ride in the text itself.
+          const missing = e.missingVideoIds ?? [];
           const message =
             e.reason === "missing_assets"
-              ? `Publish discarded: ${
-                  e.missingVideoIds?.length ?? 0
-                } video file(s) were missing from the export directory. Nothing was lost — your edits are safe in the Draft. Re-export and publish again`
+              ? `Publish discarded: ${missing.length} video file(s) were missing from the export directory (${missing.join(", ")}). Nothing was lost — your edits are safe in the Draft. Re-export and publish again`
               : "Publish discarded: the Dropbox commit failed (after one retry). Nothing was lost — your edits are safe in the Draft. Publish again when Dropbox is reachable";
           sendEvent("error", {
             message,
-            missingVideoIds: e.missingVideoIds ?? [],
+            missingVideoIds: missing,
           });
         },
       },

--- a/app/services/clip-service.ts
+++ b/app/services/clip-service.ts
@@ -12,6 +12,7 @@
 
 import type { InferSelectModel } from "drizzle-orm";
 import type { clips, chapters, videos } from "@/db/schema";
+import { parse409Message } from "@/services/version-not-draft-message";
 import type { SilenceLength } from "@/silence-detection-constants";
 // ============================================================================
 // Database Types
@@ -575,14 +576,7 @@ export function createHttpClipService(): ClipService {
       // terminal "reload into the new Draft" message, #1403) — surface it
       // verbatim so the error overlay reads as guidance, not a status dump.
       if (response.status === 409) {
-        let message = text;
-        try {
-          const parsed = JSON.parse(text);
-          if (typeof parsed === "string") message = parsed;
-        } catch {
-          // keep raw text
-        }
-        throw new Error(message);
+        throw new Error(parse409Message(text));
       }
       throw new Error(`ClipService request failed: ${response.status} ${text}`);
     }

--- a/app/services/db-lesson-section-operations.server.ts
+++ b/app/services/db-lesson-section-operations.server.ts
@@ -17,7 +17,9 @@ import { parseSectionPath } from "./section-path-service";
 import {
   requireDraftVersion,
   requireDraftVersionForLesson,
+  requireDraftVersionForLessons,
   requireDraftVersionForSection,
+  requireDraftVersionForSections,
 } from "./draft-guard.server";
 import { transactionalizeWrites } from "./with-db-transaction.server";
 
@@ -397,8 +399,9 @@ const createLessonSectionOperationsUnwrapped = (db: Database) => {
     function* (updates: { id: string; order: number }[]) {
       if (updates.length === 0) return;
       const ids = updates.map((u) => u.id);
-      // All rows in one batch belong to the same version; guard via the first.
-      yield* requireDraftVersionForLesson(db, ids[0]!);
+      // Guard every distinct owning version — a mixed-version batch must not
+      // slip past a first-element check.
+      yield* requireDraftVersionForLessons(db, ids);
 
       yield* makeDbCall(() =>
         db
@@ -437,8 +440,9 @@ const createLessonSectionOperationsUnwrapped = (db: Database) => {
     function* (updates: { id: string; order: number }[]) {
       if (updates.length === 0) return;
       const ids = updates.map((u) => u.id);
-      // All rows in one batch belong to the same version; guard via the first.
-      yield* requireDraftVersionForSection(db, ids[0]!);
+      // Guard every distinct owning version — a mixed-version batch must not
+      // slip past a first-element check.
+      yield* requireDraftVersionForSections(db, ids);
 
       yield* makeDbCall(() =>
         db

--- a/app/services/draft-guard.server.ts
+++ b/app/services/draft-guard.server.ts
@@ -13,7 +13,7 @@ import {
   VersionNotDraftError,
 } from "@/services/db-service-errors";
 import { withDbTransaction } from "@/services/with-db-transaction.server";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { Effect } from "effect";
 import type { ClipServiceEvent } from "@/services/clip-service";
 
@@ -90,6 +90,26 @@ export const requireDraftVersionForSection = Effect.fn(
   yield* lockAndAssertDraft(db, section.repoVersionId);
 });
 
+/**
+ * Guard a batch write scoped to Sections: every DISTINCT owning version is
+ * locked and asserted, so a mixed-version batch cannot slip a non-Draft
+ * write past a first-element-only check.
+ */
+export const requireDraftVersionForSections = Effect.fn(
+  "requireDraftVersionForSections"
+)(function* (db: Database, sectionIds: readonly string[]) {
+  if (sectionIds.length === 0) return;
+  const rows = yield* makeDbCall(() =>
+    db.query.sections.findMany({
+      where: inArray(sections.id, sectionIds),
+      columns: { repoVersionId: true },
+    })
+  );
+  for (const versionId of new Set(rows.map((r) => r.repoVersionId))) {
+    yield* lockAndAssertDraft(db, versionId);
+  }
+});
+
 /** Guard a write scoped to a Lesson. */
 export const requireDraftVersionForLesson = Effect.fn(
   "requireDraftVersionForLesson"
@@ -103,6 +123,26 @@ export const requireDraftVersionForLesson = Effect.fn(
   );
   if (!lesson?.section) return;
   yield* lockAndAssertDraft(db, lesson.section.repoVersionId);
+});
+
+/** Guard a batch write scoped to Lessons: every distinct owning version. */
+export const requireDraftVersionForLessons = Effect.fn(
+  "requireDraftVersionForLessons"
+)(function* (db: Database, lessonIds: readonly string[]) {
+  if (lessonIds.length === 0) return;
+  const rows = yield* makeDbCall(() =>
+    db.query.lessons.findMany({
+      where: inArray(lessons.id, lessonIds),
+      columns: { id: true },
+      with: { section: { columns: { repoVersionId: true } } },
+    })
+  );
+  const versionIds = new Set(
+    rows.flatMap((r) => (r.section ? [r.section.repoVersionId] : []))
+  );
+  for (const versionId of versionIds) {
+    yield* lockAndAssertDraft(db, versionId);
+  }
 });
 
 /** Guard a write scoped to a Video (passes for standalone/pitch videos). */
@@ -139,6 +179,22 @@ export const requireDraftVersionForClip = Effect.fn(
   yield* requireDraftVersionForVideo(db, clip.videoId);
 });
 
+/** Guard a batch write scoped to Clips: every distinct owning video. */
+export const requireDraftVersionForClips = Effect.fn(
+  "requireDraftVersionForClips"
+)(function* (db: Database, clipIds: readonly string[]) {
+  if (clipIds.length === 0) return;
+  const rows = yield* makeDbCall(() =>
+    db.query.clips.findMany({
+      where: inArray(clips.id, clipIds),
+      columns: { videoId: true },
+    })
+  );
+  for (const videoId of new Set(rows.map((r) => r.videoId))) {
+    yield* requireDraftVersionForVideo(db, videoId);
+  }
+});
+
 /** Guard a write scoped to a Chapter. */
 export const requireDraftVersionForChapter = Effect.fn(
   "requireDraftVersionForChapter"
@@ -151,6 +207,22 @@ export const requireDraftVersionForChapter = Effect.fn(
   );
   if (!chapter) return;
   yield* requireDraftVersionForVideo(db, chapter.videoId);
+});
+
+/** Guard a batch write scoped to Chapters: every distinct owning video. */
+export const requireDraftVersionForChapters = Effect.fn(
+  "requireDraftVersionForChapters"
+)(function* (db: Database, chapterIds: readonly string[]) {
+  if (chapterIds.length === 0) return;
+  const rows = yield* makeDbCall(() =>
+    db.query.chapters.findMany({
+      where: inArray(chapters.id, chapterIds),
+      columns: { videoId: true },
+    })
+  );
+  for (const videoId of new Set(rows.map((r) => r.videoId))) {
+    yield* requireDraftVersionForVideo(db, videoId);
+  }
 });
 
 /** Guard a write scoped to a Clip web link. */
@@ -190,16 +262,14 @@ export const requireDraftForClipServiceEvent = Effect.fn(
       return yield* requireDraftVersionForVideo(db, event.input.sourceVideoId);
     case "archive-clips":
     case "unarchive-clips":
-      // A batch always targets one video; resolve via the first clip.
-      if (event.clipIds[0]) {
-        return yield* requireDraftVersionForClip(db, event.clipIds[0]);
-      }
-      return;
+      // Guard every distinct owning video — a mixed-version batch must not
+      // slip past a first-element check (in practice a batch targets one).
+      return yield* requireDraftVersionForClips(db, event.clipIds);
     case "update-clips":
-      if (event.clips[0]) {
-        return yield* requireDraftVersionForClip(db, event.clips[0].id);
-      }
-      return;
+      return yield* requireDraftVersionForClips(
+        db,
+        event.clips.map((c) => c.id)
+      );
     case "update-pause":
     case "reorder-clip":
       return yield* requireDraftVersionForClip(db, event.clipId);
@@ -207,10 +277,7 @@ export const requireDraftForClipServiceEvent = Effect.fn(
     case "reorder-chapter":
       return yield* requireDraftVersionForChapter(db, event.chapterId);
     case "archive-chapters":
-      if (event.chapterIds[0]) {
-        return yield* requireDraftVersionForChapter(db, event.chapterIds[0]);
-      }
-      return;
+      return yield* requireDraftVersionForChapters(db, event.chapterIds);
     default:
       return;
   }

--- a/app/services/pending-recovery.server.ts
+++ b/app/services/pending-recovery.server.ts
@@ -1,0 +1,66 @@
+import { Config, Effect } from "effect";
+import { FileSystem } from "@effect/platform";
+import path from "node:path";
+import { VersionOperationsService } from "./db-version-operations.server";
+
+/**
+ * Reconcile-on-load for a crash-stranded Pending Version (issues #1350/#1404).
+ *
+ * A Pending Version found at rest means exactly one thing: the process died
+ * between the Dropbox `course.json` rename (the commit receipt) and the
+ * Promote DB write — caught Commit failures auto-Discard (#1401), so nothing
+ * else leaves one behind. This classifier is the read-only half of the
+ * recovery surface: the publish-page loader calls it, and the state
+ * transitions (Promote when the receipt committed, operator-clicked Discard
+ * when it did not) run in the route action. Never Discard a committed
+ * version — the external receipt is the truth, and consumers may already be
+ * importing it.
+ */
+export type PendingRecovery = {
+  versionId: string;
+  versionName: string;
+  /** Whether the root `course.json` receipt names this Pending Version. */
+  receiptCommitted: boolean;
+};
+
+export const classifyPendingRecovery = Effect.fn("classifyPendingRecovery")(
+  function* (input: { courseId: string; courseName: string }) {
+    const versionOps = yield* VersionOperationsService;
+    const pending = yield* versionOps.getPendingVersion(input.courseId);
+    if (!pending) return null;
+
+    const effectFs = yield* FileSystem.FileSystem;
+    const dropboxPath = yield* Config.string("DROPBOX_PATH");
+    const courseJsonPath = path.join(
+      dropboxPath,
+      input.courseName,
+      "course.json"
+    );
+
+    // The receipt committed iff the root course.json exists, parses, and names
+    // this Pending Version (its `courseVersionId` field — the same id the sync
+    // stamped into the manifest). Missing, unreadable, or naming another
+    // version all mean the crash happened before the rename: nothing landed.
+    const receiptVersionId = yield* effectFs
+      .readFileString(courseJsonPath)
+      .pipe(
+        Effect.map((raw): string | null => {
+          try {
+            const doc = JSON.parse(raw) as { courseVersionId?: unknown };
+            return typeof doc.courseVersionId === "string"
+              ? doc.courseVersionId
+              : null;
+          } catch {
+            return null;
+          }
+        }),
+        Effect.catchAll(() => Effect.succeed<string | null>(null))
+      );
+
+    return {
+      versionId: pending.id,
+      versionName: pending.name,
+      receiptCommitted: receiptVersionId === pending.id,
+    } satisfies PendingRecovery;
+  }
+);

--- a/app/services/pending-recovery.server.ts
+++ b/app/services/pending-recovery.server.ts
@@ -19,8 +19,14 @@ import { VersionOperationsService } from "./db-version-operations.server";
 export type PendingRecovery = {
   versionId: string;
   versionName: string;
-  /** Whether the root `course.json` receipt names this Pending Version. */
-  receiptCommitted: boolean;
+  /**
+   * How the root `course.json` receipt classifies this Pending Version.
+   * `committed` — the receipt names it: Promote. `absent` — provably no
+   * receipt for it (none exists, or an older publish's): offer Discard.
+   * `unreadable` — the mount or receipt could not be read: refuse to
+   * classify, offer nothing destructive.
+   */
+  receiptState: "committed" | "absent" | "unreadable";
 };
 
 export const classifyPendingRecovery = Effect.fn("classifyPendingRecovery")(
@@ -37,30 +43,46 @@ export const classifyPendingRecovery = Effect.fn("classifyPendingRecovery")(
       "course.json"
     );
 
-    // The receipt committed iff the root course.json exists, parses, and names
-    // this Pending Version (its `courseVersionId` field — the same id the sync
-    // stamped into the manifest). Missing, unreadable, or naming another
-    // version all mean the crash happened before the rename: nothing landed.
-    const receiptVersionId = yield* effectFs
-      .readFileString(courseJsonPath)
-      .pipe(
-        Effect.map((raw): string | null => {
-          try {
-            const doc = JSON.parse(raw) as { courseVersionId?: unknown };
-            return typeof doc.courseVersionId === "string"
-              ? doc.courseVersionId
-              : null;
-          } catch {
-            return null;
-          }
-        }),
-        Effect.catchAll(() => Effect.succeed<string | null>(null))
-      );
+    // Discard may only be offered on a PROVABLY absent receipt — a mount that
+    // cannot be read proves nothing, and discarding a committed version is the
+    // one unforgivable outcome. So an unreachable Dropbox root refuses to
+    // classify rather than reading a missing file as "nothing landed".
+    const rootExists = yield* effectFs
+      .exists(dropboxPath)
+      .pipe(Effect.catchAll(() => Effect.succeed(false)));
+
+    // The receipt committed iff the root course.json parses and names this
+    // Pending Version (its `courseVersionId` field — the same id the sync
+    // stamped into the manifest). A missing file or one naming an earlier
+    // publish is a provably absent receipt: the crash preceded the rename.
+    // Any other read failure — and garbage bytes, which the atomic rename
+    // makes impossible for a real receipt — classifies as unreadable.
+    const receiptState = !rootExists
+      ? ("unreadable" as const)
+      : yield* effectFs.readFileString(courseJsonPath).pipe(
+          Effect.map((raw): PendingRecovery["receiptState"] => {
+            try {
+              const doc = JSON.parse(raw) as { courseVersionId?: unknown };
+              return doc.courseVersionId === pending.id
+                ? "committed"
+                : "absent";
+            } catch {
+              return "unreadable";
+            }
+          }),
+          Effect.catchAll((error) =>
+            Effect.succeed<PendingRecovery["receiptState"]>(
+              error._tag === "SystemError" && error.reason === "NotFound"
+                ? "absent"
+                : "unreadable"
+            )
+          )
+        );
 
     return {
       versionId: pending.id,
       versionName: pending.name,
-      receiptCommitted: receiptVersionId === pending.id,
+      receiptState,
     } satisfies PendingRecovery;
   }
 );

--- a/app/services/pending-recovery.test.ts
+++ b/app/services/pending-recovery.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Reconcile-on-load classification for a crash-stranded Pending Version
+ * (issues #1350/#1404). The classifier correlates the course's Pending row
+ * (at most one, by the partial unique index) against the root Dropbox
+ * `course.json` receipt: the receipt naming the Pending Version means the
+ * publish committed (→ Promote); anything else means the crash preceded the
+ * atomic rename (→ offer Discard). The transitions themselves
+ * (promote/discard) are covered in version-lifecycle.test.ts.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { ConfigProvider, Effect, Layer } from "effect";
+import { NodeContext } from "@effect/platform-node";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createTestDb,
+  truncateAllTables,
+  type TestDb,
+} from "@/test-utils/pglite";
+import { CourseOperationsService } from "@/services/db-course-operations.server";
+import { VersionOperationsService } from "@/services/db-version-operations.server";
+import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
+import { DrizzleService } from "@/services/drizzle-service.server";
+import { classifyPendingRecovery } from "@/services/pending-recovery.server";
+
+let testDb: TestDb;
+let dropboxDir: string;
+
+beforeAll(async () => {
+  const result = await createTestDb();
+  testDb = result.testDb;
+  dropboxDir = await fs.mkdtemp(path.join(os.tmpdir(), "cvm-recovery-"));
+});
+
+const COURSE_NAME = "recovery-course";
+
+const setup = async () => {
+  await truncateAllTables(testDb);
+  await fs.rm(path.join(dropboxDir, COURSE_NAME), {
+    recursive: true,
+    force: true,
+  });
+  await fs.mkdir(path.join(dropboxDir, COURSE_NAME), { recursive: true });
+
+  const drizzleLayer = Layer.succeed(DrizzleService, testDb as any);
+  const dbLayer = Layer.mergeAll(
+    CourseOperationsService.Default,
+    VersionOperationsService.Default,
+    LessonSectionOperationsService.Default
+  ).pipe(Layer.provide(drizzleLayer), Layer.merge(NodeContext.layer));
+
+  const run = <A, E>(effect: Effect.Effect<A, E, any>) =>
+    Effect.runPromise(
+      effect.pipe(
+        Effect.provide(dbLayer),
+        Effect.withConfigProvider(
+          ConfigProvider.fromMap(new Map([["DROPBOX_PATH", dropboxDir]]))
+        )
+      ) as Effect.Effect<A, E, never>
+    ) as Promise<A>;
+
+  const seeded = await run(
+    Effect.gen(function* () {
+      const courseOps = yield* CourseOperationsService;
+      const versionOps = yield* VersionOperationsService;
+      const course = yield* courseOps.createCourse({ name: COURSE_NAME });
+      const version = yield* versionOps.createCourseVersion({
+        repoId: course.id,
+        name: "",
+      });
+      return { course, version };
+    })
+  );
+
+  // Submit: freeze the Draft as a Pending Version — the state a crash between
+  // the receipt rename and Promote leaves at rest.
+  const submit = () =>
+    run(
+      Effect.gen(function* () {
+        const versionOps = yield* VersionOperationsService;
+        return yield* versionOps.freezeAndCloneVersion({
+          sourceVersionId: seeded.version.id,
+          repoId: seeded.course.id,
+          newVersionName: "",
+          sourceName: "v1.0.0",
+          sourceDescription: "First release",
+        });
+      })
+    );
+
+  const classify = () =>
+    run(
+      classifyPendingRecovery({
+        courseId: seeded.course.id,
+        courseName: COURSE_NAME,
+      })
+    );
+
+  const writeReceipt = (contents: string) =>
+    fs.writeFile(path.join(dropboxDir, COURSE_NAME, "course.json"), contents);
+
+  return { ...seeded, submit, classify, writeReceipt };
+};
+
+describe("classifyPendingRecovery (#1404)", () => {
+  it("returns null when the course has no Pending Version", async () => {
+    const { classify } = await setup();
+    expect(await classify()).toBeNull();
+  });
+
+  it("classifies a Pending with no receipt as not committed", async () => {
+    const { submit, classify, version } = await setup();
+    await submit();
+    expect(await classify()).toEqual({
+      versionId: version.id,
+      versionName: "v1.0.0",
+      receiptCommitted: false,
+    });
+  });
+
+  it("classifies a Pending whose receipt names it as committed", async () => {
+    const { submit, classify, writeReceipt, version } = await setup();
+    await submit();
+    await writeReceipt(JSON.stringify({ courseVersionId: version.id }));
+    expect(await classify()).toEqual({
+      versionId: version.id,
+      versionName: "v1.0.0",
+      receiptCommitted: true,
+    });
+  });
+
+  it("a receipt naming an earlier version does not commit this Pending", async () => {
+    const { submit, classify, writeReceipt } = await setup();
+    await submit();
+    await writeReceipt(JSON.stringify({ courseVersionId: "some-older-id" }));
+    expect((await classify())?.receiptCommitted).toBe(false);
+  });
+
+  it("an unparseable receipt reads as not committed", async () => {
+    const { submit, classify, writeReceipt } = await setup();
+    await submit();
+    await writeReceipt("{ not json");
+    expect((await classify())?.receiptCommitted).toBe(false);
+  });
+});

--- a/app/services/pending-recovery.test.ts
+++ b/app/services/pending-recovery.test.ts
@@ -100,7 +100,7 @@ const setup = async () => {
   const writeReceipt = (contents: string) =>
     fs.writeFile(path.join(dropboxDir, COURSE_NAME, "course.json"), contents);
 
-  return { ...seeded, submit, classify, writeReceipt };
+  return { ...seeded, run, submit, classify, writeReceipt };
 };
 
 describe("classifyPendingRecovery (#1404)", () => {
@@ -109,13 +109,13 @@ describe("classifyPendingRecovery (#1404)", () => {
     expect(await classify()).toBeNull();
   });
 
-  it("classifies a Pending with no receipt as not committed", async () => {
+  it("classifies a Pending with no receipt as provably absent", async () => {
     const { submit, classify, version } = await setup();
     await submit();
     expect(await classify()).toEqual({
       versionId: version.id,
       versionName: "v1.0.0",
-      receiptCommitted: false,
+      receiptState: "absent",
     });
   });
 
@@ -126,21 +126,43 @@ describe("classifyPendingRecovery (#1404)", () => {
     expect(await classify()).toEqual({
       versionId: version.id,
       versionName: "v1.0.0",
-      receiptCommitted: true,
+      receiptState: "committed",
     });
   });
 
-  it("a receipt naming an earlier version does not commit this Pending", async () => {
+  it("a receipt naming an earlier version is absent for this Pending", async () => {
     const { submit, classify, writeReceipt } = await setup();
     await submit();
     await writeReceipt(JSON.stringify({ courseVersionId: "some-older-id" }));
-    expect((await classify())?.receiptCommitted).toBe(false);
+    expect((await classify())?.receiptState).toBe("absent");
   });
 
-  it("an unparseable receipt reads as not committed", async () => {
+  // Discard may only be offered on a PROVABLY absent receipt: anything we
+  // could not actually read refuses to classify, so a down mount can never
+  // lead to discarding a version whose receipt in fact committed.
+  it("an unparseable receipt refuses to classify (unreadable)", async () => {
     const { submit, classify, writeReceipt } = await setup();
     await submit();
     await writeReceipt("{ not json");
-    expect((await classify())?.receiptCommitted).toBe(false);
+    expect((await classify())?.receiptState).toBe("unreadable");
+  });
+
+  it("a missing Dropbox root refuses to classify (unreadable)", async () => {
+    const { submit, run, course } = await setup();
+    await submit();
+    const result = await run(
+      classifyPendingRecovery({
+        courseId: course.id,
+        courseName: COURSE_NAME,
+      }).pipe(
+        // Innermost provider wins: simulate the whole mount being absent.
+        Effect.withConfigProvider(
+          ConfigProvider.fromMap(
+            new Map([["DROPBOX_PATH", path.join(dropboxDir, "no-such-mount")]])
+          )
+        )
+      )
+    );
+    expect(result?.receiptState).toBe("unreadable");
   });
 });

--- a/app/services/version-not-draft-message.ts
+++ b/app/services/version-not-draft-message.ts
@@ -9,3 +9,18 @@
  */
 export const VERSION_NOT_DRAFT_MESSAGE =
   "This version was published while you were editing — reload to continue in the new Draft.";
+
+/**
+ * Extract the human message from a 409 response body. route-action
+ * serializes the error's `message` as a JSON string; a proxy or crash may
+ * hand back plain text instead, so fall back to the raw body.
+ */
+export const parse409Message = (body: string): string => {
+  try {
+    const parsed = JSON.parse(body);
+    if (typeof parsed === "string") return parsed;
+  } catch {
+    // keep raw body
+  }
+  return body;
+};


### PR DESCRIPTION
Closes #1404. Part of #1347. Stacked on #1407 (which is stacked on #1406) — merge those first; GitHub should retarget this automatically.

Implements the locked design from #1350: the publish-page loader detects a crash-stranded \`commitState = 'pending'\` version and reconciles it against the external commit receipt.

## What a stranded Pending means

Caught Commit failures auto-Discard (#1401), so a Pending Version found **at rest** means exactly one thing: the process died between the Dropbox \`course.json\` atomic rename (the commit receipt) and the Promote DB write. Previously this stranded silently — a phantom half-published version.

## How it works

- **\`classifyPendingRecovery\`** (`app/services/pending-recovery.server.ts`, read-only): finds the course's Pending row (≤1 by the partial unique index) and classifies the root \`course.json\` receipt three ways: **committed** (it names this version's \`courseVersionId\`), **absent** (provably no receipt for it — file missing with the mount reachable, or an older publish's receipt), or **unreadable** (mount down / read failure — refuse to classify; Discard is only ever offered on a *provably* absent receipt, so a down mount can never lead to discarding a version whose receipt in fact committed).
- **Loader classifies, actions transition** — no writes in a GET. The route action runs \`promotePendingVersion\` / \`discardPendingVersion\`, both CAS-guarded on \`commitState='pending'\` in the DB, so a stale banner or double-click gets a 409 and can never touch a Draft or Published row.
- **Banner** on the publish page:
  - Committed → **auto-Promote on render** (never discard a committed version — it's already live and consumers may be importing it), confirming "Publish finished — recovered ✓" only once the action returns success.
  - Absent → "Your last publish didn't finish" with **one-click Discard**; edits are safe in the current Draft.
  - Unreadable → a non-destructive notice: check the Dropbox mount and reload.
  - Suppressed while a publish from this client is live (its Pending is in flight, not stranded), and publishing is blocked until the Pending is reconciled (a second Submit would violate at-most-one-pending anyway).
- Docs kept in sync per CLAUDE.md: CONTEXT.md's Pending entry (with offsetting trims to stay under the token budget) and \`cvm course publish\` FAILURE HANDLING.

## Tests

\`app/services/pending-recovery.test.ts\` — 6 tests over real Submit + a temp-dir Dropbox mount covering all classifications, including the missing-mount and unparseable-receipt refusals. Full suite: 2347 passed; the only failures are the 20 pre-existing \`segment\` CLI tests broken on main.

The second commit applies findings from a two-axis code review of the first (unreadable-receipt refusal, honest promote-success check, corrected banner copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)