### PR TITLE
feat(cvm): add `--description` to `cvm lesson update`

### DIFF
--- a/app/cli/cli-lesson-move-update.test.ts
+++ b/app/cli/cli-lesson-move-update.test.ts
@@ -38,6 +38,7 @@ interface Lesson {
   id: string;
   sectionId: string;
   title: string;
+  description: string;
   order: number;
   archived: boolean;
 }
@@ -212,6 +213,100 @@ describe("lesson update --title", () => {
       "lesson",
       "update",
       "--title",
+      "Nope",
+      s.publishedLessonId,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stderr).toContain("ParseError");
+  });
+
+  it("rejects an update with no flags at all (exit 3)", async () => {
+    const { exitCode, stderr } = await run(["lesson", "update", s.a1]);
+    expect(exitCode).toBe(3);
+    expect(stderr).toContain("ParseError");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update --description
+// ---------------------------------------------------------------------------
+
+describe("lesson update --description", () => {
+  it("writes the description and echoes the lesson", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "lesson",
+      "update",
+      "--description",
+      "What this lesson actually covers",
+      s.a1,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    const lesson = one<Lesson>(stdout);
+    expect(lesson.description).toBe("What this lesson actually covers");
+  });
+
+  // The whole point of the flag: the column is NOT NULL DEFAULT '', so blanking
+  // a stale description means writing "" — which must NOT be rejected the way
+  // an empty --title is.
+  it('clears a stale description with --description ""', async () => {
+    await run(["lesson", "update", "--description", "stale", s.a1]);
+
+    const { exitCode, stdout, stderr } = await run([
+      "lesson",
+      "update",
+      "--description",
+      "",
+      s.a1,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(one<Lesson>(stdout).description).toBe("");
+  });
+
+  it("leaves the title untouched (partial patch)", async () => {
+    const { stdout } = await run([
+      "lesson",
+      "update",
+      "--description",
+      "Just the description",
+      s.a1,
+    ]);
+    expect(one<Lesson>(stdout).title).toBe("A One");
+  });
+
+  it("patches title and description together", async () => {
+    const { stdout, exitCode } = await run([
+      "lesson",
+      "update",
+      "--title",
+      "Renamed",
+      "--description",
+      "And described",
+      s.a1,
+    ]);
+    expect(exitCode).toBe(0);
+    const lesson = one<Lesson>(stdout);
+    expect(lesson.title).toBe("Renamed");
+    expect(lesson.description).toBe("And described");
+  });
+
+  it("reports a missing lesson as not-found (exit 2)", async () => {
+    const { exitCode } = await run([
+      "lesson",
+      "update",
+      "--description",
+      "X",
+      "les_missing",
+    ]);
+    expect(exitCode).toBe(2);
+  });
+
+  it("refuses to edit a lesson in a published version (exit 3)", async () => {
+    const { exitCode, stderr } = await run([
+      "lesson",
+      "update",
+      "--description",
       "Nope",
       s.publishedLessonId,
     ]);

--- a/app/cli/commands/lesson.help.ts
+++ b/app/cli/commands/lesson.help.ts
@@ -15,6 +15,9 @@ KEY FIELDS
   authoringStatus  Where a lesson sits in the authoring workflow: "todo"
                    (default for newly created lessons) or "done" (marked ready
                    in the UI).
+  description      Free-text description of the lesson. Never null — an absent
+                   description is the empty string, so clearing one means
+                   writing "".
   path             The lesson's slug/segment (often number-prefixed, e.g.
                    "01-intro"). Unique per section among non-archived lessons.
   title            Human-readable lesson title (may be empty; untitled lesson).
@@ -33,9 +36,9 @@ VERBS
   tree <id> [--depth N] Skeleton tree lesson -> videos -> clips.
   create --section <id> --title <t> [--before|--after <lessonId>]
                         Create a lesson in a Section (WRITE).
-  update <id> [--title <t>] [--authoring-status todo|done]
-                        Rename a lesson and/or set its authoring status (WRITE;
-                        slug unchanged).
+  update <id> [--title <t>] [--description <d>] [--authoring-status todo|done]
+                        Rename a lesson, rewrite its description and/or set its
+                        authoring status (WRITE; slug unchanged).
   move <id> [--section <id>] [--before|--after <lessonId>]
                         Reorder within a section, or re-home to another (WRITE).
   search <id> <query>   Substring search down this lesson's subtree
@@ -122,12 +125,19 @@ Examples:
   cvm lesson create --section sec_123 --title "Intro to Effect"
   cvm lesson create --section sec_123 --title "Setup" --before les_abc`;
 
-export const UPDATE_HELP = `Update a lesson by id. Change its display TITLE and/or its AUTHORING STATUS.
+export const UPDATE_HELP = `Update a lesson by id. Change its display TITLE, its DESCRIPTION and/or its
+AUTHORING STATUS.
 
-Flags (pass at least one — an update with neither is invalid input, exit 3):
+Flags (pass at least one — an update with none is invalid input, exit 3):
   --title <text>              new display title. The lesson's 'path' (its slug)
                               is deliberately left untouched, so renaming never
                               moves a URL. An empty title is invalid (exit 3).
+  --description <text>        replace the lesson's free-text description. The
+                              column is NOT NULL, so an empty description is
+                              "" rather than null — and that makes
+                              '--description ""' the way to CLEAR a stale
+                              description. Unlike --title, an empty (or
+                              whitespace-only) value is deliberately LEGAL here.
   --authoring-status <state>  set where the lesson sits in the authoring
                               workflow: "todo" (still needs work — the default
                               for newly created lessons) or "done" (marked
@@ -141,6 +151,8 @@ Echoes the updated lesson with its Section/Version/Repo hierarchy (as 'get').
 
 Examples:
   cvm lesson update les_abc --title "A clearer title"
+  cvm lesson update les_abc --description "What this lesson actually covers"
+  cvm lesson update les_abc --description ""          # clear a stale description
   cvm lesson update les_abc --authoring-status done
   cvm lesson update les_abc --authoring-status todo
   cvm lesson update les_abc --title "Setup" --authoring-status todo`;

--- a/app/cli/commands/lesson.ts
+++ b/app/cli/commands/lesson.ts
@@ -276,6 +276,16 @@ const updateTitle = Options.text("title").pipe(
   ),
   Options.optional
 );
+// The column is NOT NULL DEFAULT '', so there is no null to write back and no
+// need for a --clear-description flag: `--description ""` IS the clear, and the
+// reason this flag exists (a stale description you cannot otherwise blank from
+// the CLI). Hence no non-empty guard here, unlike --title.
+const updateDescription = Options.text("description").pipe(
+  Options.withDescription(
+    'The lesson\'s description (pass "" to clear a stale one).'
+  ),
+  Options.optional
+);
 const updateAuthoringStatus = Options.choice("authoring-status", [
   ...AUTHORING_STATUSES,
 ]).pipe(
@@ -288,16 +298,26 @@ const updateAuthoringStatus = Options.choice("authoring-status", [
 
 const updateCmd = Command.make(
   "update",
-  { id: updateId, title: updateTitle, authoringStatus: updateAuthoringStatus },
-  ({ id, title, authoringStatus }) =>
+  {
+    id: updateId,
+    title: updateTitle,
+    description: updateDescription,
+    authoringStatus: updateAuthoringStatus,
+  },
+  ({ id, title, description, authoringStatus }) =>
     withBackupCoordination(
       Effect.gen(function* () {
         const titleValue = Option.getOrUndefined(title);
+        const descriptionValue = Option.getOrUndefined(description);
         const statusValue = Option.getOrUndefined(authoringStatus);
 
-        if (titleValue === undefined && statusValue === undefined) {
+        if (
+          titleValue === undefined &&
+          descriptionValue === undefined &&
+          statusValue === undefined
+        ) {
           return yield* parseError(
-            "update needs at least one of --title or --authoring-status",
+            "update needs at least one of --title, --description or --authoring-status",
             "lesson"
           );
         }
@@ -319,6 +339,9 @@ const updateCmd = Command.make(
 
         yield* svc.updateLesson(id, {
           ...(titleValue !== undefined ? { title: titleValue } : {}),
+          ...(descriptionValue !== undefined
+            ? { description: descriptionValue }
+            : {}),
           ...(statusValue !== undefined
             ? { authoringStatus: statusValue }
             : {}),


### PR DESCRIPTION
Two CVM write gaps came in from `#Agent Triage`. **Only one of them was still real** — see the note at the bottom before reviewing.

## What this PR does

`cvm lesson update` accepted only `--title` and `--authoring-status`, so a stale lesson description could not be rewritten — or cleared — from the CLI. This adds `--description`.

- `app/cli/commands/lesson.ts` — new optional `--description` flag, folded into the existing "at least one flag" guard and the partial-patch spread passed to `updateLesson`.
- `app/cli/commands/lesson.help.ts` — `UPDATE_HELP`, the `KEY FIELDS` block and the verb summary, in the same domain-teaching register as the rest.
- `app/cli/cli-lesson-move-update.test.ts` — 6 new cases + one for the now three-way "no flags" error.

### The one design decision

`lessons.description` is `text NOT NULL DEFAULT ''`. There is no null to write, so there is no `--clear-description` flag (unlike `deliverable`'s `--clear-courses`, which empties a *link set*): **`--description ""` is the clear**, which is the whole reason the flag was asked for. Consequently, unlike `--title`, an empty or whitespace-only value is deliberately legal here. Tested both ways.

Everything else follows the existing shape of the verb: flags before the positional `<id>`, `withBackupCoordination`, the Draft guard (editing a published version is exit 3), not-found is exit 2, echoes the updated lesson with its hierarchy.

## Testing

- `pnpm vitest run app/cli/cli-lesson-move-update.test.ts` — 24 passed.
- `pnpm typecheck`, `pnpm run lint:boundaries`, `prettier --check` — clean.
- Pre-existing, unrelated: `app/cli/cli-segment-writes.test.ts` (18) and 2 segment cases in `cli-backup-coordination.test.ts` fail identically on `origin/main` with this branch stashed. Not touched here.
- Not covered: the rendered `--help` output. `bin.mjs --help` needs `DATABASE_URL`, and the help strings are plain constants, so I left it to the reviewer's terminal.

## Note on the other half of the request: `cvm deliverable` writes

The task said `deliverable` was read-only (`list`/`get`) and that moving the Hype Video from 2026-08-03 to 2026-08-06 had to be done by hand in the UI. **That is no longer true** — #1457 landed on 2026-07-29 and gave `deliverable` `create` / `update` / `archive`, and the installed `cvm` binary already has them. Nothing to build; the triage task is stale.

The move you wanted is one command:

```
cvm deliverable list | jq 'select(.title | test("Hype"))'   # get the id
cvm deliverable update --date 2026-08-06 <id>
```

**Open question for you (non-blocking, nothing here depends on it):** the fact that this got filed at all suggests the stand-up was working from a stale picture of the CLI's write surface. Worth checking whether whatever it reads to decide "the CLI can't do X" is pinned to something older than `cvm --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)