### PR TITLE
Stop persisting the writer document to localStorage

### DIFF
--- a/app/features/article-writer/document-tool-calls.test.ts
+++ b/app/features/article-writer/document-tool-calls.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import { fromPartial } from "@total-typescript/shoehorn";
+import {
+  applyDocumentToolCalls,
+  collectDocumentToolCallIds,
+  getStreamingDocument,
+} from "./document-tool-calls";
+import type { DocumentAgentMessage } from "./types";
+import type { DocumentEdit } from "./document-editing-engine";
+
+type Part = DocumentAgentMessage["parts"][number];
+
+function assistant(...parts: Part[]): DocumentAgentMessage {
+  return { id: `m-${parts.length}`, role: "assistant", parts };
+}
+
+function write(
+  toolCallId: string,
+  content: string,
+  state: "input-available" | "input-streaming" = "input-available"
+): Part {
+  return fromPartial<Part>({
+    type: "tool-writeDocument",
+    toolCallId,
+    state,
+    input: { content },
+  });
+}
+
+function edit(toolCallId: string, edits: DocumentEdit[]): Part {
+  return fromPartial<Part>({
+    type: "tool-editDocument",
+    toolCallId,
+    state: "input-available",
+    input: { edits },
+  });
+}
+
+const nothingProcessed = new Set<string>();
+
+describe("applyDocumentToolCalls", () => {
+  it("leaves the document alone when there is nothing to process", () => {
+    const outcome = applyDocumentToolCalls({
+      messages: [],
+      document: "# Loader value",
+      processedToolCallIds: nothingProcessed,
+    });
+    expect(outcome).toEqual({
+      document: "# Loader value",
+      processedToolCallIds: [],
+      outputs: [],
+    });
+  });
+
+  it("replaces the document with a writeDocument call's content", () => {
+    const outcome = applyDocumentToolCalls({
+      messages: [assistant(write("call-1", "# Written"))],
+      document: "# Loader value",
+      processedToolCallIds: nothingProcessed,
+    });
+    expect(outcome.document).toBe("# Written");
+    expect(outcome.processedToolCallIds).toEqual(["call-1"]);
+    expect(outcome.outputs).toEqual([
+      {
+        tool: "writeDocument",
+        toolCallId: "call-1",
+        output: "Document written successfully.",
+      },
+    ]);
+  });
+
+  it("applies an edit on top of a write from the same pass", () => {
+    const outcome = applyDocumentToolCalls({
+      messages: [
+        assistant(write("call-1", "# Title\n\nBody.")),
+        assistant(
+          edit("call-2", [
+            { type: "replace", old_text: "Body.", new_text: "Better body." },
+          ])
+        ),
+      ],
+      document: undefined,
+      processedToolCallIds: nothingProcessed,
+    });
+    expect(outcome.document).toBe("# Title\n\nBetter body.");
+    expect(outcome.processedToolCallIds).toEqual(["call-1", "call-2"]);
+  });
+
+  it("reports a failed edit without touching the document", () => {
+    const outcome = applyDocumentToolCalls({
+      messages: [
+        assistant(
+          edit("call-1", [
+            { type: "replace", old_text: "missing", new_text: "x" },
+          ])
+        ),
+      ],
+      document: "# Loader value",
+      processedToolCallIds: nothingProcessed,
+    });
+    expect(outcome.document).toBe("# Loader value");
+    expect(outcome.outputs[0]!.output).toContain("not found in document");
+  });
+
+  it("skips tool calls that have already been processed", () => {
+    const outcome = applyDocumentToolCalls({
+      messages: [assistant(write("call-1", "# Stale draft"))],
+      document: "# Loader value",
+      processedToolCallIds: new Set(["call-1"]),
+    });
+    expect(outcome.document).toBe("# Loader value");
+    expect(outcome.outputs).toEqual([]);
+  });
+
+  it("ignores calls whose input is still streaming", () => {
+    const outcome = applyDocumentToolCalls({
+      messages: [assistant(write("call-1", "# Half-w", "input-streaming"))],
+      document: "# Loader value",
+      processedToolCallIds: nothingProcessed,
+    });
+    expect(outcome.document).toBe("# Loader value");
+    expect(outcome.processedToolCallIds).toEqual([]);
+  });
+
+  // The conversation outlives the session that produced it, so reopening the
+  // writer replays messages whose writeDocument calls describe a document that
+  // may since have been superseded. Marking those calls processed on mount is
+  // what keeps the loader's value authoritative.
+  describe("a restored conversation", () => {
+    const restored = [assistant(write("call-1", "# Stale draft"))];
+
+    it("cannot overwrite the value the loader supplied", () => {
+      const outcome = applyDocumentToolCalls({
+        messages: restored,
+        document: "# Loader value",
+        processedToolCallIds: new Set(collectDocumentToolCallIds(restored)),
+      });
+      expect(outcome.document).toBe("# Loader value");
+    });
+
+    it("does not block tool calls issued after the writer opened", () => {
+      const outcome = applyDocumentToolCalls({
+        messages: [...restored, assistant(write("call-2", "# Fresh"))],
+        document: "# Loader value",
+        processedToolCallIds: new Set(collectDocumentToolCallIds(restored)),
+      });
+      expect(outcome.document).toBe("# Fresh");
+      expect(outcome.processedToolCallIds).toEqual(["call-2"]);
+    });
+  });
+});
+
+describe("collectDocumentToolCallIds", () => {
+  it("collects settled document tool calls only", () => {
+    expect(
+      collectDocumentToolCallIds([
+        assistant(
+          write("call-1", "# One"),
+          write("call-2", "# Two", "input-streaming")
+        ),
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        assistant(edit("call-3", [{ type: "rewrite", new_text: "# Three" }])),
+      ])
+    ).toEqual(["call-1", "call-3"]);
+  });
+});
+
+describe("getStreamingDocument", () => {
+  it("returns the content of the in-flight write", () => {
+    expect(
+      getStreamingDocument([
+        assistant(write("call-1", "# Half", "input-streaming")),
+      ])
+    ).toBe("# Half");
+  });
+
+  it("returns undefined when nothing is streaming", () => {
+    expect(getStreamingDocument([assistant(write("call-1", "# Done"))])).toBe(
+      undefined
+    );
+  });
+});

