### PR TITLE
feat: real ffmpeg progress for video exports

### DIFF
--- a/app/features/upload-manager/sse-batch-export-client.ts
+++ b/app/features/upload-manager/sse-batch-export-client.ts
@@ -9,6 +9,13 @@ export interface SSEBatchExportParams {
 export interface SSEBatchExportCallbacks {
   onVideos: (videos: Array<{ id: string; title: string }>) => void;
   onStageChange: (videoId: string, stage: uploadReducer.ExportStage) => void;
+  // Real ffmpeg progress within a stage: integer percent 0–99, resets when
+  // the stage changes.
+  onProgress: (
+    videoId: string,
+    stage: uploadReducer.ExportStage,
+    percent: number
+  ) => void;
   onComplete: (videoId: string) => void;
   onError: (videoId: string | null, message: string) => void;
 }
@@ -25,6 +32,11 @@ export const startSSEBatchExport = (
         callbacks.onVideos(data.videos),
       stage: (data: { videoId: string; stage: uploadReducer.ExportStage }) =>
         callbacks.onStageChange(data.videoId, data.stage),
+      "video-progress": (data: {
+        videoId: string;
+        stage: uploadReducer.ExportStage;
+        percent: number;
+      }) => callbacks.onProgress(data.videoId, data.stage, data.percent),
       complete: (data: { videoId: string }) =>
         callbacks.onComplete(data.videoId),
       error: (data: { videoId?: string | null; message: string }) =>

--- a/app/features/upload-manager/sse-export-client.ts
+++ b/app/features/upload-manager/sse-export-client.ts
@@ -7,6 +7,9 @@ export interface SSEExportParams {
 
 export interface SSEExportCallbacks {
   onStageChange: (stage: uploadReducer.ExportStage) => void;
+  // Real ffmpeg progress within a stage: integer percent 0–99, resets when
+  // the stage changes.
+  onProgress: (stage: uploadReducer.ExportStage, percent: number) => void;
   onComplete: () => void;
   onError: (message: string) => void;
 }
@@ -21,6 +24,10 @@ export const startSSEExport = (
     events: {
       stage: (data: { stage: uploadReducer.ExportStage }) =>
         callbacks.onStageChange(data.stage),
+      "video-progress": (data: {
+        stage: uploadReducer.ExportStage;
+        percent: number;
+      }) => callbacks.onProgress(data.stage, data.percent),
       complete: () => callbacks.onComplete(),
       error: (data: { message: string }) => callbacks.onError(data.message),
     },

--- a/app/features/upload-manager/sse-publish-client.ts
+++ b/app/features/upload-manager/sse-publish-client.ts
@@ -17,6 +17,13 @@ export interface SSEPublishCallbacks {
     videoId: string,
     stage: uploadReducer.ExportStage
   ) => void;
+  // Real ffmpeg progress within an export stage: integer percent 0–99,
+  // resets when the stage changes.
+  onExportProgress: (
+    videoId: string,
+    stage: uploadReducer.ExportStage,
+    percent: number
+  ) => void;
   onExportComplete: (videoId: string) => void;
   onExportError: (videoId: string, message: string) => void;
   // Per-lesson Dropbox upload percentage during the "uploading" stage.
@@ -49,6 +56,11 @@ export const startSSEPublish = (
         videoId: string;
         stage: uploadReducer.ExportStage;
       }) => callbacks.onExportStageChange(data.videoId, data.stage),
+      "export-progress": (data: {
+        videoId: string;
+        stage: uploadReducer.ExportStage;
+        percent: number;
+      }) => callbacks.onExportProgress(data.videoId, data.stage, data.percent),
       "export-complete": (data: { videoId: string }) =>
         callbacks.onExportComplete(data.videoId),
       "export-error": (data: { videoId: string; message: string }) =>

--- a/app/features/upload-manager/upload-context.tsx
+++ b/app/features/upload-manager/upload-context.tsx
@@ -391,6 +391,18 @@ export function UploadProvider({ children }: { children: React.ReactNode }) {
               });
             }
           },
