### PR TITLE
fix(silence-detection): stop losing the first clip of every recording

### DIFF
--- a/app/services/silence-detection.test.ts
+++ b/app/services/silence-detection.test.ts
@@ -29,6 +29,23 @@ const SILENCE_OUTPUT_TWO_PERIODS = [
   "[silencedetect @ 0x1] silence_end: 6.0 | silence_duration: 1.0",
 ].join("\n");
 
+/**
+ * Real, verbatim ffmpeg output from /mnt/d/raw-footage/2026-07-30_09-54-33.mkv
+ * (60fps, 26.27s) at the CVM's production settings (-38dB, d=0.8).
+ *
+ * Note the negative `silence_start` on the first period: ffmpeg reports a
+ * slightly-below-zero start whenever a file begins in silence, which every OBS
+ * recording does. The two speaking gaps are 3.411–5.839 and 19.395–22.327.
+ */
+const SILENCE_OUTPUT_NEGATIVE_FIRST_START = [
+  "[silencedetect @ 0x5dcf256ab0c0] silence_start: -0.000166667",
+  "[silencedetect @ 0x5dcf256ab0c0] silence_end: 3.41098 | silence_duration: 3.41115",
+  "[silencedetect @ 0x5dcf256ab0c0] silence_start: 5.83929",
+  "[silencedetect @ 0x5dcf256ab0c0] silence_end: 19.3949 | silence_duration: 13.5556",
+  "[silencedetect @ 0x5dcf256ab0c0] silence_start: 22.327",
+  "[silencedetect @ 0x5dcf256ab0c0] silence_end: 26.2398 | silence_duration: 3.91283",
+].join("\n");
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const run = <A>(effect: Effect.Effect<A, any, any>): Promise<A> =>
   Effect.runPromise(
@@ -86,5 +103,21 @@ describe("findSilenceInVideo", () => {
     const clip = result.clips[0]!;
     expect(clip.startTime).toBeCloseTo(2.0, 1);
     expect(clip.endTime).toBeCloseTo(5.07, 1);
+  });
+
+  it("keeps the first clip when ffmpeg reports a negative first silence_start", async () => {
+    const ffmpeg = mockFFmpeg({
+      fps: 60,
+      silenceOutput: SILENCE_OUTPUT_NEGATIVE_FIRST_START,
+    });
+
+    const result = await run(findSilenceInVideo(ffmpeg, "/test/video.mkv"));
+
+    expect(result.clips).toHaveLength(2);
+    // The take that used to be swallowed by the dropped first silence period
+    expect(result.clips[0]!.startTime).toBeCloseTo(3.41, 1);
+    expect(result.clips[0]!.endTime).toBeCloseTo(5.92, 1);
+    expect(result.clips[1]!.startTime).toBeCloseTo(19.4, 1);
+    expect(result.clips[1]!.endTime).toBeCloseTo(22.41, 1);
   });
 });

--- a/app/services/silence-detection.ts
+++ b/app/services/silence-detection.ts
@@ -42,11 +42,16 @@ export function getClipsOfSpeakingFromFFmpeg(
   for (const line of lines) {
     if (!line.includes("[silencedetect @")) continue;
 
-    const startMatch = line.match(/silence_start:\s*([\d.]+)/);
-    const endMatch = line.match(/silence_end:\s*([\d.]+)/);
+    // ffmpeg reports a slightly-negative silence_start (e.g. -0.000166667)
+    // whenever a file opens in silence, which every OBS recording does. The
+    // sign has to be inside the capture or the line fails to match at all, the
+    // leading silence period is dropped, and it merges with the first spoken
+    // take — losing the first clip of the recording.
+    const startMatch = line.match(/silence_start:\s*(-?[\d.]+)/);
+    const endMatch = line.match(/silence_end:\s*(-?[\d.]+)/);
 
     if (startMatch) {
-      currentSilenceStart = Number(startMatch[1]);
+      currentSilenceStart = Math.max(0, Number(startMatch[1]));
     }
 
     if (endMatch && currentSilenceStart !== null) {


### PR DESCRIPTION
## The bug

Matt reported that the first clip he creates isn't being found.

ffmpeg emits a slightly-**negative** `silence_start` whenever a media file opens in silence — which every OBS recording does:

```
[silencedetect @ 0x…] silence_start: -0.000166667
[silencedetect @ 0x…] silence_end: 3.41098 | silence_duration: 3.41115
```

`app/services/silence-detection.ts` matched the value with `([\d.]+)`, which cannot match a leading `-`, so the line failed to match *at all*. `currentSilenceStart` stayed `null`, the following `silence_end` was discarded along with it, and the entire leading silence period vanished.

Speaking clips are derived as the gaps **between** silence periods, so dropping the first period merges the leading silence into the first spoken take — and the first clip of the recording disappears. Worse: when a file held only one take, the single surviving period left no gaps at all, so the file produced **zero** clips and never even appeared in the video log.

## Verification

Re-ran `silencedetect` at the CVM's production settings (`-38dB`, `d=0.8`) over the five real recordings from session `97a358e9`, and replayed the captured output through the parser. The buggy parser reproduces the logged boundaries with 6/6 precision, which pins the diagnosis; the fixed parser preserves every one of them byte-identically while recovering the lost take:

| file | previously detected | recovered |
|---|---|---|
| `09-48-45` | 13.52–31.47 | **2.78–7.15** |
| `09-51-15` | 11.32–16.08 | **3.60–8.77** |
| `09-51-54` | 16.18–21.13, 28.12–36.45, 48.52–55.77 | **2.55–11.50** |
| `09-53-39` | *nothing at all* | **3.58–10.80** |
| `09-54-33` | 19.40–22.42 | **3.42–5.92** |

No previously-detected boundary moves.

## Why the tests missed it

The existing fixture used a clean `silence_start: 0` — a value real ffmpeg never produces for a silent open. The regression test added here uses verbatim captured ffmpeg output from `2026-07-30_09-54-33.mkv` instead, and asserts both takes survive.

`npx vitest run app/services/silence-detection.test.ts app/services/clip-service-timeline.test.ts app/features/video-editor/clip-state-reducer-recording.test.ts` → 41 passed. Typecheck shows no errors in the touched files.

## Follow-up worth considering (not fixed here)

The gap model still drops any speech **before the first** silence period and **after the last** one (`if (nextSilenceStart === null) break;`). That's invisible for OBS captures, which top and tail with silence, but it would bite a file that opens or closes mid-sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)