--- a/app/features/article-writer/document-tool-calls.ts
+++ b/app/features/article-writer/document-tool-calls.ts
@@ -1,0 +1,151 @@
+/**
+ * Pure reduction of a chat transcript's document tool calls (`writeDocument`,
+ * `editDocument`) into a document string.
+ *
+ * The writer executes these tools client-side: the model emits a tool call, the
+ * UI folds it into the working document and reports an output back to the chat.
+ * Keeping the fold pure means the hook that drives it is a single effect over
+ * `messages` rather than one effect per tool, and the interesting cases (an edit
+ * landing on top of a write, a failed edit, a replayed transcript) are testable
+ * without React.
+ */
+
+import { applyEdits, type DocumentEdit } from "./document-editing-engine";
+import type { DocumentAgentMessage } from "./types";
+
+export type DocumentToolOutput = {
+  tool: "writeDocument" | "editDocument";
+  toolCallId: string;
+  output: string;
+};
+
+export type DocumentToolCallOutcome = {
+  /** The document after folding in every not-yet-processed tool call. */
+  document: string | undefined;
+  /** Tool call ids folded in by this pass — none of them were processed before. */
+  processedToolCallIds: string[];
+  /** Outputs to report back to the chat, in the order they were produced. */
+  outputs: DocumentToolOutput[];
+};
+
+type DocumentToolPart = Extract<
+  DocumentAgentMessage["parts"][number],
+  { type: "tool-writeDocument" | "tool-editDocument" }
+>;
+
+/** The same union, with `input` known to have arrived. */
+type SettledDocumentToolPart = DocumentToolPart extends infer Part
+  ? Part extends DocumentToolPart
+    ? Part & { input: NonNullable<Part["input"]> }
+    : never
+  : never;
+
+/**
+ * A tool call whose input has stopped streaming, and so can be executed.
+ * `input-streaming` parts are handled by {@link getStreamingDocument} instead.
+ */
+function isSettledDocumentToolCall(
+  part: DocumentAgentMessage["parts"][number]
+): part is SettledDocumentToolPart {
+  return (
+    (part.type === "tool-writeDocument" || part.type === "tool-editDocument") &&
+    part.state !== "input-streaming" &&
+    Boolean(part.input)
+  );
+}
+
+function* settledDocumentToolCalls(messages: DocumentAgentMessage[]) {
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    for (const part of message.parts) {
+      if (isSettledDocumentToolCall(part)) yield part;
+    }
+  }
+}
+
+/**
+ * Every settled document tool call in the transcript. Used to mark a restored
+ * conversation's tool calls as already-processed, so replaying old messages
+ * never overwrites the document the route loader supplied.
+ */
+export function collectDocumentToolCallIds(
+  messages: DocumentAgentMessage[]
+): string[] {
+  return Array.from(settledDocumentToolCalls(messages), (p) => p.toolCallId);
+}
+
+/**
+ * Fold every tool call not present in `processedToolCallIds` into `document`,
+ * in transcript order, so an edit sees the document as left by an earlier write.
+ */
+export function applyDocumentToolCalls(opts: {
+  messages: DocumentAgentMessage[];
+  document: string | undefined;
+  processedToolCallIds: ReadonlySet<string>;
+}): DocumentToolCallOutcome {
+  const { messages, document, processedToolCallIds } = opts;
+
+  let current = document;
+  const processed: string[] = [];
+  const outputs: DocumentToolOutput[] = [];
+
+  for (const part of settledDocumentToolCalls(messages)) {
+    if (processedToolCallIds.has(part.toolCallId)) continue;
+    processed.push(part.toolCallId);
+
+    if (part.type === "tool-writeDocument") {
+      current = part.input.content;
+      outputs.push({
+        tool: "writeDocument",
+        toolCallId: part.toolCallId,
+        output: "Document written successfully.",
+      });
+      continue;
+    }
+
+    const result = applyEdits(
+      current ?? "",
+      part.input.edits as DocumentEdit[]
+    );
+    if ("error" in result) {
+      outputs.push({
+        tool: "editDocument",
+        toolCallId: part.toolCallId,
+        output: result.error,
+      });
+    } else {
+      current = result.document;
+      outputs.push({
+        tool: "editDocument",
+        toolCallId: part.toolCallId,
+        output: "Document edited successfully.",
+      });
+    }
+  }
+
+  return { document: current, processedToolCallIds: processed, outputs };
+}
+
+/**
+ * The content of the last in-flight `writeDocument` call, so the document panel
+ * can render the article as the model types it. Returns undefined when nothing
+ * is streaming.
+ */
+export function getStreamingDocument(
+  messages: DocumentAgentMessage[]
+): string | undefined {
+  let streaming: string | undefined;
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    for (const part of message.parts) {
+      if (
+        part.type === "tool-writeDocument" &&
+        part.state === "input-streaming" &&
+        part.input?.content
+      ) {
+        streaming = part.input.content;
+      }
+    }
+  }
+  return streaming;
+}