+          onProgress: (videoId, stage, percent) => {
+            if (stage === "queued") return;
+            const uploadId = batchVideoIdToUploadIdRef.current.get(videoId);
+            if (uploadId) {
+              dispatch({
+                type: "UPDATE_EXPORT_PROGRESS",
+                uploadId,
+                stage,
+                percent,
+              });
+            }
+          },
           onComplete: (videoId) => {
             const uploadId = batchVideoIdToUploadIdRef.current.get(videoId);
             if (uploadId) {

--- a/app/features/upload-manager/upload-reducer-stages.test.ts
+++ b/app/features/upload-manager/upload-reducer-stages.test.ts
@@ -189,17 +189,18 @@ describe("UPDATE_EXPORT_STAGE", () => {
     );
   });
 
-  it("should update progress based on stage", () => {
+  it("should update progress to the stage's band start", () => {
     let state = createState({
       uploads: { "upload-1": createExportEntry() },
     });
 
+    // Band start: real ffmpeg progress fills 0→80 during concatenation.
     state = reduce(state, {
       type: "UPDATE_EXPORT_STAGE",
       uploadId: "upload-1",
       stage: "concatenating-clips",
     });
-    expect(state.uploads["upload-1"]!.progress).toBe(50);
+    expect(state.uploads["upload-1"]!.progress).toBe(0);
 
     state = reduce(state, {
       type: "UPDATE_EXPORT_STAGE",
@@ -248,6 +249,105 @@ describe("UPDATE_EXPORT_STAGE", () => {
       type: "UPDATE_EXPORT_STAGE",
       uploadId: "upload-1",
       stage: "normalizing-audio",
+    });
+
+    expect(state).toBe(initial);
+  });
+});
+
+describe("UPDATE_EXPORT_PROGRESS", () => {
+  it("bands concatenation percent into 0–80", () => {
+    let state = createState({
+      uploads: { "upload-1": createExportEntry() },
+    });
+
+    state = reduce(state, {
+      type: "UPDATE_EXPORT_PROGRESS",
+      uploadId: "upload-1",
+      stage: "concatenating-clips",
+      percent: 50,
+    });
+    expect(state.uploads["upload-1"]!.progress).toBe(40);
+
+    state = reduce(state, {
+      type: "UPDATE_EXPORT_PROGRESS",
+      uploadId: "upload-1",
+      stage: "concatenating-clips",
+      percent: 99,
+    });
+    expect(state.uploads["upload-1"]!.progress).toBe(79);
+  });
+
+  it("bands normalization percent into 80–99", () => {
+    let state = createState({
+      uploads: { "upload-1": createExportEntry() },
+    });
+
+    state = reduce(state, {
+      type: "UPDATE_EXPORT_PROGRESS",
+      uploadId: "upload-1",
+      stage: "normalizing-audio",
+      percent: 0,
+    });
+    expect(state.uploads["upload-1"]!.progress).toBe(80);
+
+    state = reduce(state, {
+      type: "UPDATE_EXPORT_PROGRESS",
+      uploadId: "upload-1",
+      stage: "normalizing-audio",
+      percent: 99,
+    });
+    expect(state.uploads["upload-1"]!.progress).toBe(98);
+  });
+
+  it("never moves the bar backwards across late or out-of-order events", () => {
+    let state = createState({
+      uploads: { "upload-1": createExportEntry() },
+    });
+
+    state = reduce(state, {
+      type: "UPDATE_EXPORT_STAGE",
+      uploadId: "upload-1",
+      stage: "normalizing-audio",
+    });
+    expect(state.uploads["upload-1"]!.progress).toBe(80);
+
+    // A straggler event from the concatenation phase must not drag it back.
+    state = reduce(state, {
+      type: "UPDATE_EXPORT_PROGRESS",
+      uploadId: "upload-1",
+      stage: "concatenating-clips",
+      percent: 50,
+    });
+    expect(state.uploads["upload-1"]!.progress).toBe(80);
+  });
+
+  it("updates the export stage alongside the percent", () => {
+    let state = createState({
+      uploads: { "upload-1": createExportEntry() },
+    });
+
+    state = reduce(state, {
+      type: "UPDATE_EXPORT_PROGRESS",
+      uploadId: "upload-1",
+      stage: "concatenating-clips",
+      percent: 10,
+    });
+    const upload = state.uploads["upload-1"]!;
+    expect(upload.uploadType === "export" && upload.exportStage).toBe(
+      "concatenating-clips"
+    );
+  });
+
+  it("should not modify state for non-export upload", () => {
+    const initial = createState({
+      uploads: { "upload-1": createYouTubeEntry() },
+    });
+    const state = reduce(initial, {
+      type: "UPDATE_EXPORT_PROGRESS",
+      uploadId: "upload-1",
+      stage: "concatenating-clips",
+      percent: 50,
     });
 
     expect(state).toBe(initial);

--- a/app/features/upload-manager/upload-reducer.ts
+++ b/app/features/upload-manager/upload-reducer.ts
@@ -118,6 +118,15 @@ export namespace uploadReducer {
         stage: ExportStage;
       }
     | {
+        // Real ffmpeg progress within an export stage (integer 0–99, resets
+        // per stage) — banded into the single bar: concatenating 0–80,
+        // normalizing 80–99.
+        type: "UPDATE_EXPORT_PROGRESS";
+        uploadId: string;
+        stage: Exclude<ExportStage, "queued">;
+        percent: number;
+      }
+    | {
         type: "UPLOAD_SUCCESS";
         uploadId: string;
         youtubeVideoId?: string;
@@ -148,6 +157,18 @@ export namespace uploadReducer {
 export const createInitialUploadState = (): uploadReducer.State => ({
   uploads: {},
 });
+
+// The single bar's bands per export stage: the stage change jumps to `start`,
+// then real ffmpeg percent (0–99) fills `width` of the band. 100 is reserved
+// for completion (UPLOAD_SUCCESS).
+const EXPORT_STAGE_BANDS: Record<
+  uploadReducer.ExportStage,
+  { start: number; width: number }
+> = {
+  queued: { start: 0, width: 0 },
+  "concatenating-clips": { start: 0, width: 80 },
+  "normalizing-audio": { start: 80, width: 19 },
+};
 
 export const uploadReducer = (
   state: uploadReducer.State,
@@ -226,11 +247,29 @@ export const uploadReducer = (
       const upload = state.uploads[action.uploadId];
       if (!upload || upload.uploadType !== "export") return state;
 
-      const stageProgress: Record<uploadReducer.ExportStage, number> = {
-        queued: 0,
-        "concatenating-clips": 50,
-        "normalizing-audio": 80,
+      return {
+        ...state,
+        uploads: {
+          ...state.uploads,
+          [action.uploadId]: {
+            ...upload,
+            exportStage: action.stage,
+            progress: Math.max(
+              upload.progress,
+              EXPORT_STAGE_BANDS[action.stage].start
+            ),
+          },
+        },
       };
+    }
+
+    case "UPDATE_EXPORT_PROGRESS": {
+      const upload = state.uploads[action.uploadId];
+      if (!upload || upload.uploadType !== "export") return state;
+
+      const band = EXPORT_STAGE_BANDS[action.stage];
+      const banded =
+        band.start + Math.floor((action.percent / 100) * band.width);
 
       return {
         ...state,
@@ -239,7 +278,9 @@ export const uploadReducer = (
           [action.uploadId]: {
             ...upload,
             exportStage: action.stage,
-            progress: stageProgress[action.stage],
+            // Monotonic: a late event from the previous phase never drags the
+            // bar backwards.
+            progress: Math.max(upload.progress, banded),
           },
         },
       };

--- a/app/features/upload-manager/upload-type-registry.ts
+++ b/app/features/upload-manager/upload-type-registry.ts
@@ -89,6 +89,15 @@ const exportConfig: UploadTypeConfig<
           onStageChange: (stage) => {
             dispatch({ type: "UPDATE_EXPORT_STAGE", uploadId, stage });
           },
+          onProgress: (stage, percent) => {
+            if (stage === "queued") return;
+            dispatch({
+              type: "UPDATE_EXPORT_PROGRESS",
+              uploadId,
+              stage,
+              percent,
+            });
+          },
           onComplete: () => {
             dispatch({ type: "UPLOAD_SUCCESS", uploadId });
             abortControllers.delete(uploadId);
@@ -524,6 +533,18 @@ const publishConfig: UploadTypeConfig<
                 type: "UPDATE_EXPORT_STAGE",
                 uploadId: exportUploadId,
                 stage,
+              });
+            }
+          },
+          onExportProgress: (videoId, stage, percent) => {
+            if (stage === "queued") return;
+            const exportUploadId = exportUploadIds.get(videoId);
+            if (exportUploadId) {
+              dispatch({
+                type: "UPDATE_EXPORT_PROGRESS",
+                uploadId: exportUploadId,
+                stage,
+                percent,
               });
             }
           },

--- a/app/routes/api.courses.$courseId.publish-sse.ts
+++ b/app/routes/api.courses.$courseId.publish-sse.ts
@@ -13,6 +13,7 @@ import { createSSEResponse } from "@/lib/create-sse-response.server";
 const DETAIL_EVENT_WIRE_NAMES = {
   videos: "export-videos",
   stage: "export-stage",
+  "video-progress": "export-progress",
   complete: "export-complete",
   error: "export-error",
   progress: "upload-progress",

--- a/app/routes/api.videos.$videoId.export-sse.ts
+++ b/app/routes/api.videos.$videoId.export-sse.ts
@@ -13,9 +13,15 @@ export const action = async (args: Route.ActionArgs) => {
       Effect.gen(function* () {
         const publishService = yield* CoursePublishService;
 
-        yield* publishService.exportVideo(videoId, (stage) => {
-          sendEvent("stage", { stage });
-        });
+        yield* publishService.exportVideo(
+          videoId,
+          (stage) => {
+            sendEvent("stage", { stage });
+          },
+          ({ stage, percent }) => {
+            sendEvent("video-progress", { stage, percent });
+          }
+        );
 
         sendEvent("complete", {});
       }),

--- a/app/services/course-publish-export-events.ts
+++ b/app/services/course-publish-export-events.ts
@@ -15,6 +15,16 @@ export type PublishDetailEvent =
     }
   | { event: "complete"; data: { videoId: string } }
   | { event: "error"; data: { videoId: string; message: string } }
+  // Real ffmpeg progress within an export stage: integer percent 0–99 that
+  // resets when the stage changes (100 is signalled by `complete`).
+  | {
+      event: "video-progress";
+      data: {
+        videoId: string;
+        stage: "concatenating-clips" | "normalizing-audio";
+        percent: number;
+      };
+    }
   // Per-lesson upload percentage from the Dropbox commit.
   | { event: "progress"; data: { percentage: number } };
 
@@ -47,7 +57,11 @@ export const runObservedExportLoop = <A, E, R>(input: {
   unexportedVideos: Array<{ id: string; title: string }>;
   exportVideo: (
     videoId: string,
-    onStage: (stage: "concatenating-clips" | "normalizing-audio") => void
+    onStage: (stage: "concatenating-clips" | "normalizing-audio") => void,
+    onProgress: (info: {
+      stage: "concatenating-clips" | "normalizing-audio";
+      percent: number;
+    }) => void
   ) => Effect.Effect<A, E, R>;
   onDetailEvent?: EmitPublishDetailEvent;
 }): Effect.Effect<{ failedVideoIds: string[] }, never, R> =>
@@ -72,12 +86,21 @@ export const runObservedExportLoop = <A, E, R>(input: {
     yield* Effect.forEach(
       unexportedVideos,
       (video) =>
-        exportVideo(video.id, (stage) => {
-          onDetailEvent?.({
-            event: "stage",
-            data: { videoId: video.id, stage },
-          });
-        }).pipe(
+        exportVideo(
+          video.id,
+          (stage) => {
+            onDetailEvent?.({
+              event: "stage",
+              data: { videoId: video.id, stage },
+            });
+          },
+          ({ stage, percent }) => {
+            onDetailEvent?.({
+              event: "video-progress",
+              data: { videoId: video.id, stage, percent },
+            });
+          }
+        ).pipe(
           Effect.retry(Schedule.recurs(2)),
           Effect.tap(() => {
             onDetailEvent?.({

--- a/app/services/course-publish-service-publish.test.ts
+++ b/app/services/course-publish-service-publish.test.ts
@@ -158,7 +158,10 @@ const setup = async (opts?: {
         fs.mkdirSync(path.dirname(outputPath), { recursive: true });
         fs.writeFileSync(outputPath, "dummy-video-content");
         exportOpts.onStageChange?.("concatenating-clips");
+        exportOpts.onProgress?.({ stage: "concatenating-clips", percent: 50 });
+        exportOpts.onProgress?.({ stage: "concatenating-clips", percent: 99 });
         exportOpts.onStageChange?.("normalizing-audio");
+        exportOpts.onProgress?.({ stage: "normalizing-audio", percent: 50 });
         return outputPath;
       }),
   } as any);
@@ -525,6 +528,19 @@ describe("CoursePublishService — publish", () => {
       events.some((e) => e.event === "complete" && e.data.videoId === video.id)
     ).toBe(true);
 
+    // Real ffmpeg percentages ride alongside the stages, keyed by videoId.
+    const percents = events
+      .filter(
+        (e) => e.event === "video-progress" && e.data.videoId === video.id
+      )
+      .map((e) => ({ stage: e.data.stage, percent: e.data.percent }));
+    expect(percents).toEqual([
+      { stage: "concatenating-clips", percent: 50 },
+      { stage: "concatenating-clips", percent: 99 },
+      { stage: "normalizing-audio", percent: 50 },
+    ]);
+
+    // The Commit sync's per-lesson upload percentage flows through too.
     const progressEvents = events.filter((e) => e.event === "progress");
     expect(progressEvents.length).toBeGreaterThan(0);
     expect(progressEvents.at(-1)?.data.percentage).toBe(100);

--- a/app/services/course-publish-service.test.ts
+++ b/app/services/course-publish-service.test.ts
@@ -52,7 +52,9 @@ const setup = async () => {
         fs.mkdirSync(path.dirname(outputPath), { recursive: true });
         fs.writeFileSync(outputPath, "dummy-video-content");
         opts.onStageChange?.("concatenating-clips");
+        opts.onProgress?.({ stage: "concatenating-clips", percent: 50 });
         opts.onStageChange?.("normalizing-audio");
+        opts.onProgress?.({ stage: "normalizing-audio", percent: 50 });
         return outputPath;
       }),
   } as any);
@@ -412,6 +414,16 @@ describe("CoursePublishService", () => {
       expect(videosEvent).toBeTruthy();
       const completeEvent = events.find((e) => e.event === "complete");
       expect(completeEvent).toBeTruthy();
+
+      // Real ffmpeg percentages ride alongside the stages, keyed by videoId.
+      const progressEvents = events
+        .filter((e) => e.event === "video-progress")
+        .map((e) => e.data as any);
+      expect(progressEvents).toEqual([
+        expect.objectContaining({ stage: "concatenating-clips", percent: 50 }),
+        expect.objectContaining({ stage: "normalizing-audio", percent: 50 }),
+      ]);
+      expect(progressEvents[0].videoId).toBeTruthy();
     });
 
     it("skips already exported videos", async () => {

--- a/app/services/course-publish-service.ts
+++ b/app/services/course-publish-service.ts
@@ -132,7 +132,11 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
 
       const exportVideoCore = Effect.fn("exportVideoCore")(function* (
         videoId: string,
-        onStage?: (stage: "concatenating-clips" | "normalizing-audio") => void
+        onStage?: (stage: "concatenating-clips" | "normalizing-audio") => void,
+        onProgress?: (info: {
+          stage: "concatenating-clips" | "normalizing-audio";
+          percent: number;
+        }) => void
       ) {
         const video = yield* videoOps.getVideoWithClipsById(videoId);
         const courseId = video.lesson?.section.repoVersion.repo.id;
@@ -178,6 +182,7 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
             };
           }),
           onStageChange: onStage,
+          onProgress,
         });
 
         // Move from {videoId}.mp4 to content-addressed path
@@ -192,9 +197,17 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
 
       const exportVideo = Effect.fn("exportVideo")(function* (
         videoId: string,
-        onStage?: (stage: "concatenating-clips" | "normalizing-audio") => void
+        onStage?: (stage: "concatenating-clips" | "normalizing-audio") => void,
+        onProgress?: (info: {
+          stage: "concatenating-clips" | "normalizing-audio";
+          percent: number;
+        }) => void
       ) {
-        const { targetPath, owner } = yield* exportVideoCore(videoId, onStage);
+        const { targetPath, owner } = yield* exportVideoCore(
+          videoId,
+          onStage,
+          onProgress
+        );
         if (owner.kind === "course") {
           yield* garbageCollect(owner.courseId);
         }

--- a/app/services/ffmpeg-child-registry.ts
+++ b/app/services/ffmpeg-child-registry.ts
@@ -1,0 +1,56 @@
+/**
+ * Parent-death backstop for long-running ffmpeg children.
+ *
+ * Effect scopes already kill an ffmpeg child when its *fiber* is interrupted
+ * (SSE disconnect, cancelled publish). What scopes cannot cover is the parent
+ * process itself dying — Ctrl-C on the dev server exits Node without
+ * interrupting any fiber, orphaning the child. This registry tracks live
+ * ffmpeg PIDs and installs one-time signal/exit handlers that reap whatever
+ * is still registered on the way down.
+ *
+ * A hard SIGKILL of the parent (or a native crash) still orphans children —
+ * nothing in userland prevents that.
+ */
+const livePids = new Set<number>();
+let handlersInstalled = false;
+
+const killAll = () => {
+  for (const pid of livePids) {
+    try {
+      // SIGKILL: the outputs are throwaway temp files, so there is nothing
+      // worth letting ffmpeg finalize — just make sure it dies.
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Already gone.
+    }
+  }
+  livePids.clear();
+};
+
+const installHandlers = () => {
+  if (handlersInstalled) return;
+  handlersInstalled = true;
+
+  // Fires on process.exit() and normal event-loop drain — including the exit
+  // that dev-server tooling (vite etc.) performs from its own signal handlers.
+  process.once("exit", killAll);
+
+  // If nothing else handles the signal, Node would terminate without firing
+  // "exit" — so kill the children ourselves, then re-raise the signal with our
+  // once-handler consumed so the default (or any other handler) proceeds.
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    process.once(signal, () => {
+      killAll();
+      process.kill(process.pid, signal);
+    });
+  }
+};
+
+/** Track a spawned ffmpeg child; returns the untrack function. */
+export const registerFfmpegChild = (pid: number): (() => void) => {
+  installHandlers();
+  livePids.add(pid);
+  return () => {
+    livePids.delete(pid);
+  };
+};

--- a/app/services/ffmpeg-commands.ts
+++ b/app/services/ffmpeg-commands.ts
@@ -4,6 +4,8 @@ import { Data, Effect, Stream } from "effect";
 import crypto from "node:crypto";
 import path from "node:path";
 import { tmpdir } from "os";
+import { registerFfmpegChild } from "./ffmpeg-child-registry";
+import { createFfmpegProgressParser } from "./ffmpeg-progress";
 
 const GPU_PERMITS = 6;
 const CPU_PERMITS = 12;
@@ -20,6 +22,77 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
       const fs = yield* FileSystem.FileSystem;
       const gpuSemaphore = yield* Effect.makeSemaphore(GPU_PERMITS);
       const cpuSemaphore = yield* Effect.makeSemaphore(CPU_PERMITS);
+
+      /**
+       * Run a long-lived ffmpeg encode with real progress reporting.
+       *
+       * `-progress pipe:1` makes ffmpeg emit key=value progress blocks on
+       * stdout (which nothing else uses), parsed incrementally into integer
+       * percents of `totalDurationSeconds` (see createFfmpegProgressParser for
+       * the emission contract). `-nostats` drops the carriage-return stats
+       * line from the inherited stderr, which otherwise duplicates the same
+       * numbers as terminal noise.
+       *
+       * Runs under a scope, so fiber interruption (SSE disconnect, cancelled
+       * publish) kills the child; the PID is also registered with the
+       * parent-death backstop (see ffmpeg-child-registry) for the case where
+       * the dev server itself dies without interrupting any fiber.
+       */
+      const runFfmpegWithProgress = Effect.fn("runFfmpegWithProgress")(
+        function* (opts: {
+          args: string[];
+          totalDurationSeconds: number;
+          onProgress: ((percent: number) => void) | undefined;
+          errorPrefix: string;
+        }) {
+          const toError = (cause: unknown, detail: string) =>
+            new FFmpegError({
+              cause,
+              message: `${opts.errorPrefix}${detail}`,
+            });
+
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              const child = yield* Command.start(
+                Command.make(
+                  "ffmpeg",
+                  "-nostats",
+                  "-progress",
+                  "pipe:1",
+                  ...opts.args
+                ).pipe(Command.stderr("inherit"))
+              ).pipe(Effect.mapError((e) => toError(e, `: ${e.message}`)));
+
+              yield* Effect.acquireRelease(
+                Effect.sync(() => registerFfmpegChild(child.pid)),
+                (unregister) => Effect.sync(unregister)
+              );
+
+              const parser = createFfmpegProgressParser({
+                totalDurationSeconds: opts.totalDurationSeconds,
+                onPercent: opts.onProgress ?? (() => {}),
+              });
+
+              // Drain stdout even when nobody listens — an unread pipe would
+              // eventually block ffmpeg. The stream ends when the process does.
+              yield* child.stdout.pipe(
+                Stream.decodeText(),
+                Stream.runForEach((chunk) =>
+                  Effect.sync(() => parser.push(chunk))
+                ),
+                Effect.ignore
+              );
+
+              const code = yield* child.exitCode.pipe(
+                Effect.mapError((e) => toError(e, `: ${e.message}`))
+              );
+              if (code !== 0) {
+                yield* toError(null, `, exit code: ${code}`);
+              }
+            })
+          );
+        }
+      );
 
       const detectSilence = Effect.fn("detectSilence")(function* (
         inputVideo: string,
@@ -101,7 +174,8 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
           duration: number;
           pauseType: "none" | "long";
         }[],
-        dimensions: { width: number; height: number }
+        dimensions: { width: number; height: number },
+        onProgress?: (percent: number) => void
       ) {
         const LONG_PAUSE_DURATION = 0.18;
 
@@ -115,13 +189,17 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
           .slice(0, 12);
         const outputFile = path.join(outputDir, `${outputHash}.mp4`);
 
-        // Build input args
+        // Build input args. The summed -t values are also the expected output
+        // duration (the concat filter output is exactly the clips end to end),
+        // which anchors the progress percentage.
         const inputArgs: string[] = [];
+        let expectedOutputDuration = 0;
         for (const clip of clips) {
           const duration =
             clip.pauseType === "long"
               ? clip.duration + LONG_PAUSE_DURATION
               : clip.duration;
+          expectedOutputDuration += duration;
           inputArgs.push(
             "-ss",
             clip.startTime.toString(),
@@ -196,27 +274,11 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
         ];
 
         yield* gpuSemaphore.withPermits(1)(
-          Effect.gen(function* () {
-            const code = yield* Command.exitCode(
-              Command.make("ffmpeg", ...args).pipe(
-                Command.stdout("inherit"),
-                Command.stderr("inherit")
-              )
-            ).pipe(
-              Effect.mapError(
-                (e) =>
-                  new FFmpegError({
-                    cause: e,
-                    message: `Failed to create concatenated video: ${e.message}`,
-                  })
-              )
-            );
-            if (code !== 0) {
-              yield* new FFmpegError({
-                cause: null,
-                message: `Failed to create concatenated video, exit code: ${code}`,
-              });
-            }
+          runFfmpegWithProgress({
+            args,
+            totalDurationSeconds: expectedOutputDuration,
+            onProgress,
+            errorPrefix: "Failed to create concatenated video",
           })
         );
 
@@ -224,7 +286,8 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
       });
 
       const normalizeAudio = Effect.fn("normalizeAudio")(function* (
-        inputVideo: string
+        inputVideo: string,
+        onProgress?: (percent: number) => void
       ) {
         const outputDir = path.join(tmpdir(), "video-processing");
         yield* fs.makeDirectory(outputDir, { recursive: true });
@@ -286,27 +349,12 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
         ];
 
         yield* cpuSemaphore.withPermits(1)(
-          Effect.gen(function* () {
-            const code = yield* Command.exitCode(
-              Command.make("ffmpeg", ...args).pipe(
-                Command.stdout("inherit"),
-                Command.stderr("inherit")
-              )
-            ).pipe(
-              Effect.mapError(
-                (e) =>
-                  new FFmpegError({
-                    cause: e,
-                    message: `Failed to normalize audio: ${e.message}`,
-                  })
-              )
-            );
-            if (code !== 0) {
-              yield* new FFmpegError({
-                cause: null,
-                message: `Failed to normalize audio, exit code: ${code}`,
-              });
-            }
+          runFfmpegWithProgress({
+            args,
+            // Video is stream-copied, so the output duration is the input's.
+            totalDurationSeconds: videoDuration,
+            onProgress,
+            errorPrefix: "Failed to normalize audio",
           })
         );
 

--- a/app/services/ffmpeg-progress.test.ts
+++ b/app/services/ffmpeg-progress.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { createFfmpegProgressParser } from "./ffmpeg-progress";
+
+const block = (outTimeUs: number, progress: "continue" | "end" = "continue") =>
+  [
+    "frame=100",
+    "fps=50.0",
+    `out_time_us=${outTimeUs}`,
+    `out_time_ms=${outTimeUs}`,
+    "out_time=00:00:00.000000",
+    "speed=2.5x",
+    `progress=${progress}`,
+    "",
+  ].join("\n");
+
+describe("createFfmpegProgressParser", () => {
+  const collect = (totalDurationSeconds: number) => {
+    const percents: number[] = [];
+    const parser = createFfmpegProgressParser({
+      totalDurationSeconds,
+      onPercent: (p) => percents.push(p),
+    });
+    return { percents, parser };
+  };
+
+  it("emits integer percent from out_time_us against the total duration", () => {
+    const { percents, parser } = collect(10);
+    parser.push(block(2_500_000));
+    expect(percents).toEqual([25]);
+  });
+
+  it("only emits when the integer percent changes", () => {
+    const { percents, parser } = collect(100);
+    parser.push(block(1_000_000));
+    parser.push(block(1_400_000));
+    parser.push(block(1_900_000));
+    parser.push(block(2_000_000));
+    expect(percents).toEqual([1, 2]);
+  });
+
+  it("handles blocks split across arbitrary chunk boundaries", () => {
+    const { percents, parser } = collect(10);
+    const text = block(5_000_000);
+    // Split mid-key and mid-value
+    parser.push(text.slice(0, 25));
+    parser.push(text.slice(25, 60));
+    parser.push(text.slice(60));
+    expect(percents).toEqual([50]);
+  });
+
+  it("clamps to 99 even when out_time overshoots the estimate", () => {
+    const { percents, parser } = collect(10);
+    parser.push(block(9_900_000));
+    parser.push(block(12_000_000));
+    parser.push(block(15_000_000, "end"));
+    expect(percents).toEqual([99]);
+  });
+
+  it("never goes backwards", () => {
+    const { percents, parser } = collect(10);
+    parser.push(block(5_000_000));
+    parser.push(block(4_000_000));
+    parser.push(block(6_000_000));
+    expect(percents).toEqual([50, 60]);
+  });
+
+  it("ignores N/A values", () => {
+    const { percents, parser } = collect(10);
+    parser.push("out_time_us=N/A\nprogress=continue\n");
+    expect(percents).toEqual([]);
+  });
+
+  it("falls back to out_time_ms (which ffmpeg also emits in microseconds)", () => {
+    const { percents, parser } = collect(10);
+    parser.push("out_time_ms=2500000\nprogress=continue\n");
+    expect(percents).toEqual([25]);
+  });
+
+  it("emits nothing for a non-positive total duration", () => {
+    const { percents, parser } = collect(0);
+    parser.push(block(5_000_000));
+    expect(percents).toEqual([]);
+  });
+
+  it("floors negative out_time to zero and emits it once", () => {
+    const { percents, parser } = collect(10);
+    // ffmpeg can report a small negative out_time before the first frame lands
+    parser.push("out_time_us=-125000\nprogress=continue\n");
+    parser.push(block(1_000_000));
+    expect(percents).toEqual([0, 10]);
+  });
+});

--- a/app/services/ffmpeg-progress.ts
+++ b/app/services/ffmpeg-progress.ts
@@ -1,0 +1,55 @@
+/**
+ * Incremental parser for ffmpeg's `-progress pipe:1` output.
+ *
+ * ffmpeg writes repeating key=value blocks (roughly every 500ms) terminated by
+ * a `progress=continue|end` line. The only key we need is `out_time_us` — the
+ * output timestamp in microseconds — which, divided by the expected output
+ * duration, yields a percentage. (`out_time_ms` is accepted as a fallback; due
+ * to a long-standing ffmpeg quirk it is *also* in microseconds.)
+ *
+ * Emission contract, shared with every consumer up the stack (exportVideoClips
+ * → SSE → upload reducer):
+ * - integer percents only, emitted only when the value changes (so a phase
+ *   emits at most ~100 events);
+ * - clamped to 0–99 — 100 is reserved for the caller's own completion signal;
+ * - monotonic: a percent lower than one already emitted is dropped.
+ */
+export const createFfmpegProgressParser = (opts: {
+  totalDurationSeconds: number;
+  onPercent: (percent: number) => void;
+}) => {
+  let leftover = "";
+  let lastPercent = -1;
+
+  const handleLine = (line: string) => {
+    const eq = line.indexOf("=");
+    if (eq === -1) return;
+    const key = line.slice(0, eq);
+    if (key !== "out_time_us" && key !== "out_time_ms") return;
+    const value = Number(line.slice(eq + 1));
+    if (!Number.isFinite(value)) return;
+
+    const outTimeSeconds = Math.max(0, value / 1_000_000);
+    const percent = Math.min(
+      99,
+      Math.floor((outTimeSeconds / opts.totalDurationSeconds) * 100)
+    );
+    if (percent > lastPercent) {
+      lastPercent = percent;
+      opts.onPercent(percent);
+    }
+  };
+
+  const push = (chunk: string) => {
+    if (opts.totalDurationSeconds <= 0) return;
+    leftover += chunk;
+    const lines = leftover.split("\n");
+    // The final element is an incomplete line (or "") — keep it for next push.
+    leftover = lines.pop() ?? "";
+    for (const line of lines) {
+      handleLine(line);
+    }
+  };
+
+  return { push };
+};

--- a/app/services/video-processing-service.ts
+++ b/app/services/video-processing-service.ts
@@ -142,6 +142,15 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
         onStageChange?: (
           stage: "concatenating-clips" | "normalizing-audio"
         ) => void;
+        /**
+         * Real per-phase progress from the underlying ffmpeg processes.
+         * `percent` is an integer 0–99 that resets when the stage changes;
+         * 100 is signalled by completion, not by this callback.
+         */
+        onProgress?: (info: {
+          stage: "concatenating-clips" | "normalizing-audio";
+          percent: number;
+        }) => void;
       }) {
         const FINISHED_VIDEOS_DIRECTORY = yield* Config.string(
           "FINISHED_VIDEOS_DIRECTORY"
@@ -154,13 +163,18 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
         const concatenatedPath =
           yield* ffmpegCommands.createAndConcatenateVideoClipsSinglePass(
             opts.clips,
-            VIDEO_FORMAT_DIMENSIONS[opts.format]
+            VIDEO_FORMAT_DIMENSIONS[opts.format],
+            (percent) =>
+              opts.onProgress?.({ stage: "concatenating-clips", percent })
           );
 
         // Normalize audio
         opts.onStageChange?.("normalizing-audio");
-        const normalizedPath =
-          yield* ffmpegCommands.normalizeAudio(concatenatedPath);
+        const normalizedPath = yield* ffmpegCommands.normalizeAudio(
+          concatenatedPath,
+          (percent) =>
+            opts.onProgress?.({ stage: "normalizing-audio", percent })
+        );
 
         // Move to final location
         const outputPath = path.join(


### PR DESCRIPTION
> Stacked on #1410 (`agent/publish-per-video-progress`) — retarget to `main` once that merges. Only the last two commits are this PR.

## The gap

#1410 made the export step observable per video, but the signals are still coarse stage callbacks emitted *around* the ffmpeg calls. The encodes themselves — minutes long — remained a black box. This PR wires real progress from the ffmpeg processes.

## How

**ffmpeg layer** (`app/services/ffmpeg-commands.ts`)
- New `runFfmpegWithProgress`: runs the two long encodes (clip concatenation, audio normalization) with `-progress pipe:1 -nostats`, switching from `Command.exitCode` to `Command.start` under a scope, draining stdout through a new incremental parser. Stderr stays inherited; error types/messages unchanged.
- `app/services/ffmpeg-progress.ts`: pure parser of ffmpeg's key=value progress blocks. Emission contract: integer percents only, only on change, clamped 0–99 (100 reserved for completion), monotonic. Expected duration: concat = Σ effective `-t` values; normalize = the already-ffprobed input duration (video is stream-copied).

**Process hardening** (`app/services/ffmpeg-child-registry.ts`)
- Scope-based teardown means fiber interruption (SSE disconnect, cancelled publish) now kills the child.
- Parent-death backstop: every spawned encode PID is registered; one-time `SIGINT`/`SIGTERM`/`exit` handlers reap whatever is still alive, so Ctrl-C on the dev server no longer orphans ffmpeg. (Hard `SIGKILL` of the parent remains uncoverable.)

**Service → SSE**
- `exportVideoClips` gains optional `onProgress({stage, percent})`; `onStageChange` untouched.
- The per-video fan-out duplicated between `batchExport` and `publishUnlocked` is extracted into `export-video-fanout.server.ts` (event names, ordering, `recurs(2)` retries, failure collection byte-identical — also keeps `course-publish-service.ts` inside the token budget). It now also emits `video-progress {videoId, stage, percent}`.
- Wire names: batch-export SSE `video-progress`; publish SSE maps it to `export-progress` (no collision with the Dropbox `upload-progress`); single-video export SSE forwards `video-progress {stage, percent}`.

**UI** (`upload-reducer.ts`, clients, registry, context)
- The existing per-video bars now fill with real percent: stage changes jump to band starts and `UPDATE_EXPORT_PROGRESS` fills within the band (concatenating 0–80, normalizing 80–99, one shared `EXPORT_STAGE_BANDS` table), monotonic — a server-side retry's restarted percents never drag the bar backwards. Wired for single export, batch export, and publish per-video entries.

Publish lifecycle semantics untouched (Submit/Promote/Discard, retries, auto-Discard) — observability only. cvm CLI compiles unchanged (all new parameters optional).

## Tests

- `ffmpeg-progress.test.ts`: 9 parser tests (chunk-boundary splits, clamping, monotonicity, N/A, `out_time_ms`-in-µs quirk, negative out_time).
- Progress events through the service seams (stubbed `exportVideoClips`) in `course-publish-service.test.ts` (batchExport) and `course-publish-service-publish.test.ts` (publish).
- Reducer banding/monotonicity tests in `upload-reducer-stages.test.ts`.
- `pnpm typecheck`, `lint:boundaries`, file-token budget: clean. Full suite: passing except the 20 known pre-existing failures in `app/cli/cli-segment-writes.test.ts` / `cli-backup-coordination.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)