### PR TITLE
fix(publish): survive Dropbox sync-client locks during the bundle commit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,14 @@ DROPBOX_PATH="/path/to/dropbox/courses"
 FINISHED_VIDEOS_DIRECTORY="/path/to/finished-videos"
 DUMP_FILE_LOCATION="/path/to/database-backups/cvm.sql"
 
+# Publish staging (optional)
+# Where publish stages the immutable asset bundle before renaming it into
+# DROPBOX_PATH. Keep this OUTSIDE the Dropbox-synced tree (the sync client
+# holds handles on files it is indexing, which breaks the bundle rename) but
+# on the SAME volume as DROPBOX_PATH (the rename must stay atomic).
+# Unset, staging happens inside the course dir as before.
+# PUBLISH_STAGING_DIR="/path/to/cvm-publish-staging"
+
 # pg_dump container name (default: ai-app-template-postgres)
 # PG_DUMP_CONTAINER="ai-app-template-postgres"
 

--- a/app/services/course-publish-dropbox.ts
+++ b/app/services/course-publish-dropbox.ts
@@ -1,4 +1,4 @@
-import { Config, Effect, Stream } from "effect";
+import { Config, Effect, Option, Schedule, Stream } from "effect";
 import { FileSystem } from "@effect/platform";
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
@@ -45,6 +45,31 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
     "FINISHED_VIDEOS_DIRECTORY"
   );
   const dropboxPath = yield* Config.string("DROPBOX_PATH");
+  // Optional out-of-tree staging area. The Dropbox client indexes files the
+  // moment they land inside the synced tree and holds open handles while it
+  // does, which makes the bundle rename below fail with EACCES on
+  // Windows-backed mounts. Staging outside the synced tree sidesteps the
+  // contention entirely; it must live on the same volume as DROPBOX_PATH so
+  // the rename into the bundle dir stays atomic.
+  const publishStagingDir = yield* Config.option(
+    Config.string("PUBLISH_STAGING_DIR")
+  );
+
+  // Rename through transient sync-client locks: while the Dropbox client is
+  // indexing freshly-written files it holds handles that surface as
+  // EACCES/EBUSY on rename. The contention clears once indexing finishes, so
+  // retry with backoff before treating the failure as real.
+  const renameThroughSyncLocks = (oldPath: string, newPath: string) =>
+    effectFs.rename(oldPath, newPath).pipe(
+      Effect.retry({
+        while: (error) =>
+          error._tag === "SystemError" &&
+          (error.reason === "PermissionDenied" || error.reason === "Busy"),
+        schedule: Schedule.exponential("1 second").pipe(
+          Schedule.intersect(Schedule.recurs(6))
+        ),
+      })
+    );
 
   const hashFile = Effect.fn("hashFileSha256")(function* (filePath: string) {
     const hash = createHash("sha256");
@@ -117,7 +142,10 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
   let completedLessons = 0;
   const syncId = randomUUID();
   const dropboxCourseDir = path.join(dropboxPath, repoWithSections.name);
-  const stagingDir = path.join(dropboxCourseDir, `.cvm-staging-${syncId}`);
+  const stagingDir = Option.match(publishStagingDir, {
+    onNone: () => path.join(dropboxCourseDir, `.cvm-staging-${syncId}`),
+    onSome: (dir) => path.join(dir, `cvm-staging-${syncId}`),
+  });
   const manifestTempPath = path.join(dropboxCourseDir, `.course-${syncId}.tmp`);
   const courseJsonPath = path.join(dropboxCourseDir, "course.json");
   const videoAssets = new Map<string, { sha256: string; bytes: number }>();
@@ -263,7 +291,7 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
         });
       }
     } else {
-      yield* effectFs.rename(stagingDir, finalBundleDir);
+      yield* renameThroughSyncLocks(stagingDir, finalBundleDir);
     }
 
     return manifestJson;
@@ -284,7 +312,7 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
     // duplication is deliberate — the bundle stays self-describing in isolation
     // while the root marker always names the current release — so it is the
     // final successful write.
