### PR TITLE
feat(article-writer): cache the writer's prompt prefix

### DIFF
--- a/app/features/article-writer/cache-stats-badge.tsx
+++ b/app/features/article-writer/cache-stats-badge.tsx
@@ -1,0 +1,52 @@
+import { DatabaseIcon, DatabaseZapIcon } from "lucide-react";
+import type { WriterCacheStats } from "./types";
+
+const formatTokens = (tokens: number): string => {
+  if (tokens >= 1000) return `${(tokens / 1000).toFixed(1)}k`;
+  return String(tokens);
+};
+
+/**
+ * The prompt cache's only visible symptom.
+ *
+ * A cache miss raises no error — Anthropic silently bills the full prefix —
+ * so without this the breakpoints could rot for months unnoticed. The headline
+ * is deliberately binary, because the daily question is "did that hit?"; the
+ * three raw counts sit in the hover text for when the answer is no.
+ */
+export function CacheStatsBadge(props: { stats: WriterCacheStats }) {
+  const { cacheReadTokens, cacheWriteTokens, noCacheTokens } = props.stats;
+
+  // A write with no read is the expected first request of a session, not a
+  // fault — so it reads as "warmed" rather than as a miss.
+  const isHit = cacheReadTokens > 0;
+  const isWarming = !isHit && cacheWriteTokens > 0;
+
+  const label = isHit
+    ? `cached ${formatTokens(cacheReadTokens)}`
+    : isWarming
+      ? `warmed ${formatTokens(cacheWriteTokens)}`
+      : "uncached";
+
+  const title = [
+    `Read from cache: ${cacheReadTokens.toLocaleString()}`,
+    `Written to cache: ${cacheWriteTokens.toLocaleString()}`,
+    `Full price: ${noCacheTokens.toLocaleString()}`,
+  ].join("\n");
+
+  const Icon = isHit ? DatabaseZapIcon : DatabaseIcon;
+
+  return (
+    <div
+      title={title}
+      className={`mt-1 inline-flex items-center gap-1 text-xs ${
+        isHit
+          ? "text-emerald-600 dark:text-emerald-400"
+          : "text-muted-foreground"
+      }`}
+    >
+      <Icon className="h-3 w-3 shrink-0" />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/app/features/article-writer/settings-view.tsx
+++ b/app/features/article-writer/settings-view.tsx
@@ -5,20 +5,11 @@ import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { FullCover } from "./context-view";
 
 // ─── SettingsView ───────────────────────────────────────────────────────────
 
 export interface SettingsViewProps {
-  model: string;
-  onModelChange: (m: string) => void;
   banned: string[];
   onAddPhrase: (phrase: string) => void;
   onRemovePhrase: (index: number) => void;
@@ -26,8 +17,6 @@ export interface SettingsViewProps {
 }
 
 export function SettingsView({
-  model,
-  onModelChange,
   banned,
   onAddPhrase,
   onRemovePhrase,
@@ -49,38 +38,8 @@ export function SettingsView({
 
   return (
     <FullCover title="Settings" onBack={onBack}>
-      {/* Model picker */}
-      <div className="space-y-2">
-        <Label className="text-sm font-medium">Model</Label>
-        <Select value={model} onValueChange={onModelChange}>
-          <SelectTrigger className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="auto">
-              <div>
-                <div>Auto</div>
-                <div className="text-xs text-muted-foreground">
-                  Haiku to generate, Sonnet to edit
-                </div>
-              </div>
-            </SelectItem>
-            <SelectItem value="claude-haiku-4-5">
-              <div>
-                <div>Haiku 4.5</div>
-              </div>
-            </SelectItem>
-            <SelectItem value="claude-sonnet-4-5">
-              <div>
-                <div>Sonnet 4</div>
-              </div>
-            </SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-
       {/* Banned phrases */}
-      <div className="mt-6 space-y-3">
+      <div className="space-y-3">
         <Label className="text-sm font-medium">Banned phrases</Label>
 
         {banned.length > 0 && (

--- a/app/features/article-writer/types.ts
+++ b/app/features/article-writer/types.ts
@@ -11,8 +11,23 @@ export type DocumentAgentTools = {
   editDocument: typeof editDocumentTool;
 };
 
+/**
+ * Prompt-cache counts for one assistant message, sent down from the server.
+ *
+ * A cache miss produces no error — it just bills the full prefix — so these
+ * counts are the only signal that the breakpoints are still working.
+ */
+export type WriterCacheStats = {
+  /** Prefix tokens served from cache. Large means a hit. */
+  cacheReadTokens: number;
+  /** Prefix tokens written to cache. Large on the first request of a session. */
+  cacheWriteTokens: number;
+  /** Tokens billed at full price because nothing cached them. */
+  noCacheTokens: number;
+};
+
 export type DocumentAgentMessage = UIMessage<
-  unknown,
+  WriterCacheStats,
   never,
   InferUITools<DocumentAgentTools>
 >;
@@ -33,11 +48,6 @@ export type SectionWithWordCount = {
  * Inferred from the schema definition to ensure type safety.
  */
 export type Mode = TextWritingAgentMode;
-
-/**
- * AI model selection for article generation.
- */
-export type Model = "claude-sonnet-4-5" | "claude-haiku-4-5" | "auto";
 
 /**
  * The writer's sub-view. `"writer"` is the default the writer opens on.

--- a/app/features/article-writer/write-chat.tsx
+++ b/app/features/article-writer/write-chat.tsx
@@ -29,6 +29,7 @@ import {
   removeChooseScreenshot,
 } from "./choose-screenshot-mutations";
 import { WriteDocumentDisplay, EditDocumentDisplay } from "./tool-call-display";
+import { CacheStatsBadge } from "./cache-stats-badge";
 import { useMessageTextMutation } from "./message-text-mutation";
 
 export interface WriteChatProps {
@@ -251,6 +252,9 @@ export const WriteChat = memo(function WriteChat(props: WriteChatProps) {
                   >
                     {textContent}
                   </AIResponse>
+                )}
+                {message.metadata && (
+                  <CacheStatsBadge stats={message.metadata} />
                 )}
               </AIMessage>
             );

--- a/app/features/article-writer/write-toolbar.tsx
+++ b/app/features/article-writer/write-toolbar.tsx
@@ -1,11 +1,5 @@
 import { Button } from "@/components/ui/button";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-} from "@/components/ui/select";
-import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -33,14 +27,13 @@ import {
   RefreshCwIcon,
 } from "lucide-react";
 import type { LintViolation } from "./lint-rules";
-import type { Mode, Model } from "./types";
+import type { Mode } from "./types";
 import { WriteModeDropdown } from "./write-mode-dropdown";
 
 export type SaveTargetFolder = "explainer" | "problem" | "solution";
 
 export interface WriteToolbarProps {
   mode: Mode;
-  model: Model;
   status: "streaming" | "submitted" | "ready" | "error";
   isCopied: boolean;
   messagesLength: number;
@@ -53,7 +46,6 @@ export interface WriteToolbarProps {
   writeToReadmeFetcherState: "idle" | "submitting" | "loading";
   hasUnresolvedScreenshots: boolean;
   onModeChange: (mode: Mode) => void;
-  onModelChange: (model: Model) => void;
   onCopyToClipboard: () => void;
   onCopyAsRichText: () => void;
   onCopyConversationHistory: () => void;
@@ -71,7 +63,6 @@ export interface WriteToolbarProps {
 export function WriteToolbar(props: WriteToolbarProps) {
   const {
     mode,
-    model,
     status,
     isCopied,
     messagesLength,
@@ -83,7 +74,6 @@ export function WriteToolbar(props: WriteToolbarProps) {
     lastAssistantMessageText,
     writeToReadmeFetcherState,
     onModeChange,
-    onModelChange,
     onCopyToClipboard,
     onCopyAsRichText,
     onCopyConversationHistory,
@@ -99,7 +89,6 @@ export function WriteToolbar(props: WriteToolbarProps) {
   return (
     <div className="mb-4 flex gap-2 items-center">
       <WriteModeDropdown mode={mode} onModeChange={onModeChange} />
-      <ModelSelector model={model} onModelChange={onModelChange} />
       {!isDocumentMode && (
         <CopyButtons
           mode={mode}
@@ -199,53 +188,6 @@ export function WriteToolbar(props: WriteToolbarProps) {
         />
       )}
     </div>
-  );
-}
-
-function ModelSelector(props: {
-  model: Model;
-  onModelChange: (model: Model) => void;
-}) {
-  const { model, onModelChange } = props;
-  return (
-    <Select
-      value={model}
-      onValueChange={(value) => onModelChange(value as Model)}
-    >
-      <SelectTrigger>
-        {model === "auto"
-          ? "Auto"
-          : model === "claude-sonnet-4-5"
-            ? "Sonnet 4.5"
-            : "Haiku 4.5"}
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem value="auto">
-          <div>
-            <div>Auto</div>
-            <div className="text-xs text-muted-foreground">
-              Haiku for generation, Sonnet for editing
-            </div>
-          </div>
-        </SelectItem>
-        <SelectItem value="claude-haiku-4-5">
-          <div>
-            <div>Haiku 4.5</div>
-            <div className="text-xs text-muted-foreground">
-              Fast and cost-effective
-            </div>
-          </div>
-        </SelectItem>
-        <SelectItem value="claude-sonnet-4-5">
-          <div>
-            <div>Sonnet 4.5</div>
-            <div className="text-xs text-muted-foreground">
-              More capable and thorough
-            </div>
-          </div>
-        </SelectItem>
-      </SelectContent>
-    </Select>
   );
 }
 

--- a/app/features/article-writer/write-utils.ts
+++ b/app/features/article-writer/write-utils.ts
@@ -63,7 +63,6 @@ export const saveRecentMode = (mode: Mode): void => {
     // ignore
   }
 };
-export const MODEL_STORAGE_KEY = "article-writer-model";
 export const COURSE_STRUCTURE_STORAGE_KEY =
   "article-writer-include-course-structure";
 export const MEMORY_ENABLED_STORAGE_KEY = "article-writer-memory-enabled";

--- a/app/features/article-writer/writer-engine.tsx
+++ b/app/features/article-writer/writer-engine.tsx
@@ -2,7 +2,6 @@
 
 import type {
   Mode,
-  Model,
   DocumentAgentMessage,
   WriterContext,
   WriterView,
@@ -22,7 +21,7 @@ import { useRemoveDocumentBlock } from "./use-remove-document-block";
 import { useLint, useLintFix } from "@/hooks/use-lint";
 import { useBannedPhrases } from "@/hooks/use-banned-phrases";
 import { useMessageQueue } from "./use-message-queue";
-import { MODEL_STORAGE_KEY, partsToText } from "./write-utils";
+import { partsToText } from "./write-utils";
 import {
   replaceChooseScreenshotWithImage,
   updateChooseScreenshotClipIndex,
@@ -100,18 +99,6 @@ export function WriterEngine({
     modes[0] ?? "article"
   );
   const [mode, setMode] = useState<Mode>(constrainedMode);
-  const [model, setModelState] = useState<Model>(() =>
-    typeof localStorage !== "undefined"
-      ? (localStorage.getItem(MODEL_STORAGE_KEY) as Model) || "auto"
-      : "auto"
-  );
-  const setModel = useCallback((m: Model) => {
-    if (typeof localStorage !== "undefined") {
-      localStorage.setItem(MODEL_STORAGE_KEY, m);
-    }
-    setModelState(m);
-  }, []);
-
   const ctxModel = useContextModel(context, pageFields);
   useMemoryAutosave(ctxModel.memoryText, context.repoId);
 
@@ -323,7 +310,6 @@ export function WriterEngine({
       .map((f) => ({ label: f.label, value: f.value }));
     const base = {
       enabledFiles: Array.from(ctxModel.enabledFiles),
-      model,
       includeTranscript: transcriptEnabled,
       enabledSections: Array.from(ctxModel.enabledSections),
       courseStructure:
@@ -355,7 +341,6 @@ export function WriterEngine({
     ctxModel.enabledFiles,
     ctxModel.enabledFields,
     pageFields,
-    model,
     ctxModel.includeCourseStructure,
     courseStructure,
     ctxModel.memoryEnabled,
@@ -461,7 +446,6 @@ export function WriterEngine({
   const toolbarProps: WriteToolbarProps = useMemo(
     () => ({
       mode,
-      model,
       status,
       isCopied,
       messagesLength: messages.length,
@@ -474,7 +458,6 @@ export function WriterEngine({
       writeToReadmeFetcherState: "idle" as const,
       hasUnresolvedScreenshots: hasUnresolvedScreenshots(document ?? ""),
       onModeChange: handleModeChange,
-      onModelChange: (m: Model) => setModel(m),
       onCopyToClipboard: () => {
         const text = isDocumentMode
           ? (document ?? "")
@@ -494,7 +477,6 @@ export function WriterEngine({
     }),
     [
       mode,
-      model,
       status,
       isCopied,
       messages.length,
@@ -596,8 +578,6 @@ export function WriterEngine({
         {/* Settings overlay */}
         {view === "settings" && (
           <SettingsView
-            model={model}
-            onModelChange={(m) => setModel(m as Model)}
             banned={bannedPhrases.map((p) => p.readable)}
             onAddPhrase={(s) => addBannedPhrase(s, s, false)}
             onRemovePhrase={removeBannedPhrase}

--- a/app/routes/videos.$videoId.document-completions.ts
+++ b/app/routes/videos.$videoId.document-completions.ts
@@ -4,13 +4,28 @@ import {
   acquireTextWritingContext,
   createModelMessagesForTextWritingAgent,
 } from "@/services/text-writing-agent";
-import { createDocumentWritingAgent } from "@/services/document-writing-agent";
+import {
+  createDocumentWritingAgent,
+  formatRelatedFields,
+} from "@/services/document-writing-agent";
+import { CACHE_BREAKPOINT_5M } from "@/services/prompt-cache";
 import type { DocumentWritingAgentMode } from "@/services/document-writing-agent";
-import { type UIMessage } from "ai";
+import { type LanguageModelUsage, type ModelMessage, type UIMessage } from "ai";
 import { Console, Effect, Schema } from "effect";
 import type { Route } from "./+types/videos.$videoId.document-completions";
 import { anthropic } from "@ai-sdk/anthropic";
 import { data } from "react-router";
+import type { WriterCacheStats } from "@/features/article-writer/types";
+
+/**
+ * The one model the document writer uses.
+ *
+ * This was a user-facing dropdown with an "auto" setting that picked Haiku
+ * before the first draft existed and Sonnet afterwards. That flip meant the
+ * expensive first request warmed a cache on one model and every later request
+ * read from another — so the cache was never once hit. One model, always.
+ */
+export const DOCUMENT_WRITER_MODEL = "claude-sonnet-4-6";
 
 const courseStructureSchema = Schema.Struct({
   repoName: Schema.String,
@@ -39,7 +54,6 @@ const documentModeSchema = Schema.Union(
 const chatSchema = Schema.Struct({
   messages: Schema.Any,
   enabledFiles: Schema.Array(Schema.String),
-  model: Schema.String,
   mode: Schema.optionalWith(documentModeSchema, {
     default: () => "article" as const,
   }),
@@ -68,12 +82,6 @@ export const action = async (args: Route.ActionArgs) => {
     const parsed = yield* Schema.decodeUnknown(chatSchema)(body);
     const messages: UIMessage[] = parsed.messages;
     const enabledFiles: string[] = [...parsed.enabledFiles];
-    const model: string =
-      parsed.model === "auto"
-        ? parsed.document
-          ? "claude-sonnet-4-5"
-          : "claude-haiku-4-5"
-        : parsed.model;
     const includeTranscript = parsed.includeTranscript;
     const enabledSections: string[] = [...parsed.enabledSections];
 
@@ -111,10 +119,47 @@ export const action = async (args: Route.ActionArgs) => {
       createModelMessagesForTextWritingAgent({
         messages,
         imageFiles: videoContext.imageFiles,
+        cacheImages: true,
       })
     );
 
-    // Append document content to last user message for prompt caching
+    // The prompt is laid out stable-first so that each cache breakpoint only
+    // ever covers content that outlives it:
+    //
+    //   system prompt        <- 1h breakpoint (in the agent)
+    //   screenshots          <- 1h breakpoint (in the message builder)
+    //   related page fields  <- no breakpoint; churns
+    //   conversation         <- two 5m breakpoints, on the last two messages
+    //   <current-document>   <- never cached; differs on every request
+    //
+    // Anything below a breakpoint can change freely without costing the
+    // entries above it.
+    const conversationStart = videoContext.imageFiles.length > 0 ? 1 : 0;
+    const conversation = modelMessages.slice(conversationStart);
+
+    // Two breakpoints, not one. Within a single user message the client
+    // applies the edit and re-submits, so the conversation grows mid-turn;
+    // marking the last two messages lets each request read the previous one's
+    // write instead of leaning on Anthropic's 20-block lookback, which a
+    // screenshots message of up to 16 blocks makes far too tight to trust.
+    for (const message of conversation.slice(-2)) {
+      message.providerOptions = CACHE_BREAKPOINT_5M;
+    }
+
+    // Sent as a message rather than folded into the system prompt. In the SEO
+    // writer this field is the entire lesson body, which changes on every
+    // keystroke in the other pane — in the system prompt it would invalidate
+    // the transcript and screenshots along with itself.
+    const relatedFields = formatRelatedFields(parsed.pageFields);
+    if (relatedFields) {
+      modelMessages.splice(conversationStart, 0, {
+        role: "user",
+        content: relatedFields,
+      } satisfies ModelMessage);
+    }
+
+    // Always last, and never a breakpoint: the document changes on every
+    // single request, including between the two requests of one user message.
     if (parsed.document) {
       const documentText = `\n\n<current-document>\n${parsed.document}\n</current-document>`;
       modelMessages.push({
@@ -124,9 +169,8 @@ export const action = async (args: Route.ActionArgs) => {
     }
 
     const agent = createDocumentWritingAgent({
-      model: anthropic(model),
+      model: anthropic(DOCUMENT_WRITER_MODEL),
       mode: parsed.mode as DocumentWritingAgentMode,
-      document: parsed.document,
       transcript: videoContext.transcript,
       code: videoContext.textFiles,
       imageFiles: videoContext.imageFiles,
@@ -134,7 +178,6 @@ export const action = async (args: Route.ActionArgs) => {
       links,
       courseStructure: courseStructureText,
       memory: parsed.memory,
-      additionalContext: [...parsed.pageFields],
       beats: parsed.beats,
       script: parsed.script,
     });
@@ -142,11 +185,30 @@ export const action = async (args: Route.ActionArgs) => {
     const result = yield* Effect.promise(async () => {
       const stream = await (agent.stream({
         messages: modelMessages,
-      }) as Promise<{ toUIMessageStreamResponse: () => Response }>);
+      }) as Promise<{
+        toUIMessageStreamResponse: (opts: {
+          messageMetadata: (options: {
+            part: { type: string; totalUsage?: LanguageModelUsage };
+          }) => WriterCacheStats | undefined;
+        }) => Response;
+      }>);
       return stream;
     });
 
-    return result.toUIMessageStreamResponse();
+    // A cache miss is silent — Anthropic returns no error when caching does
+    // not apply, it simply bills the full prefix. Sending the counts to the
+    // client is the only way the miss ever becomes visible.
+    return result.toUIMessageStreamResponse({
+      messageMetadata: ({ part }) => {
+        if (part.type !== "finish" || !part.totalUsage) return undefined;
+        const details = part.totalUsage.inputTokenDetails;
+        return {
+          cacheReadTokens: details?.cacheReadTokens ?? 0,
+          cacheWriteTokens: details?.cacheWriteTokens ?? 0,
+          noCacheTokens: details?.noCacheTokens ?? 0,
+        };
+      },
+    });
   }).pipe(
     Effect.tapErrorCause((e) => Console.dir(e, { depth: null })),
     Effect.catchTag("ParseError", () => {

--- a/app/services/document-writing-agent.test.ts
+++ b/app/services/document-writing-agent.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDocumentWritingSystemMessage,
+  formatRelatedFields,
+  type DocumentWritingContext,
+} from "./document-writing-agent";
+import { CACHE_BREAKPOINT_1H } from "./prompt-cache";
+
+const baseContext = (
+  overrides: Partial<DocumentWritingContext> = {}
+): DocumentWritingContext => ({
+  transcript: "[1] So today we are going to look at prompt caching.",
+  code: [{ path: "writer-notes.md", content: "# Notes" }],
+  imageFiles: [],
+  ...overrides,
+});
+
+describe("buildDocumentWritingSystemMessage", () => {
+  it("carries a one-hour cache breakpoint", () => {
+    const message = buildDocumentWritingSystemMessage(baseContext());
+
+    expect(message.role).toBe("system");
+    expect(message.providerOptions).toEqual(CACHE_BREAKPOINT_1H);
+    expect(message.providerOptions?.anthropic?.cacheControl).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
+  });
+
+  // The whole scheme rests on this. The prompt used to branch on whether a
+  // document existed, so the first draft landing rewrote the system block and
+  // threw away the transcript, code files and screenshots with it — once per
+  // document, silently. The model must discriminate on the message instead.
+  it("describes both tools and discriminates on <current-document>", () => {
+    const message = buildDocumentWritingSystemMessage(baseContext());
+
+    expect(message.content).toContain("writeDocument");
+    expect(message.content).toContain("editDocument");
+    expect(message.content).toContain("<current-document>");
+  });
+
+  it("puts the transcript ahead of the code files", () => {
+    const message = buildDocumentWritingSystemMessage(
+      baseContext({
+        transcript: "UNIQUE_TRANSCRIPT_MARKER",
+        code: [{ path: "notes.md", content: "UNIQUE_CODE_MARKER" }],
+      })
+    );
+
+    const transcriptAt = message.content.indexOf("UNIQUE_TRANSCRIPT_MARKER");
+    const codeAt = message.content.indexOf("UNIQUE_CODE_MARKER");
+
+    expect(transcriptAt).toBeGreaterThanOrEqual(0);
+    expect(codeAt).toBeGreaterThan(transcriptAt);
+  });
+
+  // Memory changes rarely — less than once an hour — so it belongs inside the
+  // cached block rather than costing a breakpoint of its own.
+  it("includes memory in the cached block", () => {
+    const message = buildDocumentWritingSystemMessage(
+      baseContext({ memory: "UNIQUE_MEMORY_MARKER" })
+    );
+
+    expect(message.content).toContain("UNIQUE_MEMORY_MARKER");
+  });
+
+  // The counterpart to the rule above: page fields churn (in the SEO writer
+  // they are the entire lesson body), so they must never reach the system
+  // prompt. The route sends them as a message behind the breakpoint instead.
+  it("never contains the related page fields", () => {
+    const message = buildDocumentWritingSystemMessage(baseContext());
+
+    expect(message.content).not.toContain("Related Fields");
+  });
+});
+
+describe("formatRelatedFields", () => {
+  it("returns undefined when there is nothing to send", () => {
+    expect(formatRelatedFields([])).toBeUndefined();
+    expect(
+      formatRelatedFields([{ label: "SEO", value: "   " }])
+    ).toBeUndefined();
+  });
+
+  it("renders populated fields and drops empty ones", () => {
+    const result = formatRelatedFields([
+      { label: "SEO Description", value: "A lesson about caching." },
+      { label: "Empty Field", value: "" },
+    ]);
+
+    expect(result).toContain("SEO Description");
+    expect(result).toContain("A lesson about caching.");
+    expect(result).not.toContain("Empty Field");
+  });
+});

--- a/app/services/document-writing-agent.ts
+++ b/app/services/document-writing-agent.ts
@@ -9,6 +9,7 @@ import {
   ToolLoopAgent as Agent,
   tool,
   type LanguageModel,
+  type SystemModelMessage,
   stepCountIs,
 } from "ai";
 import { z } from "zod";
@@ -17,6 +18,7 @@ import type {
   TextWritingAgentCodeFile,
   TextWritingAgentImageFile,
 } from "./text-writing-agent";
+import { CACHE_BREAKPOINT_1H } from "./prompt-cache";
 
 export type DocumentWritingAgentMode =
   "article" | "skill-building" | "newsletter" | "seo-description-document";
@@ -63,10 +65,34 @@ export const editDocumentTool = tool({
   outputSchema: z.string(),
 });
 
-export const createDocumentWritingAgent = (props: {
-  model: LanguageModel;
+/**
+ * Render the other fields on the same page as reference context.
+ *
+ * This is NOT part of the system prompt, and must not become part of it. In
+ * the SEO writer the "related field" is the entire lesson body, which changes
+ * on every keystroke in the other pane; in the body writer it is the SEO
+ * description. Sending it as a message keeps that churn behind the system and
+ * screenshot cache breakpoints, where it can only invalidate itself.
+ *
+ * Returns undefined when there is nothing worth sending.
+ */
+export const formatRelatedFields = (
+  fields: ReadonlyArray<{ label: string; value: string }>
+): string | undefined => {
+  const populated = fields.filter((field) => field.value.trim());
+  if (populated.length === 0) return undefined;
+
+  return `## Related Fields
+
+The following fields from the same lesson page are provided as reference. Use them to stay consistent, but do not simply copy them:
+
+${populated
+  .map((field) => `<field label="${field.label}">\n${field.value}\n</field>`)
+  .join("\n\n")}`;
+};
+
+export type DocumentWritingContext = {
   mode?: DocumentWritingAgentMode;
-  document: string | undefined;
   transcript: string;
   code: TextWritingAgentCodeFile[];
   imageFiles: TextWritingAgentImageFile[];
@@ -74,13 +100,27 @@ export const createDocumentWritingAgent = (props: {
   links?: GlobalLink[];
   courseStructure?: string;
   memory?: string;
-  /** Other fields from the same page, offered as reference context. */
-  additionalContext?: Array<{ label: string; value: string }>;
   /** Pre-formatted beat plan text (kinds + titles + descriptions). */
   beats?: string;
   /** The video's script — the base Matt improvised from. */
   script?: string;
-}) => {
+};
+
+/**
+ * Build the writer's system prompt as a single cache-breakpointed block.
+ *
+ * Exported so a test can assert the cache layout directly. A dropped
+ * breakpoint produces no error and no visible defect — just a silently larger
+ * bill — so the structure is worth pinning down.
+ *
+ * Every part of this block is stable for the life of a writing session. That
+ * is the whole point: content that churns (the related page fields, the
+ * document itself) is sent as messages by the route, so that it lands AFTER
+ * this breakpoint and cannot invalidate it.
+ */
+export const buildDocumentWritingSystemMessage = (
+  props: DocumentWritingContext
+): SystemModelMessage => {
   const links = props.links ?? [];
   const mode = props.mode ?? "article";
 
@@ -123,12 +163,19 @@ export const createDocumentWritingAgent = (props: {
     }
   })();
 
-  const documentInstructions = props.document
-    ? `
+  // These instructions deliberately do NOT branch on whether a document
+  // exists. They used to, which meant the first draft landing rewrote the
+  // system prompt and threw away the whole cached prefix — transcript,
+  // screenshots and all — exactly once per document. The model picks its tool
+  // from the presence of <current-document> instead, so the prefix now
+  // survives the write-to-edit transition.
+  const documentInstructions = `
 
-## Document Editing Instructions
+## Document Instructions
 
-A document already exists. The user will provide it in a <current-document> tag. You MUST use the \`editDocument\` tool to make changes. Do not output the full content as plain text.
+Which tool you use depends on whether a document already exists.
+
+**If the user's messages contain a <current-document> tag, a document exists.** You MUST use the \`editDocument\` tool to make changes. Do not output the full content as plain text.
 
 IMPORTANT: The user may have manually edited the document since your last tool call. The <current-document> tag always contains the latest version of the document. Do NOT assume your previous tool call inputs reflect the current state — always reference <current-document> as the single source of truth when planning edits.
 
@@ -141,31 +188,15 @@ You can include multiple edits in a single editDocument call. Edits are applied 
 
 If an edit fails (e.g. text not found), you will receive an error message. Read it carefully and retry with corrected text.
 
+**If there is no <current-document> tag, there is no document yet.** You MUST use the \`writeDocument\` tool to create the content. Do not output the content as plain text — always use the tool.
+
+Never call \`writeDocument\` when a <current-document> tag is present: that would discard the user's existing work. Never call \`editDocument\` when one is absent.
+
 ## Adding Screenshots
 
 When the user asks you to add a screenshot or image from the video, you MUST use the \`<ChooseScreenshot clipIndex={N} alt="description" />\` component — do NOT insert a raw markdown image like \`![alt](url)\`. The ChooseScreenshot component lets the user interactively select the exact frame from the video clip. The clipIndex must reference a valid clip index from the transcript.
 
-After calling editDocument, you may add a brief conversational message explaining what you changed.`
-    : `
-
-## Document Writing Instructions
-
-There is no document yet. You MUST use the \`writeDocument\` tool to create the content. Do not output the content as plain text — always use the tool.
-
-After calling writeDocument, you may add a brief conversational message explaining what you wrote.`;
-
-  const additionalContext = (props.additionalContext ?? []).filter((f) =>
-    f.value.trim()
-  );
-  const additionalContextSection =
-    additionalContext.length > 0
-      ? `\n\n## Related Fields\n\nThe following fields from the same lesson page are provided as reference. Use them to stay consistent, but do not simply copy them:\n\n${additionalContext
-          .map((f) => `<field label="${f.label}">\n${f.value}\n</field>`)
-          .join("\n\n")}`
-      : "";
-
-  const systemPrompt =
-    basePrompt + additionalContextSection + documentInstructions;
+After calling a tool, you may add a brief conversational message explaining what you did.`;
 
   const memorySection = props.memory
     ? `\n\n## Course Memory\n\nThe following is course-level context provided by the author. Use it to inform your response:\n\n<memory>\n${props.memory}\n</memory>`
@@ -175,6 +206,21 @@ After calling writeDocument, you may add a brief conversational message explaini
 
   const scriptSection = getScriptSection(props.script ?? "");
 
+  return {
+    role: "system",
+    content:
+      basePrompt +
+      documentInstructions +
+      scriptSection +
+      beatsSection +
+      memorySection,
+    providerOptions: CACHE_BREAKPOINT_1H,
+  };
+};
+
+export const createDocumentWritingAgent = (
+  props: DocumentWritingContext & { model: LanguageModel }
+) => {
   const repairToolCall: ConstructorParameters<
     typeof Agent
   >[0]["experimental_repairToolCall"] = async ({ toolCall }) => {
@@ -186,20 +232,16 @@ After calling writeDocument, you may add a brief conversational message explaini
     }
   };
 
-  if (props.document) {
-    return new Agent({
-      model: props.model,
-      instructions: systemPrompt + memorySection + scriptSection + beatsSection,
-      tools: { editDocument: editDocumentTool },
-      stopWhen: stepCountIs(5),
-      experimental_repairToolCall: repairToolCall,
-    });
-  }
-
+  // Both tools are always registered. Changing the tool set invalidates the
+  // tools, the system prompt AND the messages, so a tool set that flipped
+  // when the first draft landed was throwing the entire cache away.
   return new Agent({
     model: props.model,
-    instructions: systemPrompt + memorySection + scriptSection + beatsSection,
-    tools: { writeDocument: writeDocumentTool },
+    instructions: [buildDocumentWritingSystemMessage(props)],
+    tools: {
+      writeDocument: writeDocumentTool,
+      editDocument: editDocumentTool,
+    },
     stopWhen: stepCountIs(5),
     experimental_repairToolCall: repairToolCall,
   });

--- a/app/services/prompt-cache.ts
+++ b/app/services/prompt-cache.ts
@@ -1,0 +1,46 @@
+/**
+ * Anthropic prompt-caching breakpoints for the writing agents.
+ *
+ * A writing session re-sends the same 10k–26k tokens of transcript, code files
+ * and screenshots on every request, and there are two requests per user
+ * message because the client re-submits after applying each edit. Caching that
+ * prefix is the difference between paying for it once and paying for it twenty
+ * times.
+ *
+ * Anthropic builds the cache in a strict order — tools, then system, then
+ * messages — and a change at any level invalidates that level and everything
+ * after it. So the layout that matters is: put stable content first, put a
+ * breakpoint at the end of it, and keep churning content strictly behind that
+ * breakpoint. The writing agents are arranged to make that true.
+ *
+ * Only four breakpoints are allowed per request. The document writer spends
+ * them on the system prompt, the screenshots, and the last two messages of the
+ * conversation.
+ */
+
+/**
+ * The one-hour breakpoint, for content that is stable across a whole session:
+ * the system prompt and the screenshots.
+ *
+ * The five-minute default is wrong here. Writing sessions have long gaps —
+ * Matt reads the draft, hand-edits it, and comes back — so a five-minute
+ * entry would nearly always be cold. A one-hour write costs 2x base and a read
+ * costs 0.1x, so it pays back after roughly one hit.
+ *
+ * Anthropic requires longer TTLs to appear ahead of shorter ones in the
+ * prompt. The system-before-messages ordering guarantees that.
+ */
+export const CACHE_BREAKPOINT_1H = {
+  anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } },
+} as const;
+
+/**
+ * The five-minute breakpoint, for the conversation tail.
+ *
+ * The tail turns over within a single user message — the client applies each
+ * edit and immediately re-submits — so it is read back in seconds and is never
+ * worth the 2x write premium of a one-hour entry.
+ */
+export const CACHE_BREAKPOINT_5M = {
+  anthropic: { cacheControl: { type: "ephemeral" } },
+} as const;

--- a/app/services/text-writing-agent.ts
+++ b/app/services/text-writing-agent.ts
@@ -19,6 +19,7 @@ import { generateScopingDocumentPrompt } from "@/prompts/generate-scoping-docume
 import type { GlobalLink } from "@/prompts/link-instructions";
 import { getBeatsSection } from "@/prompts/beats-instructions";
 import { getScriptSection } from "@/prompts/script-instructions";
+import { CACHE_BREAKPOINT_1H } from "./prompt-cache";
 import {
   ToolLoopAgent as Agent,
   convertToModelMessages,
@@ -213,6 +214,16 @@ export const createTextWritingAgent = (props: {
 export const createModelMessagesForTextWritingAgent = async (props: {
   messages: UIMessage[];
   imageFiles: TextWritingAgentImageFile[];
+  /**
+   * Put an Anthropic cache breakpoint on the screenshots message.
+   *
+   * Off by default. Only the document writer holds a conversation, so only it
+   * ever reads the cache back; the one-shot generation modes would pay the
+   * write premium and never get a hit. A video carries up to eight
+   * screenshots — roughly 13k tokens — so this earns a breakpoint wherever
+   * there IS a second request.
+   */
+  cacheImages?: boolean;
 }): Promise<ModelMessage[]> => {
   const modelMessages = await convertToModelMessages(props.messages);
 
@@ -231,6 +242,7 @@ export const createModelMessagesForTextWritingAgent = async (props: {
           },
         ];
       }),
+      ...(props.cacheImages ? { providerOptions: CACHE_BREAKPOINT_1H } : {}),
     });
   }
 


### PR DESCRIPTION
The document writer cached nothing. Every request re-sent the whole prefix — 10k–26k tokens of transcript, code files and screenshots — and there are **two** requests per user message, because the client applies each edit and re-submits. A ten-message session paid for that prefix about twenty times.

Measured against the real data: transcripts run 3k–9k tokens, `writer-notes.md` reaches 55 KB (~14k tokens), and 38 of ~48 videos carry screenshots — up to 8 in one video, roughly 13k tokens.

## The layout

Stable-first, so each breakpoint only covers content that outlives it:

| Order | Content | Breakpoint |
|---|---|---|
| tools | `writeDocument` + `editDocument`, both always registered | — |
| system | prompt → transcript → code files → script + beats → memory | **1h** |
| messages[0] | screenshots | **1h** |
| messages[1] | related page fields | none; churns |
| messages[2..n] | conversation | **two 5m**, on the last two messages |
| messages[last] | `<current-document>` | never; differs every request |

Four breakpoints, which is exactly the API maximum.

## What had to move

- **The system prompt branched on whether a document existed.** So the first draft landing rewrote it and threw the whole cache away, once per document. It now discriminates on the `<current-document>` message instead.
- **The tool set flipped** `writeDocument` → `editDocument` at that same moment. Changing tools invalidates tools, system *and* messages. Both are now always registered — `types.ts` already declared both, so the server was the odd one out.
- **Related page fields sat in the system prompt.** In the SEO writer that field is the entire lesson body, which changes on every keystroke in the other pane. Now a message, behind the breakpoints.

Memory stays inside the cached block: it changes less than once an hour.

## Model picker removed

`auto` picked Haiku before the first draft and Sonnet after, so the expensive first request warmed a cache on one model that no later request could ever read. Haiku also needs 4,096 tokens minimum to cache. One model now — Sonnet 4.6 — hardcoded server-side, so the client cannot reintroduce a second cache entry.

## Making misses visible

A cache miss raises no error; Anthropic just bills the full prefix. Each assistant message now carries a hit/miss badge, with read / write / full-price counts on hover. A test pins the cache layout down, since a dropped breakpoint has no visible symptom.

## Expected effect

Input cost on a ten-message session drops from roughly \$0.90 to \$0.18, and time-to-first-token improves on every message after the first.

## Risks

- Toggling a file in the context strip invalidates the system block and everything downstream. That is inherent to prefix caching — no layout avoids it.
- Sonnet 4.6 is a model change riding along with a caching change. If output shifts, the cause is ambiguous. Pin `DOCUMENT_WRITER_MODEL` back to `claude-sonnet-4-5` to isolate.

## Verification

- `pnpm typecheck` clean.
- 1,034 tests pass across `app/services` and `app/features/article-writer`, including 7 new ones.
- The 21 failures in the full suite (`cli-segment-writes`, `cli-backup-coordination`, `course-publish-service-video-tasks`) are pre-existing — confirmed failing identically on a clean `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)