--- a/app/features/article-writer/use-document-flow.ts
+++ b/app/features/article-writer/use-document-flow.ts
@@ -1,38 +1,26 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  applyDocumentToolCalls,
+  collectDocumentToolCallIds,
+  getStreamingDocument,
+} from "./document-tool-calls";
 import type { DocumentAgentMessage, Mode } from "./types";
-import { loadDocumentFromStorage, saveDocumentToStorage } from "./write-utils";
-import { applyEdits, type DocumentEdit } from "./document-editing-engine";
-
-function getAlreadyProcessedToolCallIds(
-  messages: DocumentAgentMessage[],
-  videoId: string,
-  mode: Mode
-): Set<string> {
-  const existing = loadDocumentFromStorage(videoId, mode);
-  if (!existing) return new Set();
-  const ids = new Set<string>();
-  for (const message of messages) {
-    if (message.role !== "assistant") continue;
-    for (const part of message.parts) {
-      if (
-        (part.type === "tool-writeDocument" ||
-          part.type === "tool-editDocument") &&
-        part.state !== "input-streaming"
-      ) {
-        ids.add(part.toolCallId);
-      }
-    }
-  }
-  return ids;
-}
 
 /**
- * Manages document state for the article mode document flow.
- * Handles writeDocument tool call interception, live streaming,
- * and localStorage persistence.
+ * Manages the working document for the article-mode document flow: executes
+ * `writeDocument`/`editDocument` tool calls client-side and streams the
+ * document in live while the model writes it.
+ *
+ * The document is deliberately **not** persisted. Its single source of truth is
+ * `initialDocument`, supplied by the route loader (i.e. the database), and it
+ * lives in memory for the life of the writer. Chat messages *are* persisted to
+ * localStorage by the caller — which is why a restored conversation's tool
+ * calls are marked processed on mount: replaying them would otherwise overwrite
+ * the loader's value with output from a previous session.
  */
 export function useDocumentFlow(opts: {
-  videoId: string;
+  /** The persisted value from the route loader — the source of truth. */
+  initialDocument?: string;
   mode: Mode;
   isDocumentMode: boolean;
   messages: DocumentAgentMessage[];
@@ -42,138 +30,87 @@ export function useDocumentFlow(opts: {
     toolCallId: string;
     output: string;
   }) => Promise<void>;
+  /** Notified on every document change, including AI-driven ones. */
+  onDocumentChange?: (document: string) => void;
 }) {
-  const { videoId, mode, isDocumentMode, messages, status, addToolOutput } =
-    opts;
+  const {
+    initialDocument,
+    mode,
+    isDocumentMode,
+    messages,
+    status,
+    addToolOutput,
+    onDocumentChange,
+  } = opts;
 
-  const [document, setDocument] = useState<string | undefined>(() =>
-    loadDocumentFromStorage(videoId, mode)
+  const [document, setDocumentState] = useState<string | undefined>(
+    initialDocument
   );
 
-  // Reload document from localStorage when mode changes
-  const prevModeRef = useRef(mode);
-  useEffect(() => {
-    if (prevModeRef.current !== mode) {
-      prevModeRef.current = mode;
-      setDocument(loadDocumentFromStorage(videoId, mode));
-      processedToolCallsRef.current = getAlreadyProcessedToolCallIds(
-        messages,
-        videoId,
-        mode
-      );
-    }
-  }, [mode, videoId, messages]);
-
-  // Ref tracks latest document for use in async callbacks (avoids stale closures)
+  // Ref tracks latest document for use in async callbacks and effects that must
+  // not re-run when it changes (avoids stale closures without extra deps).
   const documentRef = useRef(document);
   documentRef.current = document;
 
+  const onDocumentChangeRef = useRef(onDocumentChange);
+  onDocumentChangeRef.current = onDocumentChange;
+
+  const setDocument = useCallback((content: string | undefined) => {
+    setDocumentState(content);
+    documentRef.current = content;
+    onDocumentChangeRef.current?.(content ?? "");
+  }, []);
+
   const processedToolCallsRef = useRef<Set<string>>(
-    // On mount, if a document already exists in storage, mark all existing
-    // writeDocument/editDocument tool calls as already processed so they
-    // don't re-run and overwrite the (potentially updated) stored document.
-    getAlreadyProcessedToolCallIds(messages, videoId, mode)
+    // On mount, treat every tool call in the restored conversation as already
+    // executed: the loader owns the document, not the transcript.
+    new Set(collectDocumentToolCallIds(messages))
   );
 
-  // Handle completed writeDocument tool calls
+  // Switching mode swaps in that mode's stored conversation, whose tool calls
+  // belong to an earlier session — mark them processed for the same reason.
+  // The document itself is unaffected: a field has one working document,
+  // whichever mode wrote it.
+  const prevModeRef = useRef(mode);
+  useEffect(() => {
+    if (prevModeRef.current === mode) return;
+    prevModeRef.current = mode;
+    processedToolCallsRef.current = new Set(
+      collectDocumentToolCallIds(messages)
+    );
+  }, [mode, messages]);
+
+  // Execute newly-settled document tool calls.
   useEffect(() => {
     if (!isDocumentMode) return;
-    for (const message of messages) {
-      if (message.role !== "assistant") continue;
-      for (const part of message.parts) {
-        if (
-          part.type === "tool-writeDocument" &&
-          part.state !== "input-streaming" &&
-          part.input &&
-          !processedToolCallsRef.current.has(part.toolCallId)
-        ) {
-          processedToolCallsRef.current.add(part.toolCallId);
-          const content = part.input.content;
-          setDocument(content);
-          saveDocumentToStorage(videoId, mode, content);
-          addToolOutput({
-            tool: "writeDocument",
-            toolCallId: part.toolCallId,
-            output: "Document written successfully.",
-          });
-        }
-      }
+    const outcome = applyDocumentToolCalls({
+      messages,
+      document: documentRef.current,
+      processedToolCallIds: processedToolCallsRef.current,
+    });
+    if (outcome.processedToolCallIds.length === 0) return;
+    for (const id of outcome.processedToolCallIds) {
+      processedToolCallsRef.current.add(id);
     }
-  }, [messages, isDocumentMode, videoId, addToolOutput]);
-
-  // Handle completed editDocument tool calls
-  useEffect(() => {
-    if (!isDocumentMode) return;
-    for (const message of messages) {
-      if (message.role !== "assistant") continue;
-      for (const part of message.parts) {
-        if (
-          part.type === "tool-editDocument" &&
-          part.state !== "input-streaming" &&
-          part.input &&
-          !processedToolCallsRef.current.has(part.toolCallId)
-        ) {
-          processedToolCallsRef.current.add(part.toolCallId);
-          const edits = part.input.edits as DocumentEdit[];
-          const currentDoc = documentRef.current ?? "";
-          const result = applyEdits(currentDoc, edits);
-          if ("error" in result) {
-            addToolOutput({
-              tool: "editDocument",
-              toolCallId: part.toolCallId,
-              output: result.error,
-            });
-          } else {
-            setDocument(result.document);
-            saveDocumentToStorage(videoId, mode, result.document);
-            addToolOutput({
-              tool: "editDocument",
-              toolCallId: part.toolCallId,
-              output: "Document edited successfully.",
-            });
-          }
-        }
-      }
+    setDocument(outcome.document);
+    for (const output of outcome.outputs) {
+      addToolOutput(output);
     }
-  }, [messages, isDocumentMode, videoId, addToolOutput]);
+  }, [messages, isDocumentMode, addToolOutput, setDocument]);
 
-  // Stream document content live during writeDocument tool call
+  // Stream document content live during an in-flight writeDocument call.
   useEffect(() => {
     if (!isDocumentMode) return;
     if (status !== "streaming" && status !== "submitted") return;
-    for (const message of messages) {
-      if (message.role !== "assistant") continue;
-      for (const part of message.parts) {
-        if (
-          part.type === "tool-writeDocument" &&
-          part.state === "input-streaming" &&
-          part.input?.content
-        ) {
-          setDocument(part.input.content);
-        }
-      }
-    }
-  }, [messages, isDocumentMode, status]);
+    const streaming = getStreamingDocument(messages);
+    if (streaming !== undefined) setDocument(streaming);
+  }, [messages, isDocumentMode, status, setDocument]);
 
