### PR TITLE
fix(article-writer): stop capture remounting every screenshot picker

### DIFF
--- a/app/features/article-writer/choose-screenshot-components.tsx
+++ b/app/features/article-writer/choose-screenshot-components.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { HTMLAttributes, ReactNode } from "react";
+import type { Options } from "react-markdown";
+import { ChooseScreenshot } from "./choose-screenshot";
+import type { IndexedClip } from "./types";
+
+/**
+ * Everything a rendered `<ChooseScreenshot>` placeholder needs. It travels by
+ * context rather than by closure so the component map below can stay frozen —
+ * see {@link CHOOSE_SCREENSHOT_COMPONENTS} for why that matters.
+ */
+export interface ChooseScreenshotRuntime {
+  clips: IndexedClip[];
+  /** True while the writer is still producing text; placeholders wait. */
+  isStreaming: boolean;
+  /** Identifies the one placeholder whose capture is in flight, if any. */
+  capturingKey: string | null;
+  /**
+   * Builds the key compared against `capturingKey`. The chat scopes keys by
+   * message id; the document has one scope and ignores it.
+   */
+  keyFor: (clipIndex: number, alt: string, messageId: string) => string;
+  onClipIndexChange: (
+    messageId: string,
+    currentIndex: number,
+    newIndex: number,
+    alt: string
+  ) => void;
+  onCapture: (
+    messageId: string,
+    clipIndex: number,
+    alt: string,
+    timestamp: number,
+    videoFilename: string
+  ) => void;
+  onRemove: (messageId: string, clipIndex: number, alt: string) => void;
+}
+
+const RuntimeContext = createContext<ChooseScreenshotRuntime | null>(null);
+
+/** Wrap whatever renders the markdown; without it placeholders render nothing. */
+export function ChooseScreenshotProvider({
+  runtime,
+  children,
+}: {
+  runtime: ChooseScreenshotRuntime;
+  children: ReactNode;
+}) {
+  return (
+    <RuntimeContext.Provider value={runtime}>
+      {children}
+    </RuntimeContext.Provider>
+  );
+}
+
+function ChooseScreenshotSlot(
+  props: HTMLAttributes<HTMLElement> & Record<string, unknown>
+) {
+  const runtime = useContext(RuntimeContext);
+  if (!runtime) return null;
+
+  const clipIndex = parseInt(props.clipindex as string, 10);
+  const alt = (props.alt as string) ?? "";
+  const messageId = (props["data-message-id"] as string) ?? "";
+
+  return (
+    <ChooseScreenshot
+      clipIndex={clipIndex}
+      alt={alt}
+      clips={runtime.clips}
+      onClipIndexChange={(current, next) =>
+        runtime.onClipIndexChange(messageId, current, next, alt)
+      }
+      onCapture={(ci, a, timestamp, videoFilename) =>
+        runtime.onCapture(messageId, ci, a, timestamp, videoFilename)
+      }
+      onRemove={(ci, a) => runtime.onRemove(messageId, ci, a)}
+      isCapturing={
+        runtime.capturingKey === runtime.keyFor(clipIndex, alt, messageId)
+      }
+      isStreaming={runtime.isStreaming}
+    />
+  );
+}
+
+/**
+ * The tag → component map handed to `AIResponse`. A module constant, and it
+ * must stay one.
+ *
+ * react-markdown uses the mapped value as the React element *type*
+ * (`hast-util-to-jsx-runtime`), so handing it a fresh arrow function is not a
+ * re-render — React unmounts every rendered placeholder and mounts a new one,
+ * throwing away each `<video>` and the button under the user's cursor. Building
+ * this map inside a `useMemo` keyed on capture state did exactly that, twice
+ * per capture (once when the spinner went on, once when it came off).
+ *
+ * Everything that changes reaches the placeholder through
+ * {@link ChooseScreenshotProvider} instead. Context updates propagate through
+ * `AIResponse`'s `memo`, so the spinner still appears without the map moving.
+ */
+export const CHOOSE_SCREENSHOT_COMPONENTS = {
+  choosescreenshot: ChooseScreenshotSlot as unknown,
+} as Options["components"];

--- a/app/features/article-writer/write-chat.tsx
+++ b/app/features/article-writer/write-chat.tsx
@@ -13,15 +13,17 @@ import {
 } from "components/ui/kibo-ui/ai/input";
 import { AIMessage, AIMessageContent } from "components/ui/kibo-ui/ai/message";
 import { AIResponse } from "components/ui/kibo-ui/ai/response";
