### PR TITLE
teleprompter: push editor state instead of polling it

### DIFF
--- a/app/features/teleprompter/teleprompter-session.test.ts
+++ b/app/features/teleprompter/teleprompter-session.test.ts
@@ -21,10 +21,10 @@ const content = (
   overrides: Partial<teleprompterSession.Content> = {}
 ): teleprompterSession.Content => ({ ...EMPTY_CONTENT, ...overrides });
 
-describe("editor-spoke", () => {
+describe("editor-state", () => {
   it("connects and adopts the editor's video", () => {
     const next = reducer(initialState, {
-      type: "editor-spoke",
+      type: "editor-state",
       videoId: "v1",
       capture: "not-recording",
       tab: "script",
@@ -37,7 +37,7 @@ describe("editor-spoke", () => {
 
   it("leaves the crawl still when capture starts", () => {
     const next = reducer(connected(), {
-      type: "editor-spoke",
+      type: "editor-state",
       videoId: "v1",
       capture: "speaking-detected",
       tab: "script",
@@ -48,7 +48,7 @@ describe("editor-spoke", () => {
 
   it("leaves a hand-started crawl rolling when capture starts", () => {
     const next = reducer(connected({ playing: true }), {
-      type: "editor-spoke",
+      type: "editor-state",
       videoId: "v1",
       capture: "speaking-detected",
       tab: "script",
@@ -61,7 +61,7 @@ describe("editor-spoke", () => {
     const next = reducer(
       connected({ capture: "speaking-detected", playing: true }),
       {
-        type: "editor-spoke",
+        type: "editor-state",
         videoId: "v1",
         capture: "not-recording",
         tab: "script",
@@ -77,7 +77,7 @@ describe("editor-spoke", () => {
     const next = reducer(
       connected({ capture: "speaking-detected", playing: false }),
       {
-        type: "editor-spoke",
+        type: "editor-state",
         videoId: "v1",
         capture: "silence",
         tab: "script",
@@ -96,7 +96,7 @@ describe("editor-spoke", () => {
         lastScriptPushAt: 900,
       }),
       {
-        type: "editor-spoke",
+        type: "editor-state",
         videoId: "v2",
         capture: "not-recording",
         tab: "script",
@@ -107,6 +107,33 @@ describe("editor-spoke", () => {
     expect(next.playing).toBe(false);
     expect(next.pinnedSource).toBeNull();
     expect(next.lastScriptPushAt).toBe(0);
+  });
+});
+
+describe("editor-alive", () => {
+  it("keeps the editor connected without touching what's on the glass", () => {
+    const state = connected({
+      content: content({ script: "hello" }),
+      capture: "speaking-detected",
+      playing: true,
+      pinnedSource: { videoId: "v1", source: "beats" },
+    });
+    const next = reducer(state, { type: "editor-alive", at: 3000 });
+    expect(next.lastPongAt).toBe(3000);
+    expect(next.editorConnected).toBe(true);
+    expect(next.videoId).toBe("v1");
+    expect(next.capture).toBe("speaking-detected");
+    expect(next.playing).toBe(true);
+    expect(next.content).toBe(state.content);
+    expect(next.pinnedSource).toBe(state.pinnedSource);
+  });
+
+  it("reconnects an editor that went quiet and came back", () => {
+    const next = reducer(connected({ editorConnected: false }), {
+      type: "editor-alive",
+      at: 9000,
+    });
+    expect(next.editorConnected).toBe(true);
   });
 });
 
@@ -233,7 +260,7 @@ describe("following the editor's tab", () => {
     tab: "script" | "beats" | "reference"
   ) =>
     reducer(state, {
-      type: "editor-spoke",
+      type: "editor-state",
       videoId: "v1",
       capture: "not-recording",
       tab,

--- a/app/features/teleprompter/teleprompter-session.ts
+++ b/app/features/teleprompter/teleprompter-session.ts
@@ -63,14 +63,19 @@ export namespace teleprompterSession {
   }
 
   export type Action =
-    /** A pong, or the editor announcing itself on mount. */
+    /**
+     * The editor pushed what it has open, because something about it changed
+     * (or because we just said hello). Never arrives on a timer.
+     */
     | {
-        type: "editor-spoke";
+        type: "editor-state";
         videoId: string | null;
         capture: CaptureStatus;
         tab: EditorTab;
         at: number;
       }
+    /** A bare pong: the editor is still there, and nothing has changed. */
+    | { type: "editor-alive"; at: number }
     | { type: "editor-disconnected" }
     /** The heartbeat timer, checking whether the editor has gone quiet. */
     | { type: "liveness-checked"; at: number }
@@ -103,12 +108,18 @@ export namespace teleprompterSession {
 
   export const reducer = (state: State, action: Action): State => {
     switch (action.type) {
-      case "editor-spoke": {
+      case "editor-alive":
+        return state.editorConnected && state.lastPongAt === action.at
+          ? state
+          : { ...state, editorConnected: true, lastPongAt: action.at };
+
+      case "editor-state": {
         const videoChanged = action.videoId !== state.videoId;
         const tabSource = tabToSource(action.tab);
         const editorSource = tabSource ?? state.editorSource;
-        // Only a *change* of tab overrides a hand-picked source, so the pong
-        // every two seconds doesn't keep undoing the choice.
+        // Only a *change* of tab overrides a hand-picked source. Pushes arrive
+        // on change so this is nearly always true, but the join handshake can
+        // re-send a tab you've already overridden on the glass.
         const tabChanged =
           tabSource !== null && tabSource !== state.editorSource;
         const takeEnded =

--- a/app/features/video-editor/hooks/use-teleprompter-editor-mode.ts
+++ b/app/features/video-editor/hooks/use-teleprompter-editor-mode.ts
@@ -1,16 +1,26 @@
 /**
- * Announce this editor to the teleprompter popup, and keep answering its pings.
+ * Keep the teleprompter popup in step with this editor.
  *
  * The popup has no picker, so this is the only way it learns which video to
  * show, what capture is doing, and which of Script or Beats you're looking at.
  *
- * State is read through a ref at pong time rather than captured in the effect's
- * dependencies: the speech-detector state changes constantly mid-take, and
- * re-subscribing the channel on every change is the one failure mode a
- * teleprompter can't have.
+ * Two effects, doing two different jobs:
+ *
+ *   - The first answers the popup's heartbeat and its join handshake. State is
+ *     read through a ref rather than captured in the dependencies: the
+ *     speech-detector state changes constantly mid-take, and re-subscribing the
+ *     channel on every change is the one failure mode a teleprompter can't have.
+ *   - The second *pushes* state the moment it changes, so the glass is never a
+ *     heartbeat behind the editor. Its dependencies are the three primitives
+ *     rather than the state object, so a re-render that produces an identical
+ *     `{ videoId, capture, tab }` sends nothing — which matters, because the
+ *     speech detector re-renders far more often than it actually transitions.
  */
 import { useEffect, useRef } from "react";
-import { enableTeleprompterEditorMode } from "@/lib/teleprompter-window";
+import {
+  enableTeleprompterEditorMode,
+  pushTeleprompterState,
+} from "@/lib/teleprompter-window";
 import type { CaptureStatus } from "@/lib/teleprompter-protocol";
 import type { BeatTab } from "../beat-tab";
 
@@ -25,4 +35,9 @@ export function useTeleprompterEditorMode(state: TeleprompterEditorState) {
   ref.current = state;
 
   useEffect(() => enableTeleprompterEditorMode(() => ref.current), []);
+
+  const { videoId, capture, tab } = state;
+  useEffect(() => {
+    pushTeleprompterState({ videoId, capture, tab });
+  }, [videoId, capture, tab]);
 }

--- a/app/features/video-editor/hooks/use-video-script.ts
+++ b/app/features/video-editor/hooks/use-video-script.ts
@@ -45,8 +45,8 @@ export function useVideoScript(videoId: string, enabled = true) {
         { intent: "updateScript", script: newValue },
         { method: "post", action: `/api/videos/${videoId}/script` }
       );
-      // Straight onto the glass, throttled, without waiting for the save to
-      // land and the popup to poll for it. A no-op when no teleprompter is open.
+      // Straight onto the glass, without waiting for the save to land and the
+      // popup to poll for it. A no-op when no teleprompter is open.
       pushTeleprompterScript(videoId, newValue);
     },
     [saveFetcher, videoId]

--- a/app/lib/teleprompter-protocol.ts
+++ b/app/lib/teleprompter-protocol.ts
@@ -7,16 +7,24 @@
  * Two differences from the diagram protocol, both because the teleprompter is a
  * pure slave to the editor:
  *
- *   - There is no "load this video" command and no picker. `pong` carries the
- *     editor's current videoId, so the main window is unconditionally the source
- *     of truth for what's on the glass. No video open in the editor means an
- *     empty teleprompter.
- *   - `pong` also carries capture state, mirroring the editor's recording +
- *     silence-detection indicator so the same status is visible on the glass,
+ *   - There is no "load this video" command and no picker. `editorState` carries
+ *     the editor's current videoId, so the main window is unconditionally the
+ *     source of truth for what's on the glass. No video open in the editor means
+ *     an empty teleprompter.
+ *   - `editorState` also carries capture state, mirroring the editor's recording
+ *     + silence-detection indicator so the same status is visible on the glass,
  *     and the side panel's active tab, so the glass shows whichever of Script
  *     or Beats you're looking at in the editor.
  *
- * Nothing flows back the other way: the teleprompter never reports position.
+ * State is **pushed, not polled**. `editorState` goes out when it changes, so
+ * the glass is never more than a message behind the editor. The ping/pong
+ * heartbeat exists only to answer "is the editor still there" — a pong carries
+ * nothing, and a popup that is already attached learns everything by push.
+ * `hello` is the handshake for the other join order: a popup opened after the
+ * editor mounted missed the mount push, so it asks once, and keeps asking only
+ * while it believes nobody is on the other end.
+ *
+ * Nothing else flows back the other way: the teleprompter never reports position.
  */
 import { z } from "zod";
 
@@ -44,26 +52,25 @@ export const EditorTab = z.enum(["beats", "reference", "script"]);
 export type EditorTab = z.infer<typeof EditorTab>;
 
 export const TeleprompterParentToChild = z.discriminatedUnion("type", [
-  /** Editor answering a ping: what it has open, and what capture is doing. */
+  /**
+   * What the editor has open, what capture is doing, and which tab it's showing.
+   * Pushed whenever any of the three changes — plus once on editor mount, and
+   * once in answer to a `hello`. Never sent on a timer.
+   */
   z.object({
-    type: z.literal("pong"),
+    type: z.literal("editorState"),
     videoId: z.string().nullable(),
     capture: CaptureStatus,
     tab: EditorTab,
   }),
-  /** Sent on editor mount so the popup catches up without waiting a beat. */
-  z.object({
-    type: z.literal("editorConnected"),
-    videoId: z.string().nullable(),
-    capture: CaptureStatus,
-    tab: EditorTab,
-  }),
+  /** Heartbeat answer, and nothing more. State travels by `editorState`. */
+  z.object({ type: z.literal("pong") }),
   z.object({ type: z.literal("editorDisconnected") }),
   /** Editor saved a script or edited beats; refetch now, don't wait for the poll. */
   z.object({ type: z.literal("contentChanged"), videoId: z.string() }),
   /**
-   * The script as it stands in the editor *right now*, pushed on a throttle
-   * while typing. Carries the text itself rather than telling the popup to
+   * The script as it stands in the editor *right now*, pushed on every
+   * keystroke. Carries the text itself rather than telling the popup to
    * refetch: a refetch would race the save that produced it, and the round trip
    * is the difference between "instant" and "a beat later".
    */
@@ -84,7 +91,10 @@ export const TeleprompterParentToChild = z.discriminatedUnion("type", [
 ]);
 
 export const TeleprompterChildToParent = z.discriminatedUnion("type", [
+  /** Liveness only. Answered with a bare `pong`. */
   z.object({ type: z.literal("ping") }),
+  /** "I just arrived, or I think you left — send me your state once." */
+  z.object({ type: z.literal("hello") }),
 ]);
 
 export type TeleprompterParentToChildMessage = z.infer<

--- a/app/lib/teleprompter-window.ts
+++ b/app/lib/teleprompter-window.ts
@@ -2,9 +2,10 @@
  * PROTOTYPE — throwaway. Parent-side API for the teleprompter popup, cloned
  * from `diagram-window.ts`.
  *
- * The editor calls `enableTeleprompterEditorMode(videoId, capture)`; that single
- * call answers pings, hands over the current videoId, and relays capture state.
- * Because the popup has no picker, this is the *only* way it learns what to show.
+ * The editor calls `enableTeleprompterEditorMode()` to answer the popup's
+ * heartbeat and handshake, and {@link pushTeleprompterState} whenever what it
+ * has open changes. Because the popup has no picker, those pushes are the *only*
+ * way it learns what to show.
  */
 import {
   sendToTeleprompter,
@@ -14,6 +15,12 @@ import {
   type TeleprompterCommand,
   type TeleprompterChildToParentMessage,
 } from "./teleprompter-protocol";
+
+export type TeleprompterEditorState = {
+  videoId: string | null;
+  capture: CaptureStatus;
+  tab: EditorTab;
+};
 
 const TELEPROMPTER_PATH = "/teleprompter";
 const WINDOW_NAME = "cvm-teleprompter";
@@ -40,37 +47,39 @@ function ensureLivenessTracker(): void {
 }
 
 /**
- * Called by the Video Editor. `getState` is read at pong time rather than
- * captured, so a fast-changing capture status doesn't require re-subscribing
- * (and therefore doesn't churn the channel while recording).
+ * Called by the Video Editor. Answers the popup's heartbeat with a bare pong,
+ * and its handshake with the current state.
+ *
+ * `getState` is read at message time rather than captured so a fast-changing
+ * capture status doesn't require re-subscribing (and therefore doesn't churn
+ * the channel while recording). It is *not* how the popup normally learns
+ * anything — that's {@link pushTeleprompterState}. A `hello` only arrives when
+ * the popup thinks nobody is attached, so this reply is the join handshake, not
+ * a poll.
  */
 export function enableTeleprompterEditorMode(
-  getState: () => {
-    videoId: string | null;
-    capture: CaptureStatus;
-    tab: EditorTab;
-  }
+  getState: () => TeleprompterEditorState
 ): () => void {
   if (typeof window === "undefined") return () => {};
   const unsub = subscribeTeleprompterParent(
     (msg: TeleprompterChildToParentMessage) => {
-      if (msg.type === "ping") {
-        const { videoId, capture, tab } = getState();
-        sendToTeleprompter({ type: "pong", videoId, capture, tab });
-      }
+      if (msg.type === "ping") sendToTeleprompter({ type: "pong" });
+      else if (msg.type === "hello") pushTeleprompterState(getState());
     }
   );
-  const initial = getState();
-  sendToTeleprompter({
-    type: "editorConnected",
-    videoId: initial.videoId,
-    capture: initial.capture,
-    tab: initial.tab,
-  });
   return () => {
     sendToTeleprompter({ type: "editorDisconnected" });
     unsub();
   };
+}
+
+/**
+ * Push what the editor has open onto the glass. Call on change, not on a timer:
+ * the popup holds the last value it was given, so a message only needs to go out
+ * when that value stops being true.
+ */
+export function pushTeleprompterState(state: TeleprompterEditorState): void {
+  sendToTeleprompter({ type: "editorState", ...state });
 }
 
 /** Nudge an open teleprompter to refetch immediately after an edit. */
@@ -79,30 +88,15 @@ export function notifyTeleprompterContentChanged(videoId: string): void {
 }
 
 /**
- * Mirror the script being typed onto the glass, throttled to
- * {@link SCRIPT_PUSH_MS}.
+ * Mirror the script being typed onto the glass, on every keystroke.
  *
- * Leading *and* trailing: the first keystroke lands immediately so the update
- * feels instant, and the last one always lands too, so the glass can't end up
- * one keystroke behind when you stop typing.
+ * Deliberately unthrottled: this is a same-origin structured clone handed to
+ * another window in-process, so a few KB per keypress costs nothing, and rate
+ * limiting it only buys a glass that lags the editor. (The save this rides
+ * alongside is the expensive half, and that one is worth batching.)
  */
-const SCRIPT_PUSH_MS = 250;
-let lastScriptPushAt = 0;
-let pendingScriptPush: ReturnType<typeof setTimeout> | null = null;
-
 export function pushTeleprompterScript(videoId: string, script: string): void {
-  if (typeof window === "undefined") return;
-  if (pendingScriptPush) clearTimeout(pendingScriptPush);
-
-  const send = () => {
-    lastScriptPushAt = Date.now();
-    pendingScriptPush = null;
-    sendToTeleprompter({ type: "scriptChanged", videoId, script });
-  };
-
-  const since = Date.now() - lastScriptPushAt;
-  if (since >= SCRIPT_PUSH_MS) send();
-  else pendingScriptPush = setTimeout(send, SCRIPT_PUSH_MS - since);
+  sendToTeleprompter({ type: "scriptChanged", videoId, script });
 }
 
 /** Forward a transport control pressed in the editor to the popup. */

--- a/app/routes/teleprompter.tsx
+++ b/app/routes/teleprompter.tsx
@@ -41,16 +41,26 @@ export default function Teleprompter() {
   const { videoId, content } = state;
 
   // --- Editor sync: the only way this window learns anything --------------
+  // The editor *pushes*; the heartbeat below is liveness only. `hello` goes out
+  // alongside the ping while we believe nobody is attached, which covers both
+  // join orders (popup first, or editor first) and re-syncs after the editor
+  // reloads — and stops the moment we're attached, so a running editor isn't
+  // answering questions every two seconds.
+  const connectedRef = useRef(false);
+  connectedRef.current = state.editorConnected;
+
   useEffect(() => {
     const unsub = subscribeTeleprompterChild((msg) => {
-      if (msg.type === "pong" || msg.type === "editorConnected") {
+      if (msg.type === "editorState") {
         dispatch({
-          type: "editor-spoke",
+          type: "editor-state",
           videoId: msg.videoId,
           capture: msg.capture,
           tab: msg.tab,
           at: Date.now(),
         });
+      } else if (msg.type === "pong") {
+        dispatch({ type: "editor-alive", at: Date.now() });
       } else if (msg.type === "editorDisconnected") {
         dispatch({ type: "editor-disconnected" });
       } else if (msg.type === "contentChanged") {
@@ -65,9 +75,14 @@ export default function Teleprompter() {
       }
     });
 
-    sendToEditor({ type: "ping" });
-    const beat = setInterval(() => {
+    const knock = () => {
       sendToEditor({ type: "ping" });
+      if (!connectedRef.current) sendToEditor({ type: "hello" });
+    };
+
+    knock();
+    const beat = setInterval(() => {
+      knock();
       dispatch({ type: "liveness-checked", at: Date.now() });
     }, PING_INTERVAL_MS);
 


### PR DESCRIPTION
The teleprompter popup learned the editor's `videoId`, capture status and active tab by **pinging every two seconds and reading the answer off the pong**. That put a 2s ceiling on how fast the recording indicator and tab switches reached the glass — for state the editor already knows the instant it changes.

## What changed

The heartbeat was doing two jobs. Split them:

| Message | Direction | When |
|---|---|---|
| `ping` / `pong` | both | every 2s, liveness only — `pong` now carries nothing |
| `editorState` | editor → glass | when `videoId`, `capture` or `tab` changes, plus once on editor mount |
| `hello` | glass → editor | only while the popup believes nobody is attached |

`hello` is the join handshake, covering the popup that opened *after* the editor mounted and so missed the mount push. Because the popup stops sending it once attached, a connected pair never exchanges a question again — it's push from there on. It also self-heals: if the editor goes quiet and comes back without remounting, the popup starts saying hello again until it's re-synced.

The push effect (`use-teleprompter-editor-mode.ts`) depends on the three primitives rather than the state object, so the speech detector re-rendering constantly mid-take doesn't put messages on the channel unless the status actually transitioned between its five values.

Reducer-side, `editor-spoke` splits into `editor-state` (adopts video/capture/tab) and `editor-alive` (touches `lastPongAt` and nothing else, so a heartbeat can't jog what's on the glass).

## Also: dropped the `scriptChanged` throttle

`SCRIPT_PUSH_MS = 250` was rate-limiting a same-origin structured clone handed to another window in-process. A few KB per keystroke costs nothing, and the only thing the throttle bought was a glass lagging the editor by up to a quarter second while typing.

Two smaller notes on it: it was actually a leading-edge-plus-trailing-*debounce*, not the leading+trailing throttle its docstring claimed (it cleared the pending timer on every call). And the genuinely expensive half of that same keystroke — the save `POST` in `useVideoScript` — was never throttled at all. That one is left alone here.

## Testing

- `pnpm typecheck` — clean
- `pnpm vitest run app/features/teleprompter` — 27 passed, including two new `editor-alive` cases asserting a heartbeat leaves content, capture, crawl and pinned source untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)