-  const clearDocument = () => {
-    setDocument(undefined);
-    saveDocumentToStorage(videoId, mode, undefined);
+  /** Drop the session's work and return to the loader's value. */
+  const resetDocument = useCallback(() => {
+    setDocument(initialDocument);
     processedToolCallsRef.current.clear();
-  };
+  }, [initialDocument, setDocument]);
 
-  const saveDocument = () => {
-    if (document) {
-      saveDocumentToStorage(videoId, mode, document);
-    }
-  };
-
-  const updateDocument = useCallback(
-    (content: string) => {
-      setDocument(content);
-      saveDocumentToStorage(videoId, mode, content);
-    },
-    [videoId, mode]
-  );
-
-  return { document, documentRef, clearDocument, saveDocument, updateDocument };
+  return { document, documentRef, resetDocument, updateDocument: setDocument };
 }

--- a/app/features/article-writer/writable-field.test.ts
+++ b/app/features/article-writer/writable-field.test.ts
@@ -2,8 +2,6 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   loadFieldMessages,
   saveFieldMessages,
-  loadFieldDocument,
-  saveFieldDocument,
   FIELD_MODES,
   constrainModes,
 } from "./writer-engine-utils";
@@ -18,7 +16,7 @@ function createMockLocalStorage() {
     get length() {
       return store.size;
     },
-    key: (_index: number) => null,
+    key: (index: number) => [...store.keys()][index] ?? null,
   } satisfies Storage;
 }
 