-import type { Options } from "react-markdown";
-import type { HTMLAttributes } from "react";
 import { Loader2Icon } from "lucide-react";
 import { memo, useCallback, useMemo, useState } from "react";
 import { partsToText, saveMessagesToStorage } from "./write-utils";
 import type { WriteToolbarProps } from "./write-toolbar";
 import { WriteToolbar } from "./write-toolbar";
 import type { IndexedClip, Mode } from "./types";
-import { ChooseScreenshot } from "./choose-screenshot";
+import {
+  CHOOSE_SCREENSHOT_COMPONENTS,
+  ChooseScreenshotProvider,
+  type ChooseScreenshotRuntime,
+} from "./choose-screenshot-components";
 import { preprocessChooseScreenshotMarkdown } from "./choose-screenshot-markdown";
 import {
   replaceChooseScreenshotWithImage,
@@ -134,43 +136,28 @@ export const WriteChat = memo(function WriteChat(props: WriteChatProps) {
     [videoId, mutateMessageText]
   );
 
-  const extraComponents = useMemo((): Options["components"] | undefined => {
-    if (indexedClips.length === 0) return undefined;
-    return {
-      choosescreenshot: ((
-        compProps: HTMLAttributes<HTMLElement> & Record<string, unknown>
-      ) => {
-        const clipIdx = parseInt(compProps.clipindex as string, 10);
-        const altText = (compProps.alt as string) ?? "";
-        const msgId = (compProps["data-message-id"] as string) ?? "";
-        const key = `${msgId}-${clipIdx}-${altText}`;
-        return (
-          <ChooseScreenshot
-            clipIndex={clipIdx}
-            alt={altText}
-            clips={indexedClips}
-            onClipIndexChange={(current, next) =>
-              handleClipIndexChange(msgId, current, next, altText)
-            }
-            onCapture={(ci, a, timestamp, videoFilename) =>
-              handleCapture(msgId, ci, a, timestamp, videoFilename)
-            }
-            onRemove={(ci, a) => handleRemove(msgId, ci, a)}
-            isCapturing={capturingKey === key}
-            isStreaming={status === "streaming" || status === "submitted"}
-          />
-        );
-      }) as unknown,
-    } as Options["components"];
-  }, [
-    indexedClips,
-    mode,
-    handleClipIndexChange,
-    handleCapture,
-    handleRemove,
-    capturingKey,
-    status,
-  ]);
+  const extraComponents =
+    indexedClips.length === 0 ? undefined : CHOOSE_SCREENSHOT_COMPONENTS;
+
+  const screenshotRuntime = useMemo(
+    (): ChooseScreenshotRuntime => ({
+      clips: indexedClips,
+      isStreaming: status === "streaming" || status === "submitted",
+      capturingKey,
+      keyFor: (clipIndex, alt, messageId) => `${messageId}-${clipIndex}-${alt}`,
+      onClipIndexChange: handleClipIndexChange,
+      onCapture: handleCapture,
+      onRemove: handleRemove,
+    }),
+    [
+      indexedClips,
+      status,
+      capturingKey,
+      handleClipIndexChange,
+      handleCapture,
+      handleRemove,
+    ]
+  );
 
   const preprocessMarkdown = useMemo(() => {
     if (!extraComponents) return undefined;
@@ -188,111 +175,115 @@ export const WriteChat = memo(function WriteChat(props: WriteChatProps) {
   }, [extraComponents]);
 
   return (
-    <div
-      className={
-        className ? `${className} flex flex-col` : "w-3/4 flex flex-col"
-      }
-    >
-      <AIConversation className="flex-1 overflow-y-auto scrollbar scrollbar-track-transparent scrollbar-thumb-muted hover:scrollbar-thumb-muted-foreground">
-        <AIConversationContent className="max-w-[75ch] mx-auto">
-          {error && (
-            <Card className="p-4 mb-4 border-red-500 bg-red-50 dark:bg-red-950">
-              <div className="flex items-start gap-2">
-                <div className="text-red-500 font-semibold">Error:</div>
-                <div className="text-red-700 dark:text-red-300 flex-1">
-                  {error.message}
+    <ChooseScreenshotProvider runtime={screenshotRuntime}>
+      <div
+        className={
+          className ? `${className} flex flex-col` : "w-3/4 flex flex-col"
+        }
+      >
+        <AIConversation className="flex-1 overflow-y-auto scrollbar scrollbar-track-transparent scrollbar-thumb-muted hover:scrollbar-thumb-muted-foreground">
+          <AIConversationContent className="max-w-[75ch] mx-auto">
+            {error && (
+              <Card className="p-4 mb-4 border-red-500 bg-red-50 dark:bg-red-950">
+                <div className="flex items-start gap-2">
+                  <div className="text-red-500 font-semibold">Error:</div>
+                  <div className="text-red-700 dark:text-red-300 flex-1">
+                    {error.message}
+                  </div>
                 </div>
-              </div>
-            </Card>
-          )}
-          {messages.map((message) => {
-            if (message.role === "system") {
-              return null;
-            }
+              </Card>
+            )}
+            {messages.map((message) => {
+              if (message.role === "system") {
+                return null;
+              }
 
-            if (message.role === "user") {
+              if (message.role === "user") {
+                return (
+                  <AIMessage from={message.role} key={message.id}>
+                    <AIMessageContent>
+                      {partsToText(message.parts)}
+                    </AIMessageContent>
+                  </AIMessage>
+                );
+              }
+
+              const textContent = partsToText(message.parts);
+
               return (
                 <AIMessage from={message.role} key={message.id}>
-                  <AIMessageContent>
-                    {partsToText(message.parts)}
-                  </AIMessageContent>
+                  {message.parts.map((part, partIndex) => {
+                    if (part.type === "tool-writeDocument") {
+                      return (
+                        <WriteDocumentDisplay key={partIndex} part={part} />
+                      );
+                    }
+                    if (part.type === "tool-editDocument") {
+                      return (
+                        <EditDocumentDisplay
+                          key={partIndex}
+                          part={part}
+                          documentRef={documentRef}
+                          updateDocument={updateDocument}
+                        />
+                      );
+                    }
+                    return null;
+                  })}
+                  {textContent && (
+                    <AIResponse
+                      imageBasePath={fullPath ?? ""}
+                      extraComponents={extraComponents}
+                      preprocessMarkdown={
+                        preprocessMarkdown
+                          ? (md: string) => preprocessMarkdown(md, message.id)
+                          : undefined
+                      }
+                    >
+                      {textContent}
+                    </AIResponse>
+                  )}
+                  {message.metadata && (
+                    <CacheStatsBadge stats={message.metadata} />
+                  )}
                 </AIMessage>
               );
-            }
-
-            const textContent = partsToText(message.parts);
-
-            return (
-              <AIMessage from={message.role} key={message.id}>
-                {message.parts.map((part, partIndex) => {
-                  if (part.type === "tool-writeDocument") {
-                    return <WriteDocumentDisplay key={partIndex} part={part} />;
-                  }
-                  if (part.type === "tool-editDocument") {
-                    return (
-                      <EditDocumentDisplay
-                        key={partIndex}
-                        part={part}
-                        documentRef={documentRef}
-                        updateDocument={updateDocument}
-                      />
-                    );
-                  }
-                  return null;
-                })}
-                {textContent && (
-                  <AIResponse
-                    imageBasePath={fullPath ?? ""}
-                    extraComponents={extraComponents}
-                    preprocessMarkdown={
-                      preprocessMarkdown
-                        ? (md: string) => preprocessMarkdown(md, message.id)
-                        : undefined
-                    }
-                  >
-                    {textContent}
-                  </AIResponse>
-                )}
-                {message.metadata && (
-                  <CacheStatsBadge stats={message.metadata} />
-                )}
+            })}
+            {queuedMessages?.map((text, i) => (
+              <AIMessage from="user" key={`queued-${i}`}>
+                <AIMessageContent>
+                  <span className="flex items-center gap-2 text-muted-foreground">
+                    <Loader2Icon className="h-3 w-3 animate-spin shrink-0" />
+                    {text}
+                  </span>
+                </AIMessageContent>
               </AIMessage>
-            );
-          })}
-          {queuedMessages?.map((text, i) => (
-            <AIMessage from="user" key={`queued-${i}`}>
-              <AIMessageContent>
-                <span className="flex items-center gap-2 text-muted-foreground">
-                  <Loader2Icon className="h-3 w-3 animate-spin shrink-0" />
-                  {text}
-                </span>
-              </AIMessageContent>
-            </AIMessage>
-          ))}
-        </AIConversationContent>
-        <AIConversationScrollButton />
-      </AIConversation>
-      <div className="border-t p-4 bg-background">
-        <div className="max-w-[75ch] mx-auto">
-          {toolbarProps && <WriteToolbar {...toolbarProps} />}
-          <AIInput
-            onSubmit={(e) => {
-              e.preventDefault();
-              onSubmit(text.trim() || "Go");
-              setText("");
-            }}
-          >
-            <AIInputTextarea
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              placeholder="What would you like to create?"
-            />
-            <AIInputToolbar>
-              <AIInputSubmit status={status} onStop={onStop} />
-            </AIInputToolbar>
-          </AIInput>
+            ))}
+          </AIConversationContent>
+          <AIConversationScrollButton />
+        </AIConversation>
+        <div className="border-t p-4 bg-background">
+          <div className="max-w-[75ch] mx-auto">
+            {toolbarProps && <WriteToolbar {...toolbarProps} />}
+            <AIInput
+              onSubmit={(e) => {
+                e.preventDefault();
+                onSubmit(text.trim() || "Go");
+                setText("");
+              }}
+            >
+              <AIInputTextarea
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                placeholder="What would you like to create?"
+              />
+              <AIInputToolbar>
+                <AIInputSubmit status={status} onStop={onStop} />
+              </AIInputToolbar>
+            </AIInput>
+          </div>
         </div>
       </div>
-    </div>
+    </ChooseScreenshotProvider>
   );
 });

--- a/app/features/article-writer/writer-engine.tsx
+++ b/app/features/article-writer/writer-engine.tsx
@@ -11,8 +11,6 @@ export type { WriterContext };
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { HTMLAttributes } from "react";
-import type { Options } from "react-markdown";
 import { useFetcher } from "react-router";
 import { WriteChat } from "./write-chat";
 import { DocumentPanel } from "./document-panel";
@@ -29,7 +27,11 @@ import {
   hasUnresolvedScreenshots,
 } from "./choose-screenshot-mutations";
 import { preprocessChooseScreenshotMarkdown } from "./choose-screenshot-markdown";
-import { ChooseScreenshot } from "./choose-screenshot";
+import {
+  CHOOSE_SCREENSHOT_COMPONENTS,
+  ChooseScreenshotProvider,
+  type ChooseScreenshotRuntime,
+} from "./choose-screenshot-components";
 import type { WriteToolbarProps } from "./write-toolbar";
 import type { WriterFieldId } from "./writer-engine-utils";
 import {
@@ -225,40 +227,33 @@ export function WriterEngine({
     [documentRef, updateDocument]
   );
 
-  const docExtraComponents = useMemo((): Options["components"] | undefined => {
-    if (indexedClips.length === 0 || !isDocumentMode) return undefined;
-    return {
-      choosescreenshot: ((
-        compProps: HTMLAttributes<HTMLElement> & Record<string, unknown>
-      ) => {
-        const clipIdx = parseInt(compProps.clipindex as string, 10);
-        const altText = (compProps.alt as string) ?? "";
-        const key = `doc-${clipIdx}-${altText}`;
-        return (
-          <ChooseScreenshot
-            clipIndex={clipIdx}
-            alt={altText}
-            clips={indexedClips}
-            onClipIndexChange={(current, next) =>
-              handleDocClipIndexChange(current, next, altText)
-            }
-            onCapture={handleDocCapture}
-            onRemove={handleDocRemove}
-            isCapturing={docCapturingKey === key}
-            isStreaming={isGenerating}
-          />
-        );
-      }) as unknown,
-    } as Options["components"];
-  }, [
-    indexedClips,
-    isDocumentMode,
-    handleDocClipIndexChange,
-    handleDocCapture,
-    handleDocRemove,
-    docCapturingKey,
-    isGenerating,
-  ]);
+  const docExtraComponents =
+    indexedClips.length === 0 || !isDocumentMode
+      ? undefined
+      : CHOOSE_SCREENSHOT_COMPONENTS;
+
+  // The document is a single scope, so the message id plays no part in its keys.
+  const docScreenshotRuntime = useMemo(
+    (): ChooseScreenshotRuntime => ({
+      clips: indexedClips,
+      isStreaming: isGenerating,
+      capturingKey: docCapturingKey,
+      keyFor: (clipIndex, alt) => `doc-${clipIndex}-${alt}`,
+      onClipIndexChange: (_messageId, current, next, alt) =>
+        handleDocClipIndexChange(current, next, alt),
+      onCapture: (_messageId, clipIndex, alt, timestamp, videoFilename) =>
+        handleDocCapture(clipIndex, alt, timestamp, videoFilename),
+      onRemove: (_messageId, clipIndex, alt) => handleDocRemove(clipIndex, alt),
+    }),
+    [
+      indexedClips,
+      isGenerating,
+      docCapturingKey,
+      handleDocClipIndexChange,
+      handleDocCapture,
+      handleDocRemove,
+    ]
+  );
 
   const docPreprocessMarkdown = useMemo(() => {
     if (!docExtraComponents) return undefined;
@@ -543,15 +538,17 @@ export function WriterEngine({
               onToggleItem={ctxModel.toggleItem}
               onOpenPanel={() => onViewChange?.("context")}
             />
-            <DocumentPanel
-              variant="modal"
-              document={document}
-              fullPath={fullPath}
-              extraComponents={docExtraComponents}
-              preprocessMarkdown={docPreprocessMarkdown}
-              onRemoveBlock={handleRemoveDocBlock}
-              onDocumentChange={updateDocument}
-            />
+            <ChooseScreenshotProvider runtime={docScreenshotRuntime}>
+              <DocumentPanel
+                variant="modal"
+                document={document}
+                fullPath={fullPath}
+                extraComponents={docExtraComponents}
+                preprocessMarkdown={docPreprocessMarkdown}
+                onRemoveBlock={handleRemoveDocBlock}
+                onDocumentChange={updateDocument}
+              />
+            </ChooseScreenshotProvider>
           </div>
         </div>
 
@@ -673,16 +670,18 @@ export function WriterEngine({
         <>
           <WriteChat {...chatProps} className="w-2/5" />
           <div className="w-3/5 flex flex-col border-l">
-            <DocumentPanel
-              document={document}
-              fullPath={fullPath}
-              extraComponents={docExtraComponents}
-              preprocessMarkdown={docPreprocessMarkdown}
-              onRemoveBlock={handleRemoveDocBlock}
-              onDocumentChange={updateDocument}
-              violations={violations}
-              onFixLintViolations={handleFixLintViolations}
-            />
+            <ChooseScreenshotProvider runtime={docScreenshotRuntime}>
+              <DocumentPanel
+                document={document}
+                fullPath={fullPath}
+                extraComponents={docExtraComponents}
+                preprocessMarkdown={docPreprocessMarkdown}
+                onRemoveBlock={handleRemoveDocBlock}
+                onDocumentChange={updateDocument}
+                violations={violations}
+                onFixLintViolations={handleFixLintViolations}
+              />
+            </ChooseScreenshotProvider>
           </div>
         </>
       ) : (


### PR DESCRIPTION
Refs #1485.

## The defect

`react-markdown` uses the value in its `components` map as the React element *type* (`hast-util-to-jsx-runtime/lib/index.js:711` — `state.components[name]`). Both writer surfaces built that map inside a `useMemo` keyed on capture state, so each rebuild produced a **fresh arrow function**:

- `writer-engine.tsx:228` — deps included `docCapturingKey`
- `write-chat.tsx:137` — deps included `capturingKey`, `status`, and `handleCapture` (which itself closes over `messages`)

A new function reference is a new element type. React therefore does not re-render the placeholder — it **unmounts the subtree and mounts a fresh one**. One Capture click does this twice (once when the spinner goes on, once when it comes off), destroying every `<video>` and the button under the user's cursor. In the chat pane it also fires on every streamed message.

## The fix

The map becomes a module constant in the new `choose-screenshot-components.tsx`. Everything that changes — the clips, the streaming flag, the in-flight capture key, the three handlers — now reaches the placeholder through `ChooseScreenshotProvider`. Context updates propagate through `AIResponse`'s `memo`, so the "Capturing…" spinner still appears while the mounted subtree stays put.

## What this does not prove

#1485 reports that capturing scrolls the page to the top. A harness (real `WriterEngine`, modal layout, one placeholder) did **not** reproduce that jump, so this remount is not confirmed as its cause — only as a real defect on exactly that path. A real article carries several placeholders, and remounting all of them at once is far more disruptive than the single one tested. Needs a check against real content before #1485 is closed.

Two other suspects were ruled out by reading: Radix's dialog focus scope refocuses with `preventScroll: true`, and nothing in the writer calls `scrollIntoView`/`scrollTo` or writes `scrollTop` outside the Edit/Preview toggle. The earlier attempt (#1486) only touched React Router navigations, and the document lives in component state — capture never navigates — so it could not have addressed this.

## Checks

`pnpm typecheck` clean · `vitest` 175 tests across 16 files pass · `pnpm run lint:boundaries` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)