-    yield* effectFs.rename(manifestTempPath, courseJsonPath);
+    yield* renameThroughSyncLocks(manifestTempPath, courseJsonPath);
   }).pipe(
     Effect.onError(() =>
       effectFs.remove(manifestTempPath, { force: true }).pipe(Effect.orDie)

--- a/app/services/course-publish-service-sync.test.ts
+++ b/app/services/course-publish-service-sync.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { ConfigProvider, Effect, Layer } from "effect";
+import { FileSystem } from "@effect/platform";
+import { SystemError } from "@effect/platform/Error";
 import { NodeContext } from "@effect/platform-node";
 import fs from "node:fs";
 import path from "node:path";
@@ -33,7 +35,12 @@ beforeAll(async () => {
   testDb = result.testDb;
 });
 
-const setupSync = async () => {
+const setupSync = async (options?: {
+  // Wrap the real FileSystem service — used to fault-inject the sync-client
+  // lock contention (EACCES on rename) the Dropbox client causes in production.
+  wrapFileSystem?: (real: FileSystem.FileSystem) => FileSystem.FileSystem;
+  publishStagingDir?: string;
+}) => {
   await truncateAllTables(testDb);
 
   finishedVideosDir = fs.mkdtempSync(path.join(tmpdir(), "sync-test-videos-"));
@@ -187,16 +194,27 @@ const setupSync = async () => {
       new Map([
         ["FINISHED_VIDEOS_DIRECTORY", finishedVideosDir],
         ["DROPBOX_PATH", dropboxDir],
+        ...(options?.publishStagingDir
+          ? [["PUBLISH_STAGING_DIR", options.publishStagingDir] as const]
+          : []),
       ])
     )
   );
+
+  const fsOverrideLayer = options?.wrapFileSystem
+    ? Layer.effect(
+        FileSystem.FileSystem,
+        Effect.map(FileSystem.FileSystem, options.wrapFileSystem)
+      ).pipe(Layer.provide(NodeContext.layer))
+    : Layer.empty;
 
   const coreTestLayer = Layer.mergeAll(
     CourseOperationsService.Default,
     VideoOperationsService.Default,
     VersionOperationsService.Default,
     mockVideoProcessing,
-    NodeContext.layer
+    NodeContext.layer,
+    fsOverrideLayer
   ).pipe(Layer.provide(drizzleLayer), Layer.provide(configLayer));
 
   const testLayer = Layer.merge(
@@ -222,6 +240,100 @@ describe("CoursePublishService.syncToDropbox", () => {
         yield* svc.syncToDropbox(course.id, true);
       })
     );
+
+    const courseDir = path.join(dropboxDir, "test-course");
+    const doc = readCourseManifest(courseDir);
+    for (const video of getManifestVideos(doc)) {
+      expect(
+        fs.existsSync(path.join(courseDir, ...video.relativePath.split("/")))
+      ).toBe(true);
+    }
+  });
+
+  it("retries the bundle rename through transient sync-client locks", async () => {
+    // The Dropbox client holds handles on files it is indexing, so on
+    // Windows-backed mounts the staging → bundle dir rename fails with EACCES
+    // until the client lets go. The commit must ride out the contention
+    // instead of discarding the publish.
+    let deniedRenames = 0;
+    const { course, dropboxDir, run } = await setupSync({
+      wrapFileSystem: (real) =>
+        FileSystem.make({
+          ...real,
+          // Effect.suspend so the deny-or-delegate decision is made on every
+          // execution — Effect.retry re-runs the constructed effect, it does
+          // not call this factory again.
+          rename: (oldPath, newPath) =>
+            Effect.suspend(() => {
+              if (
+                deniedRenames < 2 &&
+                newPath.includes(`versions${path.sep}`)
+              ) {
+                deniedRenames++;
+                return Effect.fail(
+                  new SystemError({
+                    reason: "PermissionDenied",
+                    module: "FileSystem",
+                    method: "rename",
+                    pathOrDescriptor: oldPath,
+                    description: "EACCES: permission denied (sync lock)",
+                  })
+                );
+              }
+              return real.rename(oldPath, newPath);
+            }),
+        }),
+    });
+
+    await run(
+      Effect.gen(function* () {
+        const svc = yield* CoursePublishService;
+        yield* svc.syncToDropbox(course.id, true);
+      })
+    );
+
+    expect(deniedRenames).toBe(2);
+    const courseDir = path.join(dropboxDir, "test-course");
+    const doc = readCourseManifest(courseDir);
+    for (const video of getManifestVideos(doc)) {
+      expect(
+        fs.existsSync(path.join(courseDir, ...video.relativePath.split("/")))
+      ).toBe(true);
+    }
+  }, 30_000);
+
+  it("stages outside the synced tree when PUBLISH_STAGING_DIR is set", async () => {
+    const stagingRoot = fs.mkdtempSync(
+      path.join(tmpdir(), "sync-test-staging-")
+    );
+    const renameSources: string[] = [];
+    const { course, dropboxDir, run } = await setupSync({
+      publishStagingDir: stagingRoot,
+      wrapFileSystem: (real) =>
+        FileSystem.make({
+          ...real,
+          rename: (oldPath, newPath) => {
+            renameSources.push(oldPath);
+            return real.rename(oldPath, newPath);
+          },
+        }),
+    });
+
+    await run(
+      Effect.gen(function* () {
+        const svc = yield* CoursePublishService;
+        yield* svc.syncToDropbox(course.id, true);
+      })
+    );
+
+    // The bundle was staged under PUBLISH_STAGING_DIR, never inside the
+    // synced tree, and the staging area is cleaned up afterwards.
+    const bundleRenameSource = renameSources.find((source) =>
+      source.includes("cvm-staging-")
+    );
+    expect(bundleRenameSource).toBeDefined();
+    expect(bundleRenameSource!.startsWith(stagingRoot)).toBe(true);
+    expect(fs.readdirSync(stagingRoot)).toEqual([]);
 
     const courseDir = path.join(dropboxDir, "test-course");
     const doc = readCourseManifest(courseDir);


### PR DESCRIPTION
## The bug

"AI Coding Crash Course" publishes have silently failed to land in Dropbox since the `versions/<hash>` bundle was introduced (42a09a2f, Jul 16). The upload completes, then the final `.cvm-staging-* → versions/<hash>` rename fails with **EACCES**: the Dropbox client indexes freshly-written files inside the synced tree and holds open handles, and Windows-backed mounts (drvfs/9p) refuse to rename a directory containing open files. The commit is auto-discarded as `sync_failed` with the cause swallowed (`Effect.exit` drops it).

Evidence (fs-failure probe preloaded into the CLI publish):

```
rename FAILED [.cvm-staging-… → versions/c29e5d7…] EACCES: permission denied
unlink FAILED [.cvm-staging-…/course.schema.json] EACCES: permission denied
```

Fallout: v0.5.3 of the crash course is marked **published in the DB but never landed in Dropbox** (`versions/` is empty; `course.json` still points at v0.5.2) — it predates the strict lifecycle, which is why it went unnoticed. Two full stale staging dirs (~8 GB) from Jul 20 are still in the course folder.

## The fix

1. **`PUBLISH_STAGING_DIR`** (optional): stage the bundle outside the synced tree, on the same volume, so the sync client never opens handles on staging files and the rename stays atomic. Unset ⇒ previous in-course-dir behavior.
2. **Retry both commit renames** (bundle dir + `course.json` receipt) through `PermissionDenied`/`Busy` with exponential backoff — covers the in-tree default and the receipt-rename window.

## Tests

- `retries the bundle rename through transient sync-client locks` — fault-injects EACCES twice via a wrapped `FileSystem` layer; red on main, green here.
- `stages outside the synced tree when PUBLISH_STAGING_DIR is set` — pins the staging location and cleanup.
- Full publish test suites pass (17 + 38).

## Follow-up worth considering

`course-publish-service.ts` swallows the commit error's cause when it maps to `PublishCommitFailedError { reason: "sync_failed" }` — surfacing the underlying description would have made this diagnosable from the UI message alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)