@@ -98,18 +96,10 @@ describe("WritableField Apply/Cancel semantics", () => {
     });
   });
 
-  describe("Apply uses working document value", () => {
-    it("document value persisted during session is available for apply", () => {
-      const videoId = "v1";
-      const fieldId = "ai-hero-body" as const;
-      const mode = "article" as const;
-
-      saveFieldDocument(videoId, fieldId, mode, "# Draft article");
-
-      const workingValue = loadFieldDocument(videoId, fieldId, mode);
-      expect(workingValue).toBe("# Draft article");
-    });
-
+  describe("Apply/Cancel act on messages only", () => {
+    // The document itself is not persisted — the route loader owns it, and the
+    // fold that keeps a restored conversation from overwriting it is covered in
+    // document-tool-calls.test.ts.
     it("apply does not revert messages (only cancel does)", () => {
       const videoId = "v1";
       const fieldId = "skills-changelog-body" as const;
@@ -186,16 +176,14 @@ describe("WritableField keying isolation", () => {
     ]);
   });
 
-  it("documents are keyed independently from messages", () => {
+  it("stores nothing but conversations", () => {
     saveFieldMessages("v1", "ai-hero-body", "article", [{ id: "msg" }]);
-    saveFieldDocument("v1", "ai-hero-body", "article", "# Document");
 
-    expect(loadFieldMessages("v1", "ai-hero-body", "article")).toEqual([
-      { id: "msg" },
-    ]);
-    expect(loadFieldDocument("v1", "ai-hero-body", "article")).toBe(
-      "# Document"
-    );
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      keys.push(localStorage.key(i)!);
+    }
+    expect(keys).toEqual(["writer-field-messages-v1-ai-hero-body-article"]);
   });
 });
 

--- a/app/features/article-writer/write-page.tsx
+++ b/app/features/article-writer/write-page.tsx
@@ -212,9 +212,11 @@ export function WritePage({ videoId, loaderData }: WritePageProps) {
     }
   }, [blocker]);
 
-  const { document, documentRef, clearDocument, saveDocument, updateDocument } =
+  // No persisted document backs this page — it is a scratchpad whose output is
+  // exported explicitly (Apply / write-to-readme / copy), so the document lives
+  // in memory only. The conversation still survives a reload.
+  const { document, documentRef, resetDocument, updateDocument } =
     useDocumentFlow({
-      videoId,
       mode,
       isDocumentMode,
       messages,
@@ -357,7 +359,6 @@ export function WritePage({ videoId, loaderData }: WritePageProps) {
 
     if (transitionedToReady) {
       saveMessagesToStorage(videoId, mode, messages);
-      if (isDocumentMode) saveDocument();
       return;
     }
 
@@ -367,7 +368,7 @@ export function WritePage({ videoId, loaderData }: WritePageProps) {
     if (isDocumentMode && status === "ready" && messages.length > 0) {
       saveMessagesToStorage(videoId, mode, messages);
     }
-  }, [status, videoId, mode, messages, isDocumentMode, saveDocument]);
+  }, [status, videoId, mode, messages, isDocumentMode]);
 
   const handleModeChange = (newMode: Mode) => {
     if (messages.length > 0) {
@@ -397,7 +398,7 @@ export function WritePage({ videoId, loaderData }: WritePageProps) {
     setMessages([]);
     clearQueue();
     saveMessagesToStorage(videoId, mode, []);
-    if (isDocumentMode) clearDocument();
+    if (isDocumentMode) resetDocument();
   };
 
   const getBodyPayload = useCallback(() => {

--- a/app/features/article-writer/write-utils.test.ts
+++ b/app/features/article-writer/write-utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  LEGACY_DOCUMENT_PURGE_KEY,
+  getMessagesStorageKey,
+  purgeLegacyDocumentStorage,
+  saveMessagesToStorage,
+} from "./write-utils";
+
+function createMockLocalStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+    removeItem: (key: string) => store.delete(key),
+    clear: () => store.clear(),
+    get length() {
+      return store.size;
+    },
+    key: (index: number) => [...store.keys()][index] ?? null,
+  } satisfies Storage;
+}
+
+describe("purgeLegacyDocumentStorage", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createMockLocalStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("removes documents written by the retired persistence, keeping messages", () => {
+    localStorage.setItem("article-writer-document-v1-article", "# Stale");
+    localStorage.setItem(
+      "writer-field-document-v1-ai-hero-body-article",
+      "# Also stale"
+    );
+    saveMessagesToStorage("v1", "article", []);
+
+    purgeLegacyDocumentStorage();
+
+    expect(localStorage.getItem("article-writer-document-v1-article")).toBe(
+      null
+    );
+    expect(
+      localStorage.getItem("writer-field-document-v1-ai-hero-body-article")
+    ).toBe(null);
+    expect(localStorage.getItem(getMessagesStorageKey("v1", "article"))).toBe(
+      "[]"
+    );
+  });
+
+  it("does not run a second time", () => {
+    purgeLegacyDocumentStorage();
+    localStorage.setItem("article-writer-document-v1-article", "# Later");
+
+    purgeLegacyDocumentStorage();
+
+    expect(localStorage.getItem("article-writer-document-v1-article")).toBe(
+      "# Later"
+    );
+    expect(localStorage.getItem(LEGACY_DOCUMENT_PURGE_KEY)).toBe("1");
+  });
+});

--- a/app/features/article-writer/write-utils.ts
+++ b/app/features/article-writer/write-utils.ts
@@ -104,35 +104,37 @@ export const saveMessagesToStorage = (
   }
 };
 
