### PR TITLE
fix(video-editor): don't steal keys from the inline Monaco script editor

### DIFF
--- a/app/features/video-editor/hooks/should-ignore-keyboard-shortcut.test.ts
+++ b/app/features/video-editor/hooks/should-ignore-keyboard-shortcut.test.ts
@@ -55,6 +55,19 @@ describe("shouldIgnoreKeyboardShortcut", () => {
     expect(shouldIgnoreKeyboardShortcut(makeEvent(target))).toBe(false);
   });
 
+  it("suppresses shortcuts when typing in a contenteditable (Monaco's edit context)", () => {
+    const target = { isContentEditable: true, closest: () => null };
+    expect(shouldIgnoreKeyboardShortcut(makeEvent(target))).toBe(true);
+  });
+
+  it("suppresses shortcuts anywhere inside a Monaco editor", () => {
+    const editorEl = {};
+    const target = {
+      closest: (sel: string) => (sel === ".monaco-editor" ? editorEl : null),
+    };
+    expect(shouldIgnoreKeyboardShortcut(makeEvent(target))).toBe(true);
+  });
+
   it("suppresses shortcuts when focused inside a dialog", () => {
     const dialogEl = {};
     const target = {

--- a/app/features/video-editor/hooks/should-ignore-keyboard-shortcut.ts
+++ b/app/features/video-editor/hooks/should-ignore-keyboard-shortcut.ts
@@ -8,7 +8,14 @@ export function shouldIgnoreKeyboardShortcut(e: KeyboardEvent): boolean {
     return true;
   }
 
-  const target = e.target as Element | null;
+  const target = e.target as (Element & { isContentEditable?: boolean }) | null;
+
+  // Monaco 0.55 types into an EditContext-backed contenteditable div rather than
+  // a hidden textarea, so an inline script edit reaches us as a plain element.
+  if (target?.isContentEditable || target?.closest?.(".monaco-editor")) {
+    return true;
+  }
+
   if (target?.closest?.('[role="dialog"]')) {
     return true;
   }


### PR DESCRIPTION
## Problem

Editing the script inline in the video editor (Script tab → **Edit** button, no AI writer open) — space, enter and the arrow keys do nothing, or scrub/pause the video instead of typing.

## Cause

`shouldIgnoreKeyboardShortcut` only recognises `HTMLInputElement`, `HTMLTextAreaElement` and buttons. The inline field is Monaco (`writable-field.tsx:215`), and Monaco 0.55 types into an **EditContext-backed `contenteditable` div**, not the old hidden textarea — so the keydown reaches `use-keyboard-shortcuts.ts` as a generic element and gets `preventDefault()`d into `press-space-bar` / `press-return` / arrow actions.

The AI writer modal was unaffected because #1364 added the `closest('[role="dialog"]')` escape hatch. That never covered the inline field.

## Fix

Suppress the window shortcuts when the target `isContentEditable`, or sits anywhere inside `.monaco-editor` (belt-and-braces for future Monaco internals). Two tests added; existing guard tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)