### PR TITLE
feat(section): section-level Scripts document view

### DIFF
--- a/app/features/course-view/section-script-field.tsx
+++ b/app/features/course-view/section-script-field.tsx
@@ -7,10 +7,10 @@ import {
   useRef,
   useState,
 } from "react";
+import { useFetcher } from "react-router";
 import { Maximize2Icon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { useVideoScript } from "@/features/video-editor/hooks/use-video-script";
 
 const SAVE_DEBOUNCE_MS = 700;
 
@@ -19,35 +19,50 @@ const SAVE_DEBOUNCE_MS = 700;
  * document ({@link SectionScriptsView}): a title, then an auto-growing textarea
  * that reads as flowing prose (no inner scrollbar) rather than a boxed editor.
  *
- * Loads and persists through the shared {@link useVideoScript} hook — the exact
- * same `/api/videos/:videoId/script` route as the per-video Script tab and the
- * fullscreen writer — so all three surfaces stay in sync. The "Open in writer"
- * button hands off to the full {@link ScriptWriterModal} (Monaco + preview) for
- * heavier editing; we deliberately don't stack `WritableField`s here because
- * they'd all share the single `?writer=video-script` URL slot and open at once.
+ * Reads are seeded from the section loader (`initialScript`) — no per-field
+ * fetch, so opening the tab doesn't fan out one heavy writer-context request per
+ * video. Writes go per-video through `/api/videos/:videoId/script` (silent
+ * autosave, debounced + on blur); the loader re-seeds the field on revalidation
+ * when it isn't focused. The "Open in writer" button hands off to the full
+ * {@link ScriptWriterModal} (Monaco + preview) for heavier editing; we
+ * deliberately don't stack `WritableField`s here because they'd all share the
+ * single `?writer=video-script` URL slot and open at once.
  */
 export function SectionScriptField({
   videoId,
   title,
+  initialScript,
   readOnly,
   onOpenWriter,
 }: {
   videoId: string;
   title: string;
+  initialScript: string;
   readOnly: boolean;
   onOpenWriter: () => void;
 }) {
-  const { loaded, script, persistScript } = useVideoScript(videoId);
+  const saveFetcher = useFetcher();
 
-  // Local draft so typing stays smooth; re-seed from the canonical value only
-  // when the user isn't editing this field (mirrors WritableField's approach).
-  const [draft, setDraft] = useState(script);
+  // Local draft so typing stays smooth; re-seed from the loader value only when
+  // the user isn't editing this field (mirrors WritableField's approach), so a
+  // revalidation can't clobber in-progress edits.
+  const [draft, setDraft] = useState(initialScript);
   const focusedRef = useRef(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (!focusedRef.current) setDraft(script);
-  }, [script]);
+    if (!focusedRef.current) setDraft(initialScript);
+  }, [initialScript]);
+
+  const persistScript = useCallback(
+    (value: string) => {
+      saveFetcher.submit(
+        { intent: "updateScript", script: value },
+        { method: "post", action: `/api/videos/${videoId}/script` }
+      );
+    },
+    [saveFetcher, videoId]
+  );
 
   const scheduleSave = useCallback(
     (value: string) => {
@@ -97,18 +112,14 @@ export function SectionScriptField({
         ref={textareaRef}
         value={draft}
         readOnly={readOnly}
-        placeholder={
-          loaded
-            ? "Write the teleprompter script for this video…"
-            : "Loading script…"
-        }
+        placeholder="Write the teleprompter script for this video…"
         onFocus={() => {
           focusedRef.current = true;
         }}
         onBlur={() => {
           focusedRef.current = false;
           if (saveTimer.current) clearTimeout(saveTimer.current);
-          if (draft !== script) persistScript(draft);
+          if (draft !== initialScript) persistScript(draft);
         }}
         onChange={(e) => {
           const value = e.target.value;

--- a/app/features/course-view/section-script-field.tsx
+++ b/app/features/course-view/section-script-field.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { Maximize2Icon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useVideoScript } from "@/features/video-editor/hooks/use-video-script";
+
+const SAVE_DEBOUNCE_MS = 700;
+
+/**
+ * One video's teleprompter script as a block in the section-level Scripts
+ * document ({@link SectionScriptsView}): a title, then an auto-growing textarea
+ * that reads as flowing prose (no inner scrollbar) rather than a boxed editor.
+ *
+ * Loads and persists through the shared {@link useVideoScript} hook — the exact
+ * same `/api/videos/:videoId/script` route as the per-video Script tab and the
+ * fullscreen writer — so all three surfaces stay in sync. The "Open in writer"
+ * button hands off to the full {@link ScriptWriterModal} (Monaco + preview) for
+ * heavier editing; we deliberately don't stack `WritableField`s here because
+ * they'd all share the single `?writer=video-script` URL slot and open at once.
+ */
+export function SectionScriptField({
+  videoId,
+  title,
+  readOnly,
+  onOpenWriter,
+}: {
+  videoId: string;
+  title: string;
+  readOnly: boolean;
+  onOpenWriter: () => void;
+}) {
+  const { loaded, script, persistScript } = useVideoScript(videoId);
+
+  // Local draft so typing stays smooth; re-seed from the canonical value only
+  // when the user isn't editing this field (mirrors WritableField's approach).
+  const [draft, setDraft] = useState(script);
+  const focusedRef = useRef(false);
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!focusedRef.current) setDraft(script);
+  }, [script]);
+
+  const scheduleSave = useCallback(
+    (value: string) => {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+      saveTimer.current = setTimeout(
+        () => persistScript(value),
+        SAVE_DEBOUNCE_MS
+      );
+    },
+    [persistScript]
+  );
+
+  useEffect(
+    () => () => {
+      if (saveTimer.current) clearTimeout(saveTimer.current);
+    },
+    []
+  );
+
+  // Auto-grow: keep the textarea tall enough to show all its text.
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  useLayoutEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [draft]);
+
+  return (
+    <div className="group">
+      <div className="flex items-center gap-2 mb-1">
+        <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+        {!readOnly && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1.5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+            onClick={onOpenWriter}
+            title="Open in writer"
+          >
+            <Maximize2Icon className="w-3.5 h-3.5" />
+          </Button>
+        )}
+      </div>
+      <textarea
+        ref={textareaRef}
+        value={draft}
+        readOnly={readOnly}
+        placeholder={
+          loaded
+            ? "Write the teleprompter script for this video…"
+            : "Loading script…"
+        }
+        onFocus={() => {
+          focusedRef.current = true;
+        }}
+        onBlur={() => {
+          focusedRef.current = false;
+          if (saveTimer.current) clearTimeout(saveTimer.current);
+          if (draft !== script) persistScript(draft);
+        }}
+        onChange={(e) => {
+          const value = e.target.value;
+          setDraft(value);
+          if (!readOnly) scheduleSave(value);
+        }}
+        className={cn(
+          "w-full resize-none bg-transparent text-sm leading-relaxed text-foreground",
+          "placeholder:text-muted-foreground focus:outline-none",
+          "border-l-2 border-transparent focus:border-primary/50 pl-3 -ml-3",
+          readOnly && "cursor-default"
+        )}
+        rows={2}
+      />
+    </div>
+  );
+}

--- a/app/features/course-view/section-scripts-utils.test.ts
+++ b/app/features/course-view/section-scripts-utils.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSectionScripts,
+  type SectionForScripts,
+} from "./section-scripts-utils";
+
+function makeSection(
+  lessons: SectionForScripts["lessons"]
+): SectionForScripts {
+  return { lessons };
+}
+
+describe("buildSectionScripts", () => {
+  it("preserves lesson and video order as given", () => {
+    const result = buildSectionScripts(
+      makeSection([
+        {
+          id: "l1",
+          title: "First",
+          path: "first",
+          videos: [
+            { id: "v1", title: "Intro", script: "a" },
+            { id: "v2", title: "Deep dive", script: "b" },
+          ],
+        },
+        {
+          id: "l2",
+          title: "Second",
+          path: "second",
+          videos: [{ id: "v3", title: "Wrap", script: "c" }],
+        },
+      ])
+    );
+
+    expect(result.map((l) => l.lessonId)).toEqual(["l1", "l2"]);
+    expect(result[0]!.videos.map((v) => v.videoId)).toEqual(["v1", "v2"]);
+  });
+
+  it("drops lessons with no videos", () => {
+    const result = buildSectionScripts(
+      makeSection([
+        { id: "l1", title: "Empty", path: "empty", videos: [] },
+        {
+          id: "l2",
+          title: "Has one",
+          path: "has-one",
+          videos: [{ id: "v1", title: "Only", script: "x" }],
+        },
+      ])
+    );
+
+    expect(result.map((l) => l.lessonId)).toEqual(["l2"]);
+  });
+
+  it("normalises missing and null scripts to empty strings", () => {
+    const result = buildSectionScripts(
+      makeSection([
+        {
+          id: "l1",
+          title: "Mixed",
+          path: "mixed",
+          videos: [
+            { id: "v1", title: "Null", script: null },
+            { id: "v2", title: "Absent" },
+            { id: "v3", title: "Present", script: "written" },
+          ],
+        },
+      ])
+    );
+
+    expect(result[0]!.videos.map((v) => v.script)).toEqual(["", "", "written"]);
+  });
+
+  it("yields an empty document when no lesson has any videos", () => {
+    const result = buildSectionScripts(
+      makeSection([
+        { id: "l1", title: "Empty one", path: "empty-one", videos: [] },
+        { id: "l2", title: "Empty two", path: "empty-two", videos: [] },
+      ])
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it("falls back to the lesson path when the title is null or empty", () => {
+    const result = buildSectionScripts(
+      makeSection([
+        {
+          id: "l1",
+          title: null,
+          path: "the-path",
+          videos: [{ id: "v1", title: "V", script: "s" }],
+        },
+      ])
+    );
+
+    expect(result[0]!.heading).toBe("the-path");
+  });
+});

--- a/app/features/course-view/section-scripts-utils.ts
+++ b/app/features/course-view/section-scripts-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * The view model behind the section page's **Scripts** tab: the whole section's
+ * teleprompter scripts flattened into one ordered document — lesson by lesson,
+ * video by video. See {@link SectionScriptsView} for the surface that renders it.
+ *
+ * Kept as a pure function so it can be unit-tested in isolation (mirrors
+ * section-grid-utils / section-transcript): lesson/video order is preserved as
+ * given, lessons with no videos are dropped (nothing to write), and every
+ * video's `script` is normalised to a plain string ("" when absent) so each
+ * field seeds from the loader without null-checking downstream.
+ */
+
+/** The loosest shape the builder needs — accepts loader and optimistic sections. */
+export type SectionForScripts = {
+  lessons: Array<{
+    id: string;
+    title: string | null;
+    path: string;
+    videos: Array<{ id: string; title: string; script?: string | null }>;
+  }>;
+};
+
+export type SectionScriptVideo = {
+  videoId: string;
+  title: string;
+  script: string;
+};
+
+export type SectionScriptLesson = {
+  lessonId: string;
+  /** Rendered heading — the lesson title, falling back to its derived path. */
+  heading: string;
+  videos: SectionScriptVideo[];
+};
+
+export function buildSectionScripts(
+  section: SectionForScripts
+): SectionScriptLesson[] {
+  return section.lessons
+    .map((lesson) => ({
+      lessonId: lesson.id,
+      heading: lesson.title || lesson.path,
+      videos: lesson.videos.map((video) => ({
+        videoId: video.id,
+        title: video.title,
+        script: video.script ?? "",
+      })),
+    }))
+    .filter((lesson) => lesson.videos.length > 0);
+}

--- a/app/features/course-view/section-scripts-view.tsx
+++ b/app/features/course-view/section-scripts-view.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { ScriptWriterModal } from "@/features/video-editor/script-writer-modal";
+import { SectionScriptField } from "./section-script-field";
+
+/**
+ * Minimal structural shape the Scripts document needs from a section. Kept
+ * loose so it accepts both the loader's Section and the optimistically-patched
+ * course-view section without type friction.
+ */
+type SectionForScripts = {
+  lessons: Array<{
+    id: string;
+    title: string | null;
+    path: string;
+    videos: Array<{ id: string; title: string }>;
+  }>;
+};
+
+/**
+ * The section page's **Scripts** tab: every video's teleprompter script in the
+ * section stitched into one long, editable document — lesson headings with each
+ * video's script as an inline {@link SectionScriptField} beneath. A top-level
+ * read/write view of the whole section's script, so you can draft it end to end
+ * without opening each video. Read-only on non-draft versions, matching the
+ * grid's ReadOnlyBanner.
+ */
+export function SectionScriptsView({
+  section,
+  readOnly,
+}: {
+  section: SectionForScripts;
+  readOnly: boolean;
+}) {
+  const [writerVideoId, setWriterVideoId] = useState<string | null>(null);
+
+  const lessonsWithVideos = section.lessons.filter((l) => l.videos.length > 0);
+
+  if (lessonsWithVideos.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        This section has no videos yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-10 pb-24">
+      {lessonsWithVideos.map((lesson) => (
+        <section key={lesson.id} className="space-y-5">
+          <h2 className="text-lg font-bold border-b border-border pb-1">
+            {lesson.title || lesson.path}
+          </h2>
+          {lesson.videos.map((video) => (
+            <SectionScriptField
+              key={video.id}
+              videoId={video.id}
+              title={video.title}
+              readOnly={readOnly}
+              onOpenWriter={() => setWriterVideoId(video.id)}
+            />
+          ))}
+        </section>
+      ))}
+
+      {writerVideoId && (
+        <ScriptWriterModal
+          videoId={writerVideoId}
+          open={writerVideoId !== null}
+          onOpenChange={(open) => {
+            if (!open) setWriterVideoId(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/features/course-view/section-scripts-view.tsx
+++ b/app/features/course-view/section-scripts-view.tsx
@@ -3,28 +3,22 @@
 import { useState } from "react";
 import { ScriptWriterModal } from "@/features/video-editor/script-writer-modal";
 import { SectionScriptField } from "./section-script-field";
-
-/**
- * Minimal structural shape the Scripts document needs from a section. Kept
- * loose so it accepts both the loader's Section and the optimistically-patched
- * course-view section without type friction.
- */
-type SectionForScripts = {
-  lessons: Array<{
-    id: string;
-    title: string | null;
-    path: string;
-    videos: Array<{ id: string; title: string }>;
-  }>;
-};
+import {
+  buildSectionScripts,
+  type SectionForScripts,
+} from "./section-scripts-utils";
 
 /**
  * The section page's **Scripts** tab: every video's teleprompter script in the
  * section stitched into one long, editable document — lesson headings with each
  * video's script as an inline {@link SectionScriptField} beneath. A top-level
  * read/write view of the whole section's script, so you can draft it end to end
- * without opening each video. Read-only on non-draft versions, matching the
- * grid's ReadOnlyBanner.
+ * without opening each video.
+ *
+ * Reads are seeded from the section loader (which re-attaches `script` for this
+ * one section — see the route loader) via the pure {@link buildSectionScripts}
+ * view model; writes still go per-video through `/api/videos/:videoId/script`.
+ * Read-only on non-draft versions, matching the grid's ReadOnlyBanner.
  */
 export function SectionScriptsView({
   section,
@@ -35,9 +29,9 @@ export function SectionScriptsView({
 }) {
   const [writerVideoId, setWriterVideoId] = useState<string | null>(null);
 
-  const lessonsWithVideos = section.lessons.filter((l) => l.videos.length > 0);
+  const lessons = buildSectionScripts(section);
 
-  if (lessonsWithVideos.length === 0) {
+  if (lessons.length === 0) {
     return (
       <div className="text-center py-12 text-muted-foreground">
         This section has no videos yet.
@@ -47,18 +41,19 @@ export function SectionScriptsView({
 
   return (
     <div className="max-w-3xl mx-auto space-y-10 pb-24">
-      {lessonsWithVideos.map((lesson) => (
-        <section key={lesson.id} className="space-y-5">
+      {lessons.map((lesson) => (
+        <section key={lesson.lessonId} className="space-y-5">
           <h2 className="text-lg font-bold border-b border-border pb-1">
-            {lesson.title || lesson.path}
+            {lesson.heading}
           </h2>
           {lesson.videos.map((video) => (
             <SectionScriptField
-              key={video.id}
-              videoId={video.id}
+              key={video.videoId}
+              videoId={video.videoId}
               title={video.title}
+              initialScript={video.script}
               readOnly={readOnly}
-              onOpenWriter={() => setWriterVideoId(video.id)}
+              onOpenWriter={() => setWriterVideoId(video.videoId)}
             />
           ))}
         </section>

--- a/app/routes/_app.courses.$courseId.sections.$sectionId.tsx
+++ b/app/routes/_app.courses.$courseId.sections.$sectionId.tsx
@@ -19,7 +19,14 @@ import {
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import { Effect } from "effect";
 import { ChevronLeft } from "lucide-react";
-import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Link,
   useFetcher,
@@ -47,6 +54,8 @@ import {
 } from "@/features/course-view/use-optimistic-course";
 import { DivergenceReportModal } from "@/features/course-view/divergence-report-modal";
 import { BeatDescriptionsProvider } from "@/features/beats/beat-descriptions-context";
+import { SectionScriptsView } from "@/features/course-view/section-scripts-view";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 
 export const meta: Route.MetaFunction = ({ data }) => {
   const section = data?.selectedCourse?.sections[0];
@@ -101,6 +110,8 @@ export default function Component(props: Route.ComponentProps) {
     createInitialCourseViewState(),
     {}
   );
+
+  const [activeTab, setActiveTab] = useState<"videos" | "scripts">("videos");
 
   const submit = useSubmit();
 
@@ -221,38 +232,62 @@ export default function Component(props: Route.ComponentProps) {
                   </div>
                 )}
 
-                <BeatDescriptionsProvider show>
-                  <SectionGrid
-                    currentCourse={currentCourse}
-                    data={loaderData}
-                    viewMode="compact"
-                    singleColumn
-                    sensors={sensors}
-                    handleSectionDragEnd={handleSectionDragEnd}
-                    priorityFilter={priorityFilter}
-                    iconFilter={iconFilter}
-                    todoFilter={todoFilter}
-                    searchQuery={searchQuery}
-                    addLessonSectionId={addLessonSectionId}
-                    insertAdjacentLessonId={insertAdjacentLessonId}
-                    insertPosition={insertPosition}
-                    editSectionId={editSectionId}
-                    addVideoToLessonId={addVideoToLessonId}
-                    deleteLessonId={deleteLessonId}
-                    editDescriptionLessonId={editDescriptionLessonId}
-                    archiveSectionId={archiveSectionId}
-                    collapsedSections={NO_COLLAPSED_SECTIONS}
-                    toggleSection={noopToggleSection}
-                    lessonSelection={lessonSelection}
-                    dispatch={dispatch}
-                    submitEvent={submitEvent}
-                    navigate={navigate}
-                    startExportUpload={startExportUpload}
-                    revealVideoFetcher={revealVideoFetcher}
-                    deleteVideoFileFetcher={deleteVideoFileFetcher}
-                    submitDeleteVideo={submitDeleteVideo}
-                  />
-                </BeatDescriptionsProvider>
+                <Tabs
+                  value={activeTab}
+                  onValueChange={(value) =>
+                    setActiveTab(value as "videos" | "scripts")
+                  }
+                >
+                  <TabsList className="mb-4">
+                    <TabsTrigger value="videos">Videos</TabsTrigger>
+                    <TabsTrigger value="scripts">Scripts</TabsTrigger>
+                  </TabsList>
+
+                  <TabsContent value="videos">
+                    <BeatDescriptionsProvider show>
+                      <SectionGrid
+                        currentCourse={currentCourse}
+                        data={loaderData}
+                        viewMode="compact"
+                        singleColumn
+                        sensors={sensors}
+                        handleSectionDragEnd={handleSectionDragEnd}
+                        priorityFilter={priorityFilter}
+                        iconFilter={iconFilter}
+                        todoFilter={todoFilter}
+                        searchQuery={searchQuery}
+                        addLessonSectionId={addLessonSectionId}
+                        insertAdjacentLessonId={insertAdjacentLessonId}
+                        insertPosition={insertPosition}
+                        editSectionId={editSectionId}
+                        addVideoToLessonId={addVideoToLessonId}
+                        deleteLessonId={deleteLessonId}
+                        editDescriptionLessonId={editDescriptionLessonId}
+                        archiveSectionId={archiveSectionId}
+                        collapsedSections={NO_COLLAPSED_SECTIONS}
+                        toggleSection={noopToggleSection}
+                        lessonSelection={lessonSelection}
+                        dispatch={dispatch}
+                        submitEvent={submitEvent}
+                        navigate={navigate}
+                        startExportUpload={startExportUpload}
+                        revealVideoFetcher={revealVideoFetcher}
+                        deleteVideoFileFetcher={deleteVideoFileFetcher}
+                        submitDeleteVideo={submitDeleteVideo}
+                      />
+                    </BeatDescriptionsProvider>
+                  </TabsContent>
+
+                  <TabsContent value="scripts">
+                    <SectionScriptsView
+                      section={section}
+                      readOnly={Boolean(
+                        loaderData.selectedVersion &&
+                        !loaderData.isLatestVersion
+                      )}
+                    />
+                  </TabsContent>
+                </Tabs>
               </>
             ) : (
               <div className="text-center py-12">

--- a/app/routes/_app.courses.$courseId.sections.$sectionId.tsx
+++ b/app/routes/_app.courses.$courseId.sections.$sectionId.tsx
@@ -9,6 +9,7 @@ import {
 import type { CourseEditorEvent } from "@/services/course-editor-service";
 import { makeLoader } from "@/services/route-action.server";
 import { courseViewEffect } from "@/features/course-view/course-view-loader.server";
+import { VideoOperationsService } from "@/services/db-video-operations.server";
 import { NotFoundError } from "@/services/db-service-errors";
 import {
   PointerSensor,
@@ -19,19 +20,13 @@ import {
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import { Effect } from "effect";
 import { ChevronLeft } from "lucide-react";
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef } from "react";
 import {
   Link,
   useFetcher,
   useLocation,
   useNavigate,
+  useSearchParams,
   useSubmit,
 } from "react-router";
 import { useEffectReducer } from "use-effect-reducer";
@@ -77,21 +72,47 @@ export const loader = async (args: Route.LoaderArgs) => {
         selectedVersionId,
         viewMode: "compact",
       }).pipe(
-        Effect.flatMap((result) => {
-          const sectionId = params.sectionId!;
-          const section = result.selectedCourse?.sections.find(
-            (s) => s.id === sectionId
-          );
-          if (!result.selectedCourse || !section) {
-            return Effect.fail(
-              new NotFoundError({ type: "section", params: { sectionId } })
+        Effect.flatMap((result) =>
+          Effect.gen(function* () {
+            const sectionId = params.sectionId!;
+            const section = result.selectedCourse?.sections.find(
+              (s) => s.id === sectionId
             );
-          }
-          return Effect.succeed({
-            ...result,
-            selectedCourse: { ...result.selectedCourse, sections: [section] },
-          });
-        })
+            if (!result.selectedCourse || !section) {
+              return yield* Effect.fail(
+                new NotFoundError({ type: "section", params: { sectionId } })
+              );
+            }
+
+            // Re-attach the full script text the course-view loader slims away
+            // (see `toSlimVideo`), scoped to just this one section, so the
+            // Scripts tab can seed every field from the loader without a
+            // per-field fetch. Writes still go per-video via the script route.
+            const videoIds = section.lessons.flatMap((lesson) =>
+              lesson.videos.map((video) => video.id)
+            );
+            const videoOps = yield* VideoOperationsService;
+            const scripts = yield* videoOps.getVideoScriptsByIds(videoIds);
+            const sectionWithScripts = {
+              ...section,
+              lessons: section.lessons.map((lesson) => ({
+                ...lesson,
+                videos: lesson.videos.map((video) => ({
+                  ...video,
+                  script: scripts[video.id] ?? null,
+                })),
+              })),
+            };
+
+            return {
+              ...result,
+              selectedCourse: {
+                ...result.selectedCourse,
+                sections: [sectionWithScripts],
+              },
+            };
+          })
+        )
       ),
   })(args);
 };
@@ -111,7 +132,11 @@ export default function Component(props: Route.ComponentProps) {
     {}
   );
 
-  const [activeTab, setActiveTab] = useState<"videos" | "scripts">("videos");
+  // Which tab is showing lives in the URL (`?view=scripts`) so it is
+  // bookmarkable, shareable, and survives refresh and focus-revalidation.
+  // Default (absent param) = videos.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = searchParams.get("view") === "scripts" ? "scripts" : "videos";
 
   const submit = useSubmit();
 
@@ -235,7 +260,14 @@ export default function Component(props: Route.ComponentProps) {
                 <Tabs
                   value={activeTab}
                   onValueChange={(value) =>
-                    setActiveTab(value as "videos" | "scripts")
+                    setSearchParams(
+                      (prev) => {
+                        if (value === "scripts") prev.set("view", "scripts");
+                        else prev.delete("view");
+                        return prev;
+                      },
+                      { replace: true, preventScrollReset: true }
+                    )
                   }
                 >
                   <TabsList className="mb-4">

--- a/app/services/db-video-operations.server.ts
+++ b/app/services/db-video-operations.server.ts
@@ -10,7 +10,7 @@ import {
   UnknownDBServiceError,
   VideoTitleTakenError,
 } from "@/services/db-service-errors";
-import { and, asc, desc, eq, isNull, ne } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, ne } from "drizzle-orm";
 import { Effect } from "effect";
 import { copyVideoImpl } from "@/services/db-video-operations.copy.server";
 import {
@@ -253,6 +253,28 @@ const createVideoOperationsUnwrapped = (db: Database, deps: VideoOpsDeps) => {
     }
 
     return video;
+  });
+
+  /**
+   * The full script text for a set of videos, keyed by video id. Powers the
+   * section page's Scripts tab, which re-attaches scripts to the one section it
+   * narrows to (the course-view loader slims them away — see `toSlimVideo`).
+   * Videos with no row / no id in the set are simply absent from the map.
+   */
+  const getVideoScriptsByIds = Effect.fn("getVideoScriptsByIds")(function* (
+    ids: string[]
+  ) {
+    if (ids.length === 0) return {} as Record<string, string | null>;
+    const rows = yield* makeDbCall(() =>
+      db.query.videos.findMany({
+        where: inArray(videos.id, ids),
+        columns: { id: true, script: true },
+      })
+    );
+    return Object.fromEntries(rows.map((row) => [row.id, row.script])) as Record<
+      string,
+      string | null
+    >;
   });
 
   const getVideoWithLessonById = Effect.fn("getVideoWithLessonById")(function* (
@@ -729,6 +751,7 @@ const createVideoOperationsUnwrapped = (db: Database, deps: VideoOpsDeps) => {
     getArchivedStandaloneVideos,
     getVideoWithClipsById,
     getVideoWithLessonById,
+    getVideoScriptsByIds,
     createVideo,
     createStandaloneVideo,
     hasOriginalFootagePathAlreadyBeenUsed,


### PR DESCRIPTION
## What

Adds a **Videos / Scripts** tabbed view to the section page (`/courses/:courseId/sections/:sectionId`). The new **Scripts** tab is a top-level, read/write view of the *whole section's* script: every video's teleprompter script stitched into one long editable document — lesson headings, with each video's script as an auto-growing textarea beneath it. You can draft a section's script end to end without opening each video.

Follows on from #1423 (per-video Script artifact).

## How

- The Scripts tab reuses the shared `useVideoScript` hook, so inline edits persist through the **same** `/api/videos/:videoId/script` route as the per-video Script tab and the fullscreen writer — all three surfaces stay in sync automatically.
- Each video block has an **"Open in writer"** button that hands off to the existing self-contained `ScriptWriterModal` (Monaco + preview) for heavier editing.
  - Deliberately *not* stacking `WritableField`s: they gate the fullscreen writer on `?writer=<fieldId>`, and every video script shares `fieldId="video-script"`, so one "open" click would open the modal on all of them at once. The lighter textarea + per-video modal handoff avoids that and reads more like one flowing document.
- **Read-only on non-draft versions**, matching the grid's `ReadOnlyBanner` (writes go through `requireDraftVersionForVideo`).

## Prototype scope / follow-ups

- Tab is **in-page component state** (not a URL route) — simplest for the section leaf route; can promote to a routed tab later.
- Scripts are **lazy-loaded per video** (each field fetches its own script). If a large section feels sluggish, add a dedicated batch section-scripts loader.
- Editing surface is a plain auto-growing **textarea** for a document feel; swap to Monaco per block if richer inline editing is wanted.

## Verification

- `pnpm run typecheck` passes.
- Prettier-formatted.
- Not yet exercised in a running browser — worth a manual pass on a section with several lessons/videos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)