-export const getDocumentStorageKey = (videoId: string, mode: Mode) =>
-  `article-writer-document-${videoId}-${mode}`;
+// Documents are NOT persisted — only messages are. The route loader (i.e. the
+// database) is the single source of truth for a field's value; a stored draft
+// used to shadow it and could be applied over a newer value.
 
-export const loadDocumentFromStorage = (
-  videoId: string,
-  mode: Mode
-): string | undefined => {
-  if (typeof localStorage === "undefined") return undefined;
-  try {
-    const saved = localStorage.getItem(getDocumentStorageKey(videoId, mode));
-    return saved ?? undefined;
-  } catch {
-    return undefined;
-  }
-};
+/** Keys written by the retired document-persistence code. */
+export const LEGACY_DOCUMENT_KEY_PREFIXES = [
+  "article-writer-document-",
+  "writer-field-document-",
+];
 
-export const saveDocumentToStorage = (
-  videoId: string,
-  mode: Mode,
-  document: string | undefined
-) => {
+export const LEGACY_DOCUMENT_PURGE_KEY = "article-writer-document-purge-done";
+
+/**
+ * One-time removal of documents left in localStorage by earlier versions, so a
+ * stale draft can never resurface. Safe to call on every load; it no-ops once
+ * it has run. Can be deleted once every browser in use has loaded the app.
+ */
+export const purgeLegacyDocumentStorage = () => {
   if (typeof localStorage === "undefined") return;
   try {
-    const key = getDocumentStorageKey(videoId, mode);
-    if (document === undefined) {
-      localStorage.removeItem(key);
-    } else {
-      localStorage.setItem(key, document);
+    if (localStorage.getItem(LEGACY_DOCUMENT_PURGE_KEY)) return;
+    const stale: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+      if (LEGACY_DOCUMENT_KEY_PREFIXES.some((p) => key.startsWith(p))) {
+        stale.push(key);
+      }
     }
+    for (const key of stale) localStorage.removeItem(key);
+    localStorage.setItem(LEGACY_DOCUMENT_PURGE_KEY, "1");
   } catch {
     // ignore
   }

--- a/app/features/article-writer/writer-engine-utils.test.ts
+++ b/app/features/article-writer/writer-engine-utils.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   getFieldMessagesStorageKey,
-  getFieldDocumentStorageKey,
   loadFieldMessages,
   saveFieldMessages,
-  loadFieldDocument,
-  saveFieldDocument,
   constrainModes,
   FIELD_MODES,
   FIELD_LABELS,
@@ -47,22 +44,6 @@ describe("conversation keying by (videoId, fieldId, mode)", () => {
     const k2 = getFieldMessagesStorageKey("v2", "ai-hero-body", "article");
     expect(k1).not.toBe(k2);
   });
-
-  it("generates distinct document keys for different fields", () => {
-    const k1 = getFieldDocumentStorageKey("v1", "ai-hero-body", "article");
-    const k2 = getFieldDocumentStorageKey(
-      "v1",
-      "newsletter-copy",
-      "newsletter"
-    );
-    expect(k1).not.toBe(k2);
-  });
-
-  it("message and document keys for the same triple are different", () => {
-    const mk = getFieldMessagesStorageKey("v1", "ai-hero-body", "article");
-    const dk = getFieldDocumentStorageKey("v1", "ai-hero-body", "article");
-    expect(mk).not.toBe(dk);
-  });
 });
 
 describe("field messages localStorage persistence", () => {
@@ -95,31 +76,6 @@ describe("field messages localStorage persistence", () => {
     expect(loadFieldMessages("v1", "skills-changelog-body", "article")).toEqual(
       [{ id: 2 }]
     );
-  });
-});
-
-describe("field document localStorage persistence", () => {
-  beforeEach(() => {
-    vi.stubGlobal("localStorage", createMockLocalStorage());
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("loads undefined when nothing stored", () => {
-    expect(loadFieldDocument("v1", "ai-hero-body", "article")).toBeUndefined();
-  });
-
-  it("round-trips document content", () => {
-    saveFieldDocument("v1", "ai-hero-body", "article", "# Hello");
-    expect(loadFieldDocument("v1", "ai-hero-body", "article")).toBe("# Hello");
-  });
-
-  it("removes document when saved as undefined", () => {
-    saveFieldDocument("v1", "ai-hero-body", "article", "# Hello");
-    saveFieldDocument("v1", "ai-hero-body", "article", undefined);
-    expect(loadFieldDocument("v1", "ai-hero-body", "article")).toBeUndefined();
   });
 });
 

--- a/app/features/article-writer/writer-engine-utils.ts
+++ b/app/features/article-writer/writer-engine-utils.ts
@@ -37,13 +37,9 @@ export function getFieldMessagesStorageKey(
   return `writer-field-messages-${videoId}-${fieldId}-${mode}`;
 }
 
-export function getFieldDocumentStorageKey(
-  videoId: string,
-  fieldId: WriterFieldId,
-  mode: Mode
-): string {
-  return `writer-field-document-${videoId}-${fieldId}-${mode}`;
-}
+// Only the conversation is persisted. A field's document is owned by the route
+// loader (i.e. the database) and held in memory for the life of the writer —
+// see `useDocumentFlow`.
 
 export function loadFieldMessages(
   videoId: string,
@@ -73,41 +69,6 @@ export function saveFieldMessages(
       getFieldMessagesStorageKey(videoId, fieldId, mode),
       JSON.stringify(messages)
     );
-  } catch {
-    // ignore
-  }
-}
-
-export function loadFieldDocument(
-  videoId: string,
-  fieldId: WriterFieldId,
-  mode: Mode
-): string | undefined {
-  if (typeof localStorage === "undefined") return undefined;
-  try {
-    const saved = localStorage.getItem(
-      getFieldDocumentStorageKey(videoId, fieldId, mode)
-    );
-    return saved ?? undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-export function saveFieldDocument(
-  videoId: string,
-  fieldId: WriterFieldId,
-  mode: Mode,
-  document: string | undefined
-): void {
-  if (typeof localStorage === "undefined") return;
-  try {
-    const key = getFieldDocumentStorageKey(videoId, fieldId, mode);
-    if (document === undefined) {
-      localStorage.removeItem(key);
-    } else {
-      localStorage.setItem(key, document);
-    }
   } catch {
     // ignore
   }

--- a/app/features/article-writer/writer-engine.tsx
+++ b/app/features/article-writer/writer-engine.tsx
@@ -30,7 +30,6 @@ import {
   constrainModes,
   loadFieldMessages,
   saveFieldMessages,
-  saveFieldDocument,
 } from "./writer-engine-utils";
 import { useContextModel } from "./use-context-model";
 import { useMemoryAutosave } from "./use-memory-autosave";
@@ -149,50 +148,20 @@ export function WriterEngine({
     [addToolOutput]
   );
 
-  const {
-    document,
-    documentRef,
-    clearDocument: rawClearDocument,
-    saveDocument: rawSaveDocument,
-    updateDocument: rawUpdateDocument,
-  } = useDocumentFlow({
-    videoId,
-    mode,
-    isDocumentMode,
-    messages,
-    status,
-    addToolOutput: wrappedAddToolOutput,
-  });
-
-  const seeded = useRef(false);
-  useEffect(() => {
-    if (seeded.current) return;
-    if (initialDocument && !document) {
-      rawUpdateDocument(initialDocument);
-      seeded.current = true;
-    }
-  }, [initialDocument, document, rawUpdateDocument]);
-
-  const updateDocument = useCallback(
-    (content: string) => {
-      rawUpdateDocument(content);
-      saveFieldDocument(videoId, fieldId, mode, content);
-      onDocumentChange?.(content);
-    },
-    [rawUpdateDocument, videoId, fieldId, mode, onDocumentChange]
-  );
-
-  const clearDocument = useCallback(() => {
-    rawClearDocument();
-    saveFieldDocument(videoId, fieldId, mode, undefined);
-  }, [rawClearDocument, videoId, fieldId, mode]);
-
-  const saveDocument = useCallback(() => {
-    if (document) {
-      rawSaveDocument();
-      saveFieldDocument(videoId, fieldId, mode, document);
-    }
-  }, [rawSaveDocument, videoId, fieldId, mode, document]);
+  // The document is seeded from — and only from — the persisted value handed
+  // down by the host's route loader. It is never written to localStorage: a
+  // stored draft would shadow the loader and could be applied over a newer
+  // value. Only the conversation survives a reload.
+  const { document, documentRef, resetDocument, updateDocument } =
+    useDocumentFlow({
+      initialDocument,
+      mode,
+      isDocumentMode,
+      messages,
+      status,
+      addToolOutput: wrappedAddToolOutput,
+      onDocumentChange,
+    });
 
   // Screenshot support
   const handleDocCapture = useCallback(
@@ -311,14 +280,13 @@ export function WriterEngine({
 
     if (transitionedToReady) {
       saveFieldMessages(videoId, fieldId, mode, messages);
-      if (isDocumentMode) saveDocument();
       return;
     }
 
     if (isDocumentMode && status === "ready" && messages.length > 0) {
       saveFieldMessages(videoId, fieldId, mode, messages);
     }
-  }, [status, videoId, fieldId, mode, messages, isDocumentMode, saveDocument]);
+  }, [status, videoId, fieldId, mode, messages, isDocumentMode]);
 
   const handleModeChange = (newMode: Mode) => {
     if (modes.length > 0 && !modes.includes(newMode)) return;
@@ -414,7 +382,9 @@ export function WriterEngine({
     setMessages([]);
     clearQueue();
     saveFieldMessages(videoId, fieldId, mode, []);
-    if (isDocumentMode) clearDocument();
+    // Clearing the chat throws away the session's AI work; the document goes
+    // back to the persisted value rather than blank.
+    if (isDocumentMode) resetDocument();
   };
 
   const handleFixLintViolations = useCallback(() => {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -27,7 +27,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { purgeLegacyDocumentStorage } from "@/features/article-writer/write-utils";
 import { UploadProvider } from "@/features/upload-manager/upload-context";
 import { GlobalUploadProgress } from "@/features/upload-manager/global-upload-progress";
 import { FeedbackModal } from "@/components/feedback-modal";
@@ -73,6 +74,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
 export default function App() {
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [feedbackSubmitting, setFeedbackSubmitting] = useState(false);
+  // Sweep up writer documents left behind by the retired localStorage
+  // persistence, so no stale draft can resurface over a newer saved value.
+  useEffect(purgeLegacyDocumentStorage, []);
   // The teleprompter window is pointed at a camera lens, so
   // no app chrome belongs on it.
   const isTeleprompter = useLocation().pathname.startsWith("/teleprompter");


### PR DESCRIPTION
Matt's call: *"we should not store the article in local storage, but we should store the messages in local storage."*

## The bug

`useDocumentFlow` initialised its `document` state from localStorage, and `WriterEngine`'s seeding effect only applied the loader's `initialDocument` `if (initialDocument && !document)`. Since storage had already populated `document`, **a stale stored draft beat the loader**. The key (`article-writer-document-<videoId>-<mode>`) had no fieldId either, and `ScriptPanel` passes `modes={[]}` which resolves to `"article"` — so the Script writer and the Article writer for the same video shared one entry. The modal's Apply → `persistScript` is a wholesale DB overwrite, so a stale draft could silently clobber a real script.

The field-scoped trio (`getFieldDocumentStorageKey` / `saveFieldDocument` / `loadFieldDocument`) was write-only dead data: `WriterEngine` wrote it, nothing in the app ever read it — only a test did.

## The change

The route loader is the single source of truth for a field's value. The document lives in memory for the life of the writer; **messages are still persisted exactly as before**, including `writer-modal.tsx`'s Cancel path restoring a snapshot via `saveFieldMessages`.

- Deleted `saveDocumentToStorage` / `loadDocumentFromStorage` and `getFieldDocumentStorageKey` / `saveFieldDocument` / `loadFieldDocument`, plus every call site.
- `useDocumentFlow` now takes `initialDocument` (the loader value) and marks a *restored* conversation's tool calls as already-processed on mount and on mode change — otherwise replaying old `writeDocument` calls would re-overwrite the loader's value. That is what the storage check used to do by accident.
- The `seeded` ref dance and the `clearDocument` / `saveDocument` wrappers are gone rather than left as no-ops. `onDocumentChange` moved into the hook, so the modal's dirty tracking now also sees AI-driven changes (it previously only saw manual edits).
- Clear Chat resets the document to the persisted value rather than blanking it.
- Folded the two near-identical tool-call effects into one pure helper, `document-tool-calls.ts`, with tests. Side effect: a write and an edit landing in the same turn now apply in transcript order (previously all writes ran before all edits).

## One-time cleanup

`purgeLegacyDocumentStorage()` runs once per browser from `root.tsx` and removes orphaned `article-writer-document-*` and `writer-field-document-*` keys, so no stale draft can resurface. Easy to drop the call if you'd rather not have it in `root.tsx`.

## Worth knowing

The standalone `/write` page has no loader-backed document — it's a scratchpad whose output is exported explicitly (Apply / write-to-readme / copy). Its document therefore no longer survives a page reload; its chat still does. That follows directly from the decision, but it's the one place where something is genuinely lost.

## Verification

- `pnpm typecheck` clean.
- `pnpm vitest run`: 2403 passed, 20 failed — all 20 are the pre-existing `cli-segment-writes` failures on main for the retired `segment` noun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)