### PR TITLE
fix(article-writer): persist the links context toggle

### DIFF
--- a/app/features/article-writer/use-context-model.ts
+++ b/app/features/article-writer/use-context-model.ts
@@ -4,12 +4,16 @@ import { useState, useMemo, useCallback } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import type { WriterContext } from "./writer-engine";
 import { estimateTokens, type SourceView } from "./inline-context-strip";
-import { useLocalStorageBoolean } from "@/hooks/use-local-storage";
+import {
+  useLocalStorageBoolean,
+  useLocalStorageStringSet,
+} from "@/hooks/use-local-storage";
 import {
   MEMORY_ENABLED_STORAGE_KEY,
   COURSE_STRUCTURE_STORAGE_KEY,
   BEATS_ENABLED_STORAGE_KEY,
   SCRIPT_ENABLED_STORAGE_KEY,
+  LINKS_DISABLED_STORAGE_KEY,
 } from "./write-utils";
 import { formatBeatsContext } from "./format-beats-context";
 
@@ -86,9 +90,10 @@ export function useContextModel(
   );
   const [memoryText, setMemoryText] = useState(context.memory);
   // Links default to on; we track the *disabled* ids so links added after mount
-  // (via revalidation) are included by default.
-  const [disabledLinks, setDisabledLinks] = useState<Set<string>>(
-    () => new Set()
+  // (via revalidation) are included by default. Persisted like the other
+  // source toggles, so switching a link off outlives the open modal.
+  const [disabledLinks, setDisabledLinks] = useLocalStorageStringSet(
+    LINKS_DISABLED_STORAGE_KEY
   );
   const [beatsEnabled, setBeatsEnabled] = useLocalStorageBoolean(
     BEATS_ENABLED_STORAGE_KEY

--- a/app/features/article-writer/write-utils.ts
+++ b/app/features/article-writer/write-utils.ts
@@ -68,6 +68,11 @@ export const COURSE_STRUCTURE_STORAGE_KEY =
 export const MEMORY_ENABLED_STORAGE_KEY = "article-writer-memory-enabled";
 export const BEATS_ENABLED_STORAGE_KEY = "article-writer-beats-enabled";
 export const SCRIPT_ENABLED_STORAGE_KEY = "article-writer-script-enabled";
+/**
+ * The links a writer has switched OFF. Stores the disabled ids, not the enabled
+ * ones, so a Link added after the preference was saved still defaults to on.
+ */
+export const LINKS_DISABLED_STORAGE_KEY = "article-writer-links-disabled";
 
 export const getMessagesStorageKey = (videoId: string, mode: Mode) =>
   `article-writer-messages-${videoId}-${mode}`;

--- a/app/hooks/use-local-storage.test.ts
+++ b/app/hooks/use-local-storage.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { parseStringSet } from "./use-local-storage";
+
+describe("parseStringSet", () => {
+  it("reads back a stored id list", () => {
+    expect(parseStringSet('["link-1","link-2"]')).toEqual(
+      new Set(["link-1", "link-2"])
+    );
+  });
+
+  it("reads an empty list as an empty set", () => {
+    expect(parseStringSet("[]")).toEqual(new Set());
+  });
+
+  it("falls back to an empty set on unparseable JSON", () => {
+    expect(parseStringSet("not json")).toEqual(new Set());
+  });
+
+  it("falls back to an empty set when the value is not an array", () => {
+    expect(parseStringSet('{"link-1":true}')).toEqual(new Set());
+  });
+
+  it("drops non-string members rather than the whole list", () => {
+    expect(parseStringSet('["link-1",7,null,"link-2"]')).toEqual(
+      new Set(["link-1", "link-2"])
+    );
+  });
+});

--- a/app/hooks/use-local-storage.ts
+++ b/app/hooks/use-local-storage.ts
@@ -3,6 +3,7 @@ import {
   type SetStateAction,
   useCallback,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 
@@ -41,6 +42,43 @@ export function useLocalStorageBoolean(
         const next =
           typeof action === "function" ? action(prev === "true") : action;
         return String(next);
+      });
+    },
+    [setRaw]
+  );
+
+  return [value, setValue];
+}
+
+/** A stored id list that survives a bad or hand-edited value. */
+export function parseStringSet(raw: string): Set<string> {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((id): id is string => typeof id === "string"));
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * A set of ids kept in `localStorage` as a JSON array — the Set-shaped sibling
+ * of {@link useLocalStorageBoolean}, for preferences that name *which* items
+ * are on rather than one on/off.
+ */
+export function useLocalStorageStringSet(
+  key: string
+): [Set<string>, Dispatch<SetStateAction<Set<string>>>] {
+  const [raw, setRaw] = useLocalStorage(key, "[]");
+
+  const value = useMemo(() => parseStringSet(raw), [raw]);
+
+  const setValue: Dispatch<SetStateAction<Set<string>>> = useCallback(
+    (action) => {
+      setRaw((prev) => {
+        const next =
+          typeof action === "function" ? action(parseStringSet(prev)) : action;
+        return JSON.stringify([...next]);
       });
     },
     [setRaw]


### PR DESCRIPTION
## What

The Links source was the only Article Writer context source held in plain `useState`. Its `disabledLinks` set was re-initialised empty on every mount (`use-context-model.ts:90`), so switching a link off never outlived the open writer — while memory, course structure, beats and script all came back as left.

## How

- New `useLocalStorageStringSet` next to `useLocalStorageBoolean` — a JSON id array in `localStorage`, the Set-shaped sibling for preferences that name *which* items are on.
- `disabledLinks` now reads and writes `article-writer-links-disabled`.
- The stored ids are the **disabled** ones, keeping the existing rule that a Link added later still defaults to on.
- `parseStringSet` survives a bad or hand-edited value; 5 unit tests cover it.

## Checks

`pnpm typecheck` clean. `pnpm vitest run app/hooks app/features/article-writer` — 171 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)