### PR TITLE
chore: run all workflow agents on Opus 5

### DIFF
--- a/.sandcastle/architecture-review/architecture-review.ts
+++ b/.sandcastle/architecture-review/architecture-review.ts
@@ -23,7 +23,7 @@ const PromptOutput = z.discriminatedUnion("status", [
 
 const result = await runWithExtraction({
   name: `architecture-review-${new Date().toISOString().slice(0, 10)}`,
-  agent: sandcastle.claudeCode("claude-opus-4-6", {
+  agent: sandcastle.claudeCode("claude-opus-5", {
     env: {
       CLAUDE_CODE_OAUTH_TOKEN: required("CLAUDE_CODE_OAUTH_TOKEN"),
     },

--- a/.sandcastle/implement-pr/implement-pr.ts
+++ b/.sandcastle/implement-pr/implement-pr.ts
@@ -159,7 +159,7 @@ const prComments = {
 
 const result = await runWithExtraction({
   name: `implement-pr-${PR_NUMBER}`,
-  agent: sandcastle.claudeCode("claude-opus-4-6", {
+  agent: sandcastle.claudeCode("claude-opus-5", {
     env: {
       CLAUDE_CODE_OAUTH_TOKEN: required("CLAUDE_CODE_OAUTH_TOKEN"),
     },

--- a/.sandcastle/implement-prd/implement-prd.ts
+++ b/.sandcastle/implement-prd/implement-prd.ts
@@ -10,7 +10,7 @@ const BRANCH = required("BRANCH");
 
 const result = await sandcastle.run({
   name: `implement-prd-#${PRD_NUMBER}-sub-#${SUB_ISSUE_NUMBER}`,
-  agent: sandcastle.claudeCode("claude-opus-4-6", {
+  agent: sandcastle.claudeCode("claude-opus-5", {
     env: {
       CLAUDE_CODE_OAUTH_TOKEN: required("CLAUDE_CODE_OAUTH_TOKEN"),
     },

--- a/.sandcastle/implement/implement.ts
+++ b/.sandcastle/implement/implement.ts
@@ -11,7 +11,7 @@ const OUTPUT_DIR = process.env.OUTPUT_DIR ?? "/tmp";
 
 const result = await sandcastle.run({
   name: `implement-#${ISSUE_NUMBER}`,
-  agent: sandcastle.claudeCode("claude-opus-4-6", {
+  agent: sandcastle.claudeCode("claude-opus-5", {
     env: {
       CLAUDE_CODE_OAUTH_TOKEN: required("CLAUDE_CODE_OAUTH_TOKEN"),
     },

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -11,7 +11,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
   const plan = await sandcastle.run({
     sandbox: docker(),
     name: "Planner",
-    agent: sandcastle.claudeCode("claude-opus-4-6"),
+    agent: sandcastle.claudeCode("claude-opus-5"),
     promptFile: "./.sandcastle/plan-prompt.md",
   });
 
@@ -70,7 +70,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
 
         const result = await sandbox.run({
           name: "Implementer #" + issue.number,
-          agent: sandcastle.claudeCode("claude-opus-4-6"),
+          agent: sandcastle.claudeCode("claude-opus-5"),
           promptFile: "./.sandcastle/implement-prompt.md",
           promptArgs: {
             ISSUE_NUMBER: String(issue.number),
@@ -82,7 +82,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
         if (result.commits.length > 0) {
           await sandbox.run({
             name: "Reviewer #" + issue.number,
-            agent: sandcastle.claudeCode("claude-opus-4-6"),
+            agent: sandcastle.claudeCode("claude-opus-5"),
             promptFile: "./.sandcastle/review-prompt.md",
             promptArgs: {
               ISSUE_NUMBER: String(issue.number),
@@ -142,7 +142,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     sandbox: docker(),
     name: "Merger",
     maxIterations: 10,
-    agent: sandcastle.claudeCode("claude-opus-4-6"),
+    agent: sandcastle.claudeCode("claude-opus-5"),
     promptFile: "./.sandcastle/merge-prompt.md",
     promptArgs: {
       BRANCHES: completedBranches.map((b) => `- ${b}`).join("\n"),

--- a/.sandcastle/review/review.ts
+++ b/.sandcastle/review/review.ts
@@ -159,7 +159,7 @@ const prComments = {
 
 const result = await runWithExtraction({
   name: `review-pr-${PR_NUMBER}`,
-  agent: sandcastle.claudeCode("claude-opus-4-6", {
+  agent: sandcastle.claudeCode("claude-opus-5", {
     env: {
       CLAUDE_CODE_OAUTH_TOKEN: required("CLAUDE_CODE_OAUTH_TOKEN"),
     },

--- a/.sandcastle/to-issues-prd/to-issues-prd.ts
+++ b/.sandcastle/to-issues-prd/to-issues-prd.ts
@@ -21,7 +21,7 @@ const PromptOutput = z.object({
 
 const result = await runWithRetry({
   name: `to-issues-prd-#${PRD_NUMBER}`,
-  agent: sandcastle.claudeCode("claude-opus-4-6", {
+  agent: sandcastle.claudeCode("claude-opus-5", {
     env: {
       CLAUDE_CODE_OAUTH_TOKEN: required("CLAUDE_CODE_OAUTH_TOKEN"),
     },

--- a/.sandcastle/update-branch/update-branch.ts
+++ b/.sandcastle/update-branch/update-branch.ts
@@ -47,7 +47,7 @@ const PromptOutput = z.object({
 
 const result = await runWithExtraction({
   name: `update-branch-pr-${PR_NUMBER}`,
-  agent: sandcastle.claudeCode("claude-opus-4-6", {
+  agent: sandcastle.claudeCode("claude-opus-5", {
     env: {
       CLAUDE_CODE_OAUTH_TOKEN: required("CLAUDE_CODE_OAUTH_TOKEN"),
     },

--- a/.sandcastle/write-pr/write-pr.ts
+++ b/.sandcastle/write-pr/write-pr.ts
@@ -17,7 +17,7 @@ const PromptOutput = z.object({
 
 const result = await runWithRetry({
   name: `write-pr-#${ISSUE_NUMBER}`,
-  agent: sandcastle.claudeCode("claude-opus-4-6", {
+  agent: sandcastle.claudeCode("claude-opus-5", {
     env: {
       CLAUDE_CODE_OAUTH_TOKEN: required("CLAUDE_CODE_OAUTH_TOKEN"),
     },

--- a/.sandcastle/write-prd-pr/write-prd-pr.ts
+++ b/.sandcastle/write-prd-pr/write-prd-pr.ts
@@ -16,7 +16,7 @@ const PromptOutput = z.object({
 
 const result = await runWithRetry({
   name: `write-prd-pr-#${PRD_NUMBER}`,
-  agent: sandcastle.claudeCode("claude-opus-4-6", {
+  agent: sandcastle.claudeCode("claude-opus-5", {
     env: {
       CLAUDE_CODE_OAUTH_TOKEN: required("CLAUDE_CODE_OAUTH_TOKEN"),
     },


### PR DESCRIPTION
Repoints every `.sandcastle` agent invoked by a GitHub workflow from
`claude-opus-4-6` to `claude-opus-5` — 13 call sites across 10 files:

- `main.ts` (4 sites), `implement/`, `implement-pr/`, `implement-prd/`,
  `review/`, `architecture-review/`, `to-issues-prd/`, `update-branch/`,
  `write-pr/`, `write-prd-pr/`

The workflow YAML pins no model — the model lives in the sandcastle script
each workflow runs, so that's where the change is.

`scripts/prototype-generate-chapters.ts` is left on `claude-sonnet-4-5`: it's a
prototype script, not run by any workflow.

`pnpm typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)