### PR TITLE
docs(prompts): tell the writer that screenshots resolve into local images

### DIFF
--- a/app/prompts/screenshot-instructions.ts
+++ b/app/prompts/screenshot-instructions.ts
@@ -10,4 +10,6 @@ Insert \`<ChooseScreenshot clipIndex={N} alt="description of what's on screen" /
 The \`clipIndex\` must match a clip index from the transcript. The \`alt\` should describe what's visible on screen at that point.
 
 Example: \`<ChooseScreenshot clipIndex={3} alt="VS Code showing the TypeScript error" />\`
+
+Each \`<ChooseScreenshot>\` is a placeholder that the user resolves by hand. The user picks the exact frame in the UI, and the component becomes a local markdown image in its place — \`![description](./path/to/frame.png)\`. This is the normal path for every screenshot: place the component, and expect a local image where you put it.
 `.trim();

--- a/app/services/document-writing-agent.ts
+++ b/app/services/document-writing-agent.ts
@@ -196,6 +196,8 @@ Never call \`writeDocument\` when a <current-document> tag is present: that woul
 
 When the user asks you to add a screenshot or image from the video, you MUST use the \`<ChooseScreenshot clipIndex={N} alt="description" />\` component — do NOT insert a raw markdown image like \`![alt](url)\`. The ChooseScreenshot component lets the user interactively select the exact frame from the video clip. The clipIndex must reference a valid clip index from the transcript.
 
+A local markdown image in <current-document> — \`![description](./path/to/frame.png)\` — is a screenshot the user has already resolved: they picked that frame themselves, and the component was replaced in place. Treat it as finished work. Keep the image where it is and edit the prose around it.
+
 After calling a tool, you may add a brief conversational message explaining what you did.`;
 
   const memorySection = props.memory


### PR DESCRIPTION
## What

Teach the writer agent that a `<ChooseScreenshot>` component is a placeholder the user resolves by hand into a local image.

- **`app/prompts/screenshot-instructions.ts`** — the shared placement instructions (article, newsletter, skill-building) now state the lifecycle: the user picks the exact frame in the UI, and the component is replaced in place by `![description](./path/to/frame.png)`. This is the normal path for every screenshot.
- **`app/services/document-writing-agent.ts`** — the edit-time branch, which only the chat agent meets: a local markdown image in `<current-document>` is a screenshot the user already resolved. Keep it where it is and edit the prose around it.

## Why

The writer was never told what happens to a component after it emits one. A resolved image arriving back in `<current-document>` therefore read as foreign markdown — work the agent could reasonably "correct" back into a component, or write over.

The lifecycle lives in one place (the shared instructions); the edit agent adds only the consequence, not a restatement.

## Testing

`vitest run app/services/document-writing-agent app/prompts app/features/article-writer` — 210 tests pass, including the cache-layout test that pins the system message structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)