### PR TITLE
Copy unchanged Videos inside Dropbox instead of re-uploading them

### DIFF
--- a/app/routes/api.courses.$courseId.publish-sse.ts
+++ b/app/routes/api.courses.$courseId.publish-sse.ts
@@ -22,6 +22,8 @@ const DETAIL_EVENT_WIRE_NAMES = {
   "upload-video-progress": "video-upload-progress",
   "upload-video-complete": "video-upload-complete",
   "upload-video-error": "video-upload-error",
+  "upload-videos-reused": "publish-videos-reused",
+  "upload-video-reused": "video-reused",
 } satisfies Record<PublishDetailEvent["event"], string>;
 
 const publishSchema = Schema.Struct({

--- a/app/services/course-publish-dropbox-upload.test.ts
+++ b/app/services/course-publish-dropbox-upload.test.ts
@@ -638,4 +638,30 @@ describe("Dropbox publish upload — reuse from the previous Bundle", () => {
     expect(videoUploadCount()).toBe(uploadsAfterFirstRelease + 2);
     expect(remoteBundleVideoPaths()).toHaveLength(2);
   }, 30_000);
+
+  it("adopts a landed Video whose export has since been collected", async () => {
+    const { videos, sync } = await setupUploads({ videoCount: 2 });
+
+    await sync();
+    const landed = remoteBundleVideoPaths();
+    expect(landed).toHaveLength(2);
+    const uploadsAfterFirstRelease = videoUploadCount();
+
+    // The export garbage collector has been through. Both Videos are still at
+    // their Bundle address; the local files they were made from are not.
+    for (const video of videos) {
+      fs.rmSync(video.exportPath, { force: true });
+      fs.rmSync(`${video.exportPath}.sha256`, { force: true });
+    }
+
+    // Re-syncing the same Version addresses the same Bundle, so nothing is
+    // owed but the manifest's numbers — and the previous manifest has them.
+    // Before the reuse plan could supply those, this read the local file to
+    // recover them and discarded the whole Publish when it had gone.
+    const outcome: any = await sync();
+
+    expect(outcome.missingVideos ?? []).toEqual([]);
+    expect(remoteBundleVideoPaths()).toEqual(landed);
+    expect(videoUploadCount()).toBe(uploadsAfterFirstRelease);
+  }, 30_000);
 });

--- a/app/services/course-publish-dropbox-upload.test.ts
+++ b/app/services/course-publish-dropbox-upload.test.ts
@@ -511,3 +511,131 @@ describe("Dropbox publish upload — transient failures", () => {
     expect(remoteBundleVideoPaths()).toHaveLength(2);
   }, 20_000);
 });
+
+// ── Reuse from the previously Published Bundle ──────────────────────────────
+// A new Course Version means a new Bundle address, so nothing of the previous
+// release is already at the new path. But the Videos themselves are unchanged:
+// same Clips, so the same Export Hash, so the same bytes. Those come from the
+// old Bundle by server-side copy rather than from this machine.
+
+/** Take the current Draft to a frozen Version, so it can be committed. */
+const freezeLatestVersion = (
+  course: { id: string },
+  run: <A, E>(effect: Effect.Effect<A, E, any>) => Promise<A>
+) =>
+  run(
+    Effect.gen(function* () {
+      const versionOps = yield* VersionOperationsService;
+      const latest = yield* versionOps.getLatestCourseVersion(course.id);
+      yield* versionOps.freezeAndCloneVersion({
+        sourceVersionId: latest!.id,
+        repoId: course.id,
+        newVersionName: "",
+        sourceName: "second release",
+        sourceDescription: "",
+      });
+      return latest!.id;
+    })
+  );
+
+const videoUploadCount = () =>
+  fakeDropbox.fetchCalls.filter((call) =>
+    isVideoUploadRequest(call.url, call.init)
+  ).length;
+
+const copyBatchCount = () =>
+  fakeDropbox.fetchCalls.filter((call) =>
+    call.url.includes("/2/files/copy_batch_v2")
+  ).length;
+
+describe("Dropbox publish upload — reuse from the previous Bundle", () => {
+  it("copies an unchanged Video inside Dropbox rather than sending its bytes again", async () => {
+    const { course, run, sync } = await setupUploads({ videoCount: 2 });
+
+    // First release. Every Video is uploaded, and the Commit receipt names
+    // the Bundle they landed in.
+    await sync();
+    const uploadsAfterFirstRelease = videoUploadCount();
+    expect(uploadsAfterFirstRelease).toBe(2);
+    expect(remoteBundleDirs()).toHaveLength(1);
+
+    const secondVersionId = await freezeLatestVersion(course, run);
+    await run(
+      Effect.gen(function* () {
+        const svc = yield* CoursePublishService;
+        return yield* svc.syncFrozenVersionToDropbox(
+          course.id,
+          secondVersionId,
+          true
+        );
+      })
+    );
+
+    // A second Bundle exists and holds both Videos — but not one further byte
+    // left this machine to put them there.
+    expect(remoteBundleDirs()).toHaveLength(2);
+    expect(remoteBundleVideoPaths()).toHaveLength(4);
+    expect(videoUploadCount()).toBe(uploadsAfterFirstRelease);
+    expect(copyBatchCount()).toBe(1);
+  }, 30_000);
+
+  it("takes the manifest's sha256 and bytes from the previous manifest, reading no file", async () => {
+    const { course, run, sync } = await setupUploads({ videoCount: 2 });
+
+    await sync();
+    const firstManifestVideos = manifestVideos(receiptManifest());
+
+    const secondVersionId = await freezeLatestVersion(course, run);
+    await run(
+      Effect.gen(function* () {
+        const svc = yield* CoursePublishService;
+        return yield* svc.syncFrozenVersionToDropbox(
+          course.id,
+          secondVersionId,
+          true
+        );
+      })
+    );
+
+    const secondManifestVideos = manifestVideos(receiptManifest());
+    const digestOf = (videos: any[]) =>
+      videos
+        .map((video) => `${video.hash}:${video.sha256}:${video.bytes}`)
+        .sort();
+
+    // Same recipe, same bytes, same numbers — carried across releases rather
+    // than re-derived from a local read.
+    expect(digestOf(secondManifestVideos)).toEqual(
+      digestOf(firstManifestVideos)
+    );
+  }, 30_000);
+
+  it("uploads after all when the previous Bundle's file has gone", async () => {
+    const { course, run, sync } = await setupUploads({ videoCount: 2 });
+
+    await sync();
+    const uploadsAfterFirstRelease = videoUploadCount();
+
+    // Course Builder has archived the Bundle past its 90-day TTL: the receipt
+    // still promises the files, and they are no longer there.
+    for (const key of Array.from(fakeDropbox.files.keys())) {
+      if (key.endsWith(".mp4")) fakeDropbox.files.delete(key);
+    }
+
+    const secondVersionId = await freezeLatestVersion(course, run);
+    await run(
+      Effect.gen(function* () {
+        const svc = yield* CoursePublishService;
+        return yield* svc.syncFrozenVersionToDropbox(
+          course.id,
+          secondVersionId,
+          true
+        );
+      })
+    );
+
+    // The Publish stands. It just paid for it.
+    expect(videoUploadCount()).toBe(uploadsAfterFirstRelease + 2);
+    expect(remoteBundleVideoPaths()).toHaveLength(2);
+  }, 30_000);
+});

--- a/app/services/course-publish-dropbox.ts
+++ b/app/services/course-publish-dropbox.ts
@@ -148,7 +148,6 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
   const finishedVideosDirectory = yield* Config.string(
     "FINISHED_VIDEOS_DIRECTORY"
   );
-  const dropboxRemotePath = yield* Config.string("DROPBOX_REMOTE_PATH");
   const accessToken = yield* getValidDropboxAccessToken;
 
   const targetVersion = yield* versionOps.getCourseVersionById(
@@ -173,7 +172,9 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
     input.includeTodoLessons
   );
 
-  const dropboxCourseDir = `${dropboxRemotePath}/${repoWithSections.name}`;
+  const dropboxCourseDir = yield* resolveDropboxCourseDir(
+    repoWithSections.name
+  );
 
   // The Export Hash is the recipe an Exported Video is addressed by — Clip
   // filenames, source timings, order, Video Format and the Export Version Key —

--- a/app/services/course-publish-dropbox.ts
+++ b/app/services/course-publish-dropbox.ts
@@ -117,15 +117,31 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
    */
   awaitVideoReady: (videoId: string) => Effect.Effect<void, ExportError>;
   /**
-   * Which Videos already exist in the previously Published Bundle, keyed by
-   * Export Hash. The caller computes this when it wants to act on it BEFORE
-   * the export pool starts — a reused Video needs no encoding, so a Publish
-   * that knows the plan up front can drop it from the export roster entirely.
+   * The encodes the caller has ALREADY cancelled on the strength of a reuse
+   * plan, and the means to take that back.
    *
-   * Omitted by the manual re-sync, which has no export phase to inform and so
-   * simply lets this function work the plan out for itself.
+   * A caller that knows the plan before the export pool starts can drop a
+   * reusable Video from the export roster entirely — no GPU time to produce
+   * bytes Dropbox already holds. That is the whole saving, and it is also a
+   * bet: it spends the local copy of a Video before this function has proved
+   * it can get the remote one. Every way the bet can lose — a source that
+   * vanished between the plan and the copy, a batch Dropbox would not run —
+   * ends at a Video with nothing on disk to fall back TO.
+   *
+   * So the plan is not accepted on its own. `restore` encodes one Video the
+   * plan cancelled, and is what makes "fall back to upload" true rather than
+   * merely intended. The pairing is the point: a caller cannot hand over the
+   * cancellation without also handing over the undo.
+   *
+   * Omitted by the manual re-sync, which cancels nothing — it has no export
+   * phase to inform, and simply lets this function draw the plan itself.
    */
-  reusePlan?: ReusePlan;
+  cancelledExports?: {
+    /** Reusable Videos of the previous Bundle, keyed by Export Hash. */
+    plan: ReusePlan;
+    /** Encode a Video this plan cancelled, after all. */
+    restore: (videoId: string) => Effect.Effect<void, ExportError>;
+  };
 }) {
   const effectFs = yield* FileSystem.FileSystem;
   const versionOps = yield* VersionOperationsService;
@@ -251,22 +267,27 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
   // What the previously Published Bundle can hand this one for free. Videos
   // matched here are copied inside Dropbox rather than sent from this machine.
   const reusePlan =
-    input.reusePlan ??
+    input.cancelledExports?.plan ??
     (yield* planBundleReuse({ accessToken, dropboxCourseDir }));
+
+  /** A Video's source in the previous Bundle, if the plan found one. */
+  const plannedSourceOf = (entry: VideoEntry): ReusableSource | undefined =>
+    // A Video with no Clips has no Export Hash and no file anywhere. Nothing
+    // identifies its bytes, so nothing can be reused for it.
+    entry.exportHash ? reusePlan.get(entry.exportHash) : undefined;
 
   const reusableByVideoId = new Map<
     string,
     { entry: VideoEntry; source: ReusableSource }
   >();
   for (const entry of videoEntries) {
-    // A Video with no Clips has no Export Hash and no file anywhere. Nothing
-    // identifies its bytes, so nothing can be reused for it.
-    if (!entry.exportHash) continue;
-    // Precedence: a file already at this Publish's own address needs nothing
-    // at all, so the resume listing wins over the plan.
-    if (remoteFilesByPath.has(remoteVideoPath(entry).toLowerCase())) continue;
-    const source = reusePlan.get(entry.exportHash);
+    const source = plannedSourceOf(entry);
     if (!source) continue;
+    // Precedence: a file already at this Publish's own address needs nothing
+    // at all, so the resume listing wins over the plan. It is adopted in
+    // `shipVideo` instead — from the plan's own numbers, which is what lets a
+    // resumed Publish adopt a Video whose export has since been collected.
+    if (remoteFilesByPath.has(remoteVideoPath(entry).toLowerCase())) continue;
     reusableByVideoId.set(entry.videoId, { entry, source });
   }
 
@@ -347,6 +368,48 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
       event: "upload-video-error",
       data: { videoId, message },
     });
+
+  /**
+   * Adopt a landed Video with NO local file to check it against.
+   *
+   * This is the case that used to have no answer: an earlier attempt put the
+   * Video at its address, and the export it was made from has since been
+   * collected — so the manifest's SHA256 could not be recovered and the whole
+   * Publish was discarded. Reuse makes that common rather than rare, because
+   * the plan that put the Video there is the same plan that cancelled its
+   * re-encode.
+   *
+   * The previous Bundle answers it. Its manifest owes the new one this Video's
+   * SHA256 and byte count; its listing gives the content hash the landed file
+   * must carry. One comparison, and not a byte read from disk or wire.
+   *
+   * Weaker than `adoptLandedVideo`, and deliberately second to it: where the
+   * source and destination are the same file — an unchanged re-Publish, which
+   * lands in the same Bundle — the comparison is of a file with itself and
+   * cannot detect tampering. Only local bytes can do that, so wherever they
+   * exist they are used instead.
+   */
+  const adoptFromPlan = Effect.fn("adoptVideoFromReusePlan")(function* (
+    entry: VideoEntry,
+    remoteFile: DropboxFileMetadata,
+    source: ReusableSource
+  ) {
+    // Same Export Hash means identical bytes by construction, so the two
+    // hashes must agree. Disagreement is an immutability violation, exactly
+    // as it is for a locally-checked adoption, and is never overwritten.
+    if (
+      remoteFile.content_hash !== source.contentHash ||
+      remoteFile.size !== source.bytes
+    ) {
+      return yield* new ExportError({
+        message: `Immutable asset bundle conflict for video ${entry.videoId}`,
+      });
+    }
+    videoByteSizes.set(entry.videoId, source.bytes);
+    uploadedByVideo.set(entry.videoId, source.bytes);
+    reportProgress();
+    return { sha256: source.sha256, bytes: source.bytes };
+  });
 
   /**
    * A Video already sitting at its address, put there by a previous attempt.
@@ -445,36 +508,60 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
       // The handoff: this Video's own export, and nothing else's.
       yield* input.awaitVideoReady(entry.videoId);
 
-      if (!(yield* effectFs.exists(entry.localPath))) {
-        missingVideos.push({
-          videoId: entry.videoId,
-          videoTitle: entry.videoTitle,
-          lessonPath: entry.lessonPath,
-        });
-        emitVideoError(entry.videoId, "No exported file to upload");
-        return null;
-      }
-
-      const fileSize = Number((yield* effectFs.stat(entry.localPath)).size);
-      videoByteSizes.set(entry.videoId, fileSize);
-      // This Video has a slot and a size: it is uploading, not queued. The
-      // size rides along from the very first event so a consumer can weight
-      // this Video against its siblings before a byte has moved.
-      input.onDetailEvent?.({
-        event: "upload-video-progress",
-        data: {
-          videoId: entry.videoId,
-          uploadedBytes: 0,
-          totalBytes: fileSize,
-        },
-      });
-
       const remoteFile = remoteFilesByPath.get(
         remoteVideoPath(entry).toLowerCase()
       );
-      const receipt = remoteFile
-        ? yield* adoptLandedVideo(entry, remoteFile, fileSize)
-        : yield* streamVideo(entry, fileSize);
+      const plannedSource = plannedSourceOf(entry);
+
+      let receipt: { sha256: string; bytes: number };
+      let onDisk = yield* effectFs.exists(entry.localPath);
+
+      // The local file is the STRONGER witness, so it is always preferred
+      // where it exists: it was produced from this Video's Clips, whereas the
+      // plan can only report what Dropbox already holds. Adopting from the
+      // plan is the fallback for the case that used to have no answer at all.
+      if (!onDisk && remoteFile && plannedSource) {
+        receipt = yield* adoptFromPlan(entry, remoteFile, plannedSource);
+      } else {
+        // A Video the plan cancelled the encode for has arrived here with no
+        // file and nothing at its address, which means its copy did not
+        // happen — the source vanished, or the batch would not run. Nothing
+        // else will ever produce these bytes, so "fall back to upload" has to
+        // mean encoding it now. Without this the saving would turn a slow
+        // Publish into a failed one.
+        if (!onDisk && plannedSource && input.cancelledExports) {
+          yield* input.cancelledExports.restore(entry.videoId);
+          onDisk = yield* effectFs.exists(entry.localPath);
+        }
+
+        if (!onDisk) {
+          missingVideos.push({
+            videoId: entry.videoId,
+            videoTitle: entry.videoTitle,
+            lessonPath: entry.lessonPath,
+          });
+          emitVideoError(entry.videoId, "No exported file to upload");
+          return null;
+        }
+
+        const fileSize = Number((yield* effectFs.stat(entry.localPath)).size);
+        videoByteSizes.set(entry.videoId, fileSize);
+        // This Video has a slot and a size: it is uploading, not queued. The
+        // size rides along from the very first event so a consumer can weight
+        // this Video against its siblings before a byte has moved.
+        input.onDetailEvent?.({
+          event: "upload-video-progress",
+          data: {
+            videoId: entry.videoId,
+            uploadedBytes: 0,
+            totalBytes: fileSize,
+          },
+        });
+
+        receipt = remoteFile
+          ? yield* adoptLandedVideo(entry, remoteFile, fileSize)
+          : yield* streamVideo(entry, fileSize);
+      }
 
       input.onDetailEvent?.({
         event: "upload-video-complete",

--- a/app/services/course-publish-dropbox.ts
+++ b/app/services/course-publish-dropbox.ts
@@ -23,8 +23,14 @@ import {
   uploadFileFromDisk,
   getMetadata,
   listFolder,
+  copyBatch,
   type DropboxFileMetadata,
 } from "./dropbox-http-client";
+import {
+  planBundleReuse,
+  type ReusePlan,
+  type ReusableSource,
+} from "./course-publish-reuse-plan";
 import { DropboxContentHasher } from "./dropbox-content-hash";
 import { getValidDropboxAccessToken } from "./dropbox-auth-service";
 import { uploadConcurrency } from "./dropbox-upload-config";
@@ -78,6 +84,15 @@ const hashFileLocally = Effect.fn("hashFileLocally")(function* (
 export const noExportPhase = (): Effect.Effect<void, ExportError> =>
   Effect.void;
 
+/**
+ * Where a Course's Bundles live. Exported because the reuse plan has to be
+ * drawn BEFORE the export pool starts, which is upstream of this module.
+ */
+export const resolveDropboxCourseDir = (courseName: string) =>
+  Config.string("DROPBOX_REMOTE_PATH").pipe(
+    Effect.map((remotePath) => `${remotePath}/${courseName}`)
+  );
+
 export const syncFrozenCourseVersionToDropbox = Effect.fn(
   "syncFrozenCourseVersionToDropbox"
 )(function* (input: {
@@ -101,6 +116,16 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
    * `noExportPhase`.
    */
   awaitVideoReady: (videoId: string) => Effect.Effect<void, ExportError>;
+  /**
+   * Which Videos already exist in the previously Published Bundle, keyed by
+   * Export Hash. The caller computes this when it wants to act on it BEFORE
+   * the export pool starts — a reused Video needs no encoding, so a Publish
+   * that knows the plan up front can drop it from the export roster entirely.
+   *
+   * Omitted by the manual re-sync, which has no export phase to inform and so
+   * simply lets this function work the plan out for itself.
+   */
+  reusePlan?: ReusePlan;
 }) {
   const effectFs = yield* FileSystem.FileSystem;
   const versionOps = yield* VersionOperationsService;
@@ -222,6 +247,49 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
   const remoteVideoPath = (entry: VideoEntry) =>
     `${remoteBundleDir}/${entry.relativeAssetPath}`;
 
+  // ── The reuse plan ────────────────────────────────────────────────────────
+  // What the previously Published Bundle can hand this one for free. Videos
+  // matched here are copied inside Dropbox rather than sent from this machine.
+  const reusePlan =
+    input.reusePlan ??
+    (yield* planBundleReuse({ accessToken, dropboxCourseDir }));
+
+  const reusableByVideoId = new Map<
+    string,
+    { entry: VideoEntry; source: ReusableSource }
+  >();
+  for (const entry of videoEntries) {
+    // A Video with no Clips has no Export Hash and no file anywhere. Nothing
+    // identifies its bytes, so nothing can be reused for it.
+    if (!entry.exportHash) continue;
+    // Precedence: a file already at this Publish's own address needs nothing
+    // at all, so the resume listing wins over the plan.
+    if (remoteFilesByPath.has(remoteVideoPath(entry).toLowerCase())) continue;
+    const source = reusePlan.get(entry.exportHash);
+    if (!source) continue;
+    reusableByVideoId.set(entry.videoId, { entry, source });
+  }
+
+  // Everything the upload pool is still responsible for. A reused Video is not
+  // in here, so it neither waits for an export nor occupies an upload slot.
+  const uploadingEntries = videoEntries.filter(
+    (entry) => !reusableByVideoId.has(entry.videoId)
+  );
+
+  // Announced before a frame is encoded or a byte moves, so the size of the
+  // saving is visible in the first second of the Publish rather than at the
+  // end of it.
+  if (reusableByVideoId.size > 0) {
+    input.onDetailEvent?.({
+      event: "upload-videos-reused",
+      data: {
+        videos: Array.from(reusableByVideoId.values()).map(
+          ({ entry, source }) => ({ id: entry.videoId, bytes: source.bytes })
+        ),
+      },
+    });
+  }
+
   // Sizes come from stat, not from a read, and only once a Video's export has
   // landed — so under pipelining they arrive one at a time rather than upfront.
   const videoByteSizes = new Map<string, number>();
@@ -229,8 +297,11 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
   // Byte-weighted progress across every Video in the bundle. Uploads report
   // interleaved once several are in flight, so the aggregate is recomputed
   // from the per-Video counters rather than accumulated as they complete.
+  // Reused Videos are deliberately absent: their bytes never cross the wire,
+  // so counting them would make the percentage describe work nobody is doing.
+  // A Video whose copy fails is added back here when it rejoins the queue.
   const uploadedByVideo = new Map<string, number>(
-    videoEntries.map((entry) => [entry.videoId, 0])
+    uploadingEntries.map((entry) => [entry.videoId, 0])
   );
   let lastReportedPercentage = 0;
   const reportProgress = () => {
@@ -244,7 +315,7 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
     // exactly the byte-weighted total.
     const meanKnown = knownTotal / knownSizes.length;
     const denominator =
-      knownTotal + (videoEntries.length - knownSizes.length) * meanKnown;
+      knownTotal + (uploadedByVideo.size - knownSizes.length) * meanKnown;
     if (denominator <= 0) return;
     let uploaded = 0;
     for (const bytes of uploadedByVideo.values()) uploaded += bytes;
@@ -424,20 +495,98 @@ export const syncFrozenCourseVersionToDropbox = Effect.fn(
       })
   );
 
-  const receipts = yield* Effect.forEach(videoEntries, shipVideo, {
-    concurrency: uploadConcurrencyLimit,
+  /** Receipts owed to the manifest by Videos that were copied, not sent. */
+  const copyReceipts = new Map<string, { sha256: string; bytes: number }>();
+
+  /**
+   * Ask Dropbox to duplicate every reusable Video inside its own storage.
+   *
+   * One batch call for the whole bundle. The route is asynchronous even for a
+   * single entry, so the wait is unconditional — but it is a wait on Dropbox's
+   * own block copy, not on 25 GB leaving this machine.
+   *
+   * Returns the Videos that must be uploaded after all. A source that vanished
+   * between the plan and the copy is ordinary and falls back quietly; a copy
+   * whose content hash does not match its source is an identity failure and
+   * fails the Publish, exactly as a mismatched adoption does.
+   */
+  const copyPhase = Effect.fn("copyReusedVideos")(function* () {
+    const shipments = Array.from(reusableByVideoId.values());
+    if (shipments.length === 0) return [] as VideoEntry[];
+
+    const results = yield* copyBatch({
+      accessToken,
+      entries: shipments.map((shipment) => ({
+        fromPath: shipment.source.fromPath,
+        toPath: remoteVideoPath(shipment.entry),
+      })),
+    }).pipe(
+      // A batch that could not be launched or polled at all leaves every Video
+      // in it to the upload pool. Nothing is lost but the saving.
+      Effect.catchTag("DropboxApiError", () => Effect.succeed(null))
+    );
+    if (results === null) return shipments.map((shipment) => shipment.entry);
+
+    const fallbacks: VideoEntry[] = [];
+    for (const [index, shipment] of shipments.entries()) {
+      const result = results[index];
+      if (!result?.ok) {
+        fallbacks.push(shipment.entry);
+        continue;
+      }
+      if (result.metadata.content_hash !== shipment.source.contentHash) {
+        return yield* new ExportError({
+          message: `Copy verification failed for video ${shipment.entry.videoId}: content_hash mismatch`,
+        });
+      }
+      copyReceipts.set(shipment.entry.videoId, {
+        sha256: shipment.source.sha256,
+        bytes: shipment.source.bytes,
+      });
+      input.onDetailEvent?.({
+        event: "upload-video-reused",
+        data: {
+          videoId: shipment.entry.videoId,
+          bytes: shipment.source.bytes,
+        },
+      });
+    }
+    return fallbacks;
   });
+
+  // The copy runs FIRST, and on its own. It is a wait on Dropbox duplicating
+  // its own blocks — seconds — where the upload pool is a wait on tens of
+  // gigabytes, so there is nothing to gain by overlapping them and one real
+  // thing to lose: a Video whose copy fails has to reach the upload pool, and
+  // that pool must not already have finished. Running them in order also
+  // leaves every copied file in place before the first upload starts, so an
+  // interrupted Publish resumes against a bundle that is further along.
+  const fallbackEntries = yield* copyPhase();
+
+  // A Video whose copy failed now joins the byte-weighted denominator it was
+  // excluded from, because it is about to move real bytes after all.
+  for (const entry of fallbackEntries) uploadedByVideo.set(entry.videoId, 0);
+
+  const receipts = yield* Effect.forEach(
+    [...uploadingEntries, ...fallbackEntries],
+    shipVideo,
+    { concurrency: uploadConcurrencyLimit }
+  );
 
   if (missingVideos.length > 0) return { missingVideos };
 
-  const videoAssets = new Map(
-    receipts
+  const videoAssets = new Map([
+    ...copyReceipts,
+    ...receipts
       .filter((receipt) => receipt !== null)
-      .map((receipt) => [
-        receipt.videoId,
-        { sha256: receipt.sha256, bytes: receipt.bytes },
-      ])
-  );
+      .map(
+        (receipt) =>
+          [
+            receipt.videoId,
+            { sha256: receipt.sha256, bytes: receipt.bytes },
+          ] as const
+      ),
+  ]);
 
   // The manifest is built last because it carries every Video's SHA256 and
   // byte count, and those are only known once the bytes have gone past.

--- a/app/services/course-publish-export-events.ts
+++ b/app/services/course-publish-export-events.ts
@@ -47,7 +47,21 @@ export type PublishDetailEvent =
       data: { videoId: string; uploadedBytes: number; totalBytes: number };
     }
   | { event: "upload-video-complete"; data: { videoId: string; bytes: number } }
-  | { event: "upload-video-error"; data: { videoId: string; message: string } };
+  | { event: "upload-video-error"; data: { videoId: string; message: string } }
+  // ── Reuse from the previously Published Bundle ───────────────────────────
+  // The reuse plan, announced the moment it is known — before a frame is
+  // encoded or a byte moves. These Videos already exist on Dropbox and will be
+  // copied there server-side, so they never enter the byte-weighted
+  // denominator: counting bytes that never cross the wire would make the
+  // upload percentage meaningless.
+  | {
+      event: "upload-videos-reused";
+      data: { videos: Array<{ id: string; bytes: number }> };
+    }
+  // One Video's copy has landed and its content hash matched its source. A
+  // Video that fails to copy never reaches here — it emits an ordinary upload
+  // task instead, because it has rejoined the upload queue.
+  | { event: "upload-video-reused"; data: { videoId: string; bytes: number } };
 
 export type EmitPublishDetailEvent = (e: PublishDetailEvent) => void;
 

--- a/app/services/course-publish-reuse-plan.ts
+++ b/app/services/course-publish-reuse-plan.ts
@@ -1,0 +1,167 @@
+import { Effect } from "effect";
+import { download, listFolder } from "./dropbox-http-client";
+
+/**
+ * A file in the previously Published Bundle that a Video of THIS Publish can
+ * take verbatim, because both were produced from the same Export Hash.
+ *
+ * `sha256` and `bytes` are owed to the new manifest and come straight out of
+ * the old one, so a reused Video costs no local read at all. `contentHash` is
+ * what the copy is checked against once Dropbox reports it back.
+ */
+export type ReusableSource = {
+  /** Full Dropbox path of the file inside the previous Bundle. */
+  fromPath: string;
+  /** Dropbox's block hash for that file, read from the Bundle listing. */
+  contentHash: string;
+  /** SHA256 of the bytes, read from the previous manifest. */
+  sha256: string;
+  bytes: number;
+};
+
+/** Keyed by Export Hash — the only key that identifies a Video's bytes. */
+export type ReusePlan = ReadonlyMap<string, ReusableSource>;
+
+export const EMPTY_REUSE_PLAN: ReusePlan = new Map();
+
+/**
+ * The manifest is walked structurally rather than decoded against the Schema.
+ * A previous Bundle was written by whatever code shipped at the time, and a
+ * manifest this Publish cannot fully understand is a reason to reuse LESS, not
+ * a reason to fail. Anything unrecognised simply contributes no entry.
+ */
+type ManifestVideo = {
+  hash: string;
+  relativePath: string;
+  sha256: string;
+  bytes: number;
+};
+
+const isManifestVideo = (value: unknown): value is ManifestVideo => {
+  if (typeof value !== "object" || value === null) return false;
+  const { hash, relativePath, sha256, bytes } = value as Record<
+    string,
+    unknown
+  >;
+  return (
+    typeof hash === "string" &&
+    hash.length > 0 &&
+    typeof relativePath === "string" &&
+    relativePath.length > 0 &&
+    typeof sha256 === "string" &&
+    /^[a-f0-9]{64}$/.test(sha256) &&
+    typeof bytes === "number" &&
+    Number.isInteger(bytes) &&
+    bytes >= 0
+  );
+};
+
+/** Every Video in a manifest, whatever Lesson shape it arrived in. */
+const collectManifestVideos = (manifest: unknown): ManifestVideo[] => {
+  const videos: ManifestVideo[] = [];
+  if (typeof manifest !== "object" || manifest === null) return videos;
+  const sections = (manifest as Record<string, unknown>).sections;
+  if (!Array.isArray(sections)) return videos;
+
+  for (const section of sections) {
+    const lessons = (section as Record<string, unknown> | null)?.lessons;
+    if (!Array.isArray(lessons)) continue;
+    for (const lesson of lessons) {
+      if (typeof lesson !== "object" || lesson === null) continue;
+      // explainer | problem | solution — the roles a Lesson can carry.
+      for (const role of ["explainer", "problem", "solution"] as const) {
+        const candidate = (lesson as Record<string, unknown>)[role];
+        if (isManifestVideo(candidate)) videos.push(candidate);
+      }
+    }
+  }
+  return videos;
+};
+
+/**
+ * `versions/{versionFingerprint}-{assetFingerprint}` — the first two segments
+ * of a manifest `relativePath`, which is written relative to the course
+ * directory that holds the Commit receipt.
+ */
+const bundleDirOf = (relativePath: string): string | null => {
+  const segments = relativePath.split("/");
+  return segments.length >= 3 ? segments.slice(0, 2).join("/") : null;
+};
+
+/**
+ * Work out which Videos of this Publish already exist on Dropbox, and where.
+ *
+ * The plan is drawn from the Commit receipt — the previously Published Bundle
+ * — and nothing older. Reaching further back would make a Publish cost more
+ * with every release ever made, for a hit rate that barely moves.
+ *
+ * TWO reads, because they carry different halves of the answer. The manifest
+ * knows each file's Export Hash and SHA256; only a listing knows its Dropbox
+ * content hash, which is what the copy is later verified against.
+ *
+ * This NEVER fails. An absent receipt, an unparseable manifest, a Bundle that
+ * Course Builder has already archived past its 90-day TTL — each simply yields
+ * a smaller plan, and every Video without an entry uploads exactly as it does
+ * today.
+ */
+export const planBundleReuse = Effect.fn("planBundleReuse")(function* (input: {
+  accessToken: string;
+  dropboxCourseDir: string;
+}) {
+  const receipt = yield* download({
+    accessToken: input.accessToken,
+    path: `${input.dropboxCourseDir}/course.json`,
+  }).pipe(Effect.catchTag("DropboxApiError", () => Effect.succeed(null)));
+  if (receipt === null) return EMPTY_REUSE_PLAN;
+
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(receipt.toString("utf-8"));
+  } catch {
+    return EMPTY_REUSE_PLAN;
+  }
+
+  const manifestVideos = collectManifestVideos(manifest);
+  if (manifestVideos.length === 0) return EMPTY_REUSE_PLAN;
+
+  const bundleDir = bundleDirOf(manifestVideos[0]!.relativePath);
+  if (bundleDir === null) return EMPTY_REUSE_PLAN;
+
+  const remoteEntries = yield* listFolder({
+    accessToken: input.accessToken,
+    path: `${input.dropboxCourseDir}/${bundleDir}`,
+    recursive: true,
+  }).pipe(Effect.catchTag("DropboxApiError", () => Effect.succeed([])));
+
+  const contentHashByPath = new Map<string, { hash: string; size: number }>();
+  for (const entry of remoteEntries) {
+    if (entry[".tag"] !== "file") continue;
+    contentHashByPath.set(entry.path_display.toLowerCase(), {
+      hash: entry.content_hash,
+      size: entry.size,
+    });
+  }
+
+  const plan = new Map<string, ReusableSource>();
+  for (const video of manifestVideos) {
+    // Two Videos can share an Export Hash — same Clips, same Video Format.
+    // Either copy serves, because the bytes are identical by construction.
+    if (plan.has(video.hash)) continue;
+    const fromPath = `${input.dropboxCourseDir}/${video.relativePath}`;
+    const remote = contentHashByPath.get(fromPath.toLowerCase());
+    // Listed but gone, or never listed: the manifest promised a file that is
+    // no longer there. Upload it instead.
+    if (!remote) continue;
+    // The manifest and the listing must agree about the file before it is
+    // worth copying. Disagreement means the Bundle was tampered with.
+    if (remote.size !== video.bytes) continue;
+    plan.set(video.hash, {
+      fromPath,
+      contentHash: remote.hash,
+      sha256: video.sha256,
+      bytes: video.bytes,
+    });
+  }
+
+  return plan as ReusePlan;
+});

--- a/app/services/course-publish-service-reuse-fallback.test.ts
+++ b/app/services/course-publish-service-reuse-fallback.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { Effect } from "effect";
+import fs from "node:fs";
+import path from "node:path";
+import { CoursePublishService } from "@/services/course-publish-service";
+import {
+  fakeDropbox,
+  finishedVideosDir,
+  setupPublishServiceTests,
+  setupPublishableCourse as setup,
+} from "./course-publish-service-test-setup";
+
+setupPublishServiceTests();
+
+/**
+ * The reuse plan cancels an encode on the strength of a copy that has not
+ * happened yet. These tests are about the bet losing.
+ *
+ * They have to go through `publish` rather than the manual re-sync, because
+ * only `publish` has an export roster to cancel — which is exactly why the
+ * hazard is invisible from the re-sync tests.
+ */
+
+/** Only the `.mp4` uploads inside a bundle. */
+const isVideoUploadRequest = (url: string, init: RequestInit) => {
+  if (!url.includes("/2/files/upload") || url.includes("session")) return false;
+  const arg = (init.headers as Record<string, string> | undefined)?.[
+    "Dropbox-API-Arg"
+  ];
+  return Boolean(arg && JSON.parse(arg).path.endsWith(".mp4"));
+};
+
+const videoUploadCount = () =>
+  fakeDropbox.fetchCalls.filter((call) =>
+    isVideoUploadRequest(call.url, call.init)
+  ).length;
+
+const remoteBundleVideoPaths = () =>
+  Array.from(fakeDropbox.files.values())
+    .map((stored) => stored.pathDisplay)
+    .filter((remotePath) => remotePath.endsWith(".mp4"))
+    .sort();
+
+/** The `{versionFingerprint}-{assetFingerprint}` directories in Dropbox. */
+const remoteBundleDirs = () =>
+  Array.from(
+    new Set(
+      remoteBundleVideoPaths().map(
+        (remotePath) => remotePath.split("/versions/")[1]!.split("/")[0]!
+      )
+    )
+  );
+
+/** The export garbage collector, run to completion. */
+const collectAllExports = () => {
+  const walk = (dir: string) => {
+    for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, item.name);
+      if (item.isDirectory()) walk(full);
+      else fs.rmSync(full, { force: true });
+    }
+  };
+  walk(finishedVideosDir);
+};
+
+const publish = (courseId: string, versionName: string) =>
+  Effect.gen(function* () {
+    const svc = yield* CoursePublishService;
+    return yield* svc.publish({
+      courseId,
+      versionName,
+      versionDescription: `${versionName} release`,
+      includeTodoLessons: true,
+    });
+  });
+
+describe("CoursePublishService — when a cancelled encode is needed after all", () => {
+  it("re-encodes a Video whose copy Dropbox would not make", async () => {
+    const { course, run } = await setup({ videoCount: 2 });
+
+    await run(publish(course.id, "v1.0"));
+    const uploadsAfterFirstRelease = videoUploadCount();
+    expect(uploadsAfterFirstRelease).toBe(2);
+    expect(remoteBundleDirs()).toHaveLength(1);
+
+    // The export garbage collector has been through: nothing of these Videos
+    // is left on this machine. The reuse plan will therefore cancel BOTH
+    // encodes, which is precisely the case this optimisation exists for.
+    collectAllExports();
+
+    // ...and then Dropbox refuses the batch. Both Videos fall back to the
+    // upload pool, which has nothing to send. Without a way to take the
+    // cancellation back, the saving turns a slow Publish into a failed one.
+    // 400 rather than 500: a rejection Dropbox will not reconsider, so the
+    // client gives up at once instead of backing off through its retries.
+    fakeDropbox.failNextRequests({
+      match: (url: string) => url.includes("/2/files/copy_batch_v2"),
+      times: 1,
+      status: 400,
+    });
+
+    await run(publish(course.id, "v2.0"));
+
+    // The Publish stands, and it stands because the encodes came back.
+    expect(remoteBundleDirs()).toHaveLength(2);
+    expect(remoteBundleVideoPaths()).toHaveLength(4);
+    expect(videoUploadCount()).toBe(uploadsAfterFirstRelease + 2);
+  }, 60_000);
+
+  it("still copies, and encodes nothing, when the batch succeeds", async () => {
+    const { course, run } = await setup({ videoCount: 2 });
+
+    await run(publish(course.id, "v1.0"));
+    const uploadsAfterFirstRelease = videoUploadCount();
+
+    collectAllExports();
+
+    await run(publish(course.id, "v2.0"));
+
+    // The point of the whole change: a second Bundle, no encode, no upload.
+    expect(remoteBundleDirs()).toHaveLength(2);
+    expect(remoteBundleVideoPaths()).toHaveLength(4);
+    expect(videoUploadCount()).toBe(uploadsAfterFirstRelease);
+  }, 60_000);
+});

--- a/app/services/course-publish-service.ts
+++ b/app/services/course-publish-service.ts
@@ -13,6 +13,7 @@ import {
   toExportClips,
 } from "./export-hash";
 import { garbageCollect } from "./export-hash.server";
+import { digestNewExport } from "./export-sha256-sidecar";
 import { FINAL_VIDEO_PADDING } from "@/features/video-editor/constants";
 import { resolveVideoFormat } from "@/features/videos/video-format";
 import { DoesNotExistOnDbError } from "./publish-to-dropbox";
@@ -25,8 +26,11 @@ import {
 } from "./course-publish-errors";
 import {
   noExportPhase,
+  resolveDropboxCourseDir,
   syncFrozenCourseVersionToDropbox,
 } from "./course-publish-dropbox";
+import { EMPTY_REUSE_PLAN, planBundleReuse } from "./course-publish-reuse-plan";
+import { getValidDropboxAccessToken } from "./dropbox-auth-service";
 import {
   runObservedExportLoop,
   type EmitPublishDetailEvent,
@@ -186,6 +190,12 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
           `${videoId}.mp4`
         );
         yield* effectFs.rename(videoIdPath, targetPath);
+
+        // Digest it now, while it is the newest thing on the disk. A later
+        // Publish that copies this Video inside Dropbox rather than uploading
+        // it never streams the bytes, so this is the only moment they are
+        // guaranteed to pass through our hands.
+        yield* digestNewExport(effectFs, targetPath);
 
         return { targetPath, owner };
       });
@@ -348,9 +358,34 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
         // Export Hash is untouched by Submit: the clone copies Clip
         // filenames, source timings and order verbatim and never mutates the
         // source rows, so this walk sees exactly what validation saw.
-        const { unexportedVideos, shippingVideos } = yield* findShippingVideos(
-          latestVersion.id,
-          includeTodoLessons
+        const {
+          unexportedVideos: rosterUnexportedVideos,
+          shippingVideos,
+          courseName: dropboxCourseName,
+        } = yield* findShippingVideos(latestVersion.id, includeTodoLessons);
+
+        // ── The reuse plan, drawn before the GPU is touched ─────────────────
+        // A Video the previously Published Bundle already holds is copied
+        // inside Dropbox, so it needs neither an upload nor an ENCODE. Drawing
+        // the plan here — rather than inside the commit, where the copying
+        // happens — is what lets it cancel work in the export pool.
+        //
+        // Any failure at all yields an empty plan. Reuse is an optimisation,
+        // and a Publish must never fail because the optimisation could not be
+        // worked out.
+        const reusePlan = yield* Effect.gen(function* () {
+          const accessToken = yield* getValidDropboxAccessToken;
+          const dropboxCourseDir =
+            yield* resolveDropboxCourseDir(dropboxCourseName);
+          return yield* planBundleReuse({ accessToken, dropboxCourseDir });
+        }).pipe(Effect.catchAll(() => Effect.succeed(EMPTY_REUSE_PLAN)));
+
+        // Videos whose bytes Dropbox can produce on its own never enter the
+        // export queue. This is the case that hurts most today: a re-Publish
+        // after the garbage collector has reclaimed an export currently
+        // re-encodes the whole Video only to upload bytes Dropbox already had.
+        const unexportedVideos = rosterUnexportedVideos.filter(
+          (video) => !reusePlan.has(video.exportHash)
         );
 
         // Announce the whole roster before either pool starts, so every Video
@@ -454,6 +489,11 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
             includeTodoLessons,
             onDetailEvent,
             awaitVideoReady,
+            // The same plan the export roster was filtered against. Handing it
+            // over rather than letting the commit redraw it keeps the two
+            // decisions identical — a Video dropped from the export queue is
+            // exactly a Video the commit will copy.
+            reusePlan,
           }).pipe(Effect.retry(Schedule.recurs(1)))
         );
 

--- a/app/services/course-publish-service.ts
+++ b/app/services/course-publish-service.ts
@@ -1,5 +1,5 @@
 import { Config, Deferred, Effect, Exit, Schedule } from "effect";
-import { FileSystem } from "@effect/platform";
+import { CommandExecutor, FileSystem } from "@effect/platform";
 import path from "node:path";
 import { VideoOperationsService } from "./db-video-operations.server";
 import { VersionOperationsService } from "./db-version-operations.server";
@@ -13,7 +13,7 @@ import {
   toExportClips,
 } from "./export-hash";
 import { garbageCollect } from "./export-hash.server";
-import { digestNewExport } from "./export-sha256-sidecar";
+import { ensureExportDigest } from "./export-sha256-sidecar";
 import { FINAL_VIDEO_PADDING } from "@/features/video-editor/constants";
 import { resolveVideoFormat } from "@/features/videos/video-format";
 import { DoesNotExistOnDbError } from "./publish-to-dropbox";
@@ -32,6 +32,7 @@ import {
 import { EMPTY_REUSE_PLAN, planBundleReuse } from "./course-publish-reuse-plan";
 import { getValidDropboxAccessToken } from "./dropbox-auth-service";
 import {
+  extractErrorMessage,
   runObservedExportLoop,
   type EmitPublishDetailEvent,
   type PublishStage,
@@ -158,8 +159,12 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
           hash
         );
 
-        // Skip if already exported
+        // Skip if already exported — but not before making sure it carries a
+        // digest. An export that predates sidecars is exactly the one that
+        // never gets encoded again, so this path is the only one that can
+        // ever close the gap.
         if (yield* effectFs.exists(targetPath)) {
+          yield* ensureExportDigest(effectFs, targetPath);
           return { targetPath, owner };
         }
 
@@ -195,7 +200,7 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
         // Publish that copies this Video inside Dropbox rather than uploading
         // it never streams the bytes, so this is the only moment they are
         // guaranteed to pass through our hands.
-        yield* digestNewExport(effectFs, targetPath);
+        yield* ensureExportDigest(effectFs, targetPath);
 
         return { targetPath, owner };
       });
@@ -373,6 +378,10 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
         // Any failure at all yields an empty plan. Reuse is an optimisation,
         // and a Publish must never fail because the optimisation could not be
         // worked out.
+        // Captured here, where the export pool's context is still in scope, so
+        // the commit can re-run a cancelled encode from inside its own.
+        const commandExecutor = yield* CommandExecutor.CommandExecutor;
+
         const reusePlan = yield* Effect.gen(function* () {
           const accessToken = yield* getValidDropboxAccessToken;
           const dropboxCourseDir =
@@ -493,7 +502,41 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
             // over rather than letting the commit redraw it keeps the two
             // decisions identical — a Video dropped from the export queue is
             // exactly a Video the commit will copy.
-            reusePlan,
+            //
+            // `restore` is the other half of that: the roster filter spent
+            // this Video's local copy before the commit had proved it could
+            // get the remote one, so the commit must be able to encode it
+            // after all. It runs outside the export pool because the pool may
+            // already have finished; fallbacks are rare enough that the GPU
+            // contention costs less than the Publish it saves.
+            cancelledExports: {
+              plan: reusePlan,
+              restore: (videoId: string): Effect.Effect<void, ExportError> =>
+                exportVideoCore(videoId).pipe(
+                  Effect.asVoid,
+                  // Whatever an encode can go wrong with — a Video that has
+                  // gone from the database, an ffmpeg that would not run —
+                  // reaches the commit as the one failure it can attribute to
+                  // a Video: this Video did not export.
+                  Effect.catchAll((error) =>
+                    Effect.fail(
+                      new ExportError({
+                        message: `Export failed for video ${videoId}: ${extractErrorMessage(
+                          error,
+                          "unknown error"
+                        )}`,
+                      })
+                    )
+                  ),
+                  // The commit's context is fixed by the time it calls this,
+                  // so ffmpeg's executor rides along from here rather than
+                  // being demanded of the caller.
+                  Effect.provideService(
+                    CommandExecutor.CommandExecutor,
+                    commandExecutor
+                  )
+                ),
+            },
           }).pipe(Effect.retry(Schedule.recurs(1)))
         );
 

--- a/app/services/course-publish-video-roster.ts
+++ b/app/services/course-publish-video-roster.ts
@@ -59,6 +59,10 @@ export const findShippingVideos = Effect.fn("findShippingVideos")(function* (
     id: string;
     title: string;
     durationSeconds: number;
+    // Carried out of the walk so a caller can ask the previously Published
+    // Bundle whether this Video is already there. One that can be copied
+    // inside Dropbox needs no encoding, so it needs no place in this queue.
+    exportHash: string;
   }> = [];
 
   for (const section of effectiveSections) {
@@ -85,6 +89,7 @@ export const findShippingVideos = Effect.fn("findShippingVideos")(function* (
           unexportedVideos.push({
             ...entry,
             durationSeconds: clipsDurationSeconds(video.clips),
+            exportHash: hash,
           });
       }
     }
@@ -100,5 +105,10 @@ export const findShippingVideos = Effect.fn("findShippingVideos")(function* (
   // (section → lesson → title), as sort is stable.
   unexportedVideos.sort((a, b) => b.durationSeconds - a.durationSeconds);
 
-  return { courseId, shippingVideos, unexportedVideos };
+  return {
+    courseId,
+    courseName: version.repo.name,
+    shippingVideos,
+    unexportedVideos,
+  };
 });

--- a/app/services/dropbox-http-client.ts
+++ b/app/services/dropbox-http-client.ts
@@ -434,6 +434,161 @@ export const uploadFileFromDisk = Effect.fn("dropboxUploadFileFromDisk")(
 );
 
 /**
+ * One file's server-side move within Dropbox. No bytes cross the wire: the
+ * source and destination both live in Dropbox, so the transfer is theirs.
+ */
+export type DropboxCopyEntry = { fromPath: string; toPath: string };
+
+/**
+ * Per-entry, because `copy_batch_v2` reports per entry rather than failing
+ * wholesale. One unreachable source must not send its 89 siblings over the
+ * wire.
+ */
+export type DropboxCopyResult =
+  | { ok: true; toPath: string; metadata: DropboxFileMetadata }
+  | { ok: false; toPath: string; message: string };
+
+/** Dropbox's documented ceiling for a batch route. */
+const COPY_BATCH_MAX_ENTRIES = 1000;
+
+const POLL_INITIAL_MS = 1_000;
+const POLL_CEILING_MS = 10_000;
+/** How often a still-running job says so, so a long copy is never silent. */
+const POLL_REPORT_INTERVAL_MS = 30_000;
+
+type RawCopyEntry =
+  | { ".tag": "success"; success: DropboxFileMetadata }
+  | { ".tag": "failure"; failure: unknown };
+
+type RawBatchResponse =
+  | { ".tag": "complete"; entries: RawCopyEntry[] }
+  | { ".tag": "async_job_id"; async_job_id: string }
+  | { ".tag": "in_progress" }
+  | { ".tag": "other" };
+
+const postJson = Effect.fn("dropboxPostJson")(function* (opts: {
+  accessToken: string;
+  endpoint: string;
+  body: unknown;
+}) {
+  const response = yield* fetchWithRetry(
+    `https://api.dropboxapi.com/2/${opts.endpoint}`,
+    {
+      method: "POST",
+      headers: {
+        ...authHeaders(opts.accessToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(opts.body),
+    },
+    opts.endpoint
+  );
+  return yield* Effect.tryPromise({
+    try: () => response.json() as Promise<RawBatchResponse>,
+    catch: (e) =>
+      new DropboxApiError({
+        message: `Failed to parse ${opts.endpoint} response: ${e}`,
+        endpoint: opts.endpoint,
+      }),
+  });
+});
+
+const readBatchEntries = (
+  entries: RawCopyEntry[],
+  chunk: DropboxCopyEntry[]
+): DropboxCopyResult[] =>
+  chunk.map((entry, index) => {
+    const result = entries[index];
+    if (result?.[".tag"] === "success") {
+      return { ok: true, toPath: entry.toPath, metadata: result.success };
+    }
+    return {
+      ok: false,
+      toPath: entry.toPath,
+      message:
+        result === undefined
+          ? "Dropbox returned no result for this entry"
+          : `Copy failed: ${JSON.stringify(result.failure)}`,
+    };
+  });
+
+/**
+ * Copy files inside Dropbox, in as few calls as the entry ceiling allows.
+ *
+ * The route is asynchronous even for a single entry — verified against the
+ * live API — so polling is unconditional rather than a fallback. Waits grow
+ * from one second to a ten-second ceiling, which keeps a short job responsive
+ * without hammering a long one.
+ *
+ * Missing destination folders are NOT this caller's problem: Dropbox creates
+ * the intermediate parents itself, also verified live, so a bundle's whole
+ * section/lesson tree materialises from the copy alone.
+ */
+export const copyBatch = Effect.fn("dropboxCopyBatch")(function* (opts: {
+  accessToken: string;
+  entries: DropboxCopyEntry[];
+  /** Fires while a job is still running, so a slow copy stays observable. */
+  onStillRunning?: (elapsedMs: number) => void;
+}) {
+  const results: DropboxCopyResult[] = [];
+
+  for (
+    let start = 0;
+    start < opts.entries.length;
+    start += COPY_BATCH_MAX_ENTRIES
+  ) {
+    const chunk = opts.entries.slice(start, start + COPY_BATCH_MAX_ENTRIES);
+
+    let response = yield* postJson({
+      accessToken: opts.accessToken,
+      endpoint: "files/copy_batch_v2",
+      body: {
+        entries: chunk.map((entry) => ({
+          from_path: entry.fromPath,
+          to_path: entry.toPath,
+        })),
+        autorename: false,
+      },
+    });
+
+    if (response[".tag"] === "async_job_id") {
+      const jobId = response.async_job_id;
+      let waitMs = POLL_INITIAL_MS;
+      let elapsedMs = 0;
+      let nextReportMs = POLL_REPORT_INTERVAL_MS;
+
+      while (true) {
+        yield* Effect.sleep(Duration.millis(waitMs));
+        elapsedMs += waitMs;
+        waitMs = Math.min(waitMs * 2, POLL_CEILING_MS);
+
+        response = yield* postJson({
+          accessToken: opts.accessToken,
+          endpoint: "files/copy_batch/check_v2",
+          body: { async_job_id: jobId },
+        });
+        if (response[".tag"] !== "in_progress") break;
+
+        if (elapsedMs >= nextReportMs) {
+          opts.onStillRunning?.(elapsedMs);
+          nextReportMs += POLL_REPORT_INTERVAL_MS;
+        }
+      }
+    }
+
+    if (response[".tag"] !== "complete") {
+      return yield* new DropboxApiError({
+        message: `copy_batch_v2 ended as "${response[".tag"]}"`,
+        endpoint: "files/copy_batch_v2",
+      });
+    }
+    results.push(...readBatchEntries(response.entries, chunk));
+  }
+
+  return results;
+});
+
+/**
  * Download a file's content.
  */
 export const download = Effect.fn("dropboxDownload")(function* (opts: {

--- a/app/services/dropbox-http-client.ts
+++ b/app/services/dropbox-http-client.ts
@@ -455,6 +455,16 @@ const POLL_INITIAL_MS = 1_000;
 const POLL_CEILING_MS = 10_000;
 /** How often a still-running job says so, so a long copy is never silent. */
 const POLL_REPORT_INTERVAL_MS = 30_000;
+/**
+ * How long a batch may stay `in_progress` before we stop believing in it.
+ *
+ * A server-side copy of a whole course is seconds of Dropbox's work, so this
+ * is not a deadline the route should ever approach — it is there because a job
+ * that never settles would otherwise hold the Publish open for ever. Giving up
+ * is safe: the caller treats an unfinished batch as one that must be uploaded
+ * instead, which costs the saving and nothing else.
+ */
+const POLL_DEADLINE_MS = 30 * 60_000;
 
 type RawCopyEntry =
   | { ".tag": "success"; success: DropboxFileMetadata }
@@ -527,8 +537,6 @@ const readBatchEntries = (
 export const copyBatch = Effect.fn("dropboxCopyBatch")(function* (opts: {
   accessToken: string;
   entries: DropboxCopyEntry[];
-  /** Fires while a job is still running, so a slow copy stays observable. */
-  onStillRunning?: (elapsedMs: number) => void;
 }) {
   const results: DropboxCopyResult[] = [];
 
@@ -557,7 +565,7 @@ export const copyBatch = Effect.fn("dropboxCopyBatch")(function* (opts: {
       let elapsedMs = 0;
       let nextReportMs = POLL_REPORT_INTERVAL_MS;
 
-      while (true) {
+      while (elapsedMs < POLL_DEADLINE_MS) {
         yield* Effect.sleep(Duration.millis(waitMs));
         elapsedMs += waitMs;
         waitMs = Math.min(waitMs * 2, POLL_CEILING_MS);
@@ -570,7 +578,11 @@ export const copyBatch = Effect.fn("dropboxCopyBatch")(function* (opts: {
         if (response[".tag"] !== "in_progress") break;
 
         if (elapsedMs >= nextReportMs) {
-          opts.onStillRunning?.(elapsedMs);
+          yield* Effect.logInfo(
+            `copy_batch_v2 still running after ${Math.round(
+              elapsedMs / 1_000
+            )}s (${chunk.length} entries)`
+          );
           nextReportMs += POLL_REPORT_INTERVAL_MS;
         }
       }
@@ -578,7 +590,12 @@ export const copyBatch = Effect.fn("dropboxCopyBatch")(function* (opts: {
 
     if (response[".tag"] !== "complete") {
       return yield* new DropboxApiError({
-        message: `copy_batch_v2 ended as "${response[".tag"]}"`,
+        message:
+          response[".tag"] === "in_progress"
+            ? `copy_batch_v2 was still running after ${
+                POLL_DEADLINE_MS / 60_000
+              } minutes`
+            : `copy_batch_v2 ended as "${response[".tag"]}"`,
         endpoint: "files/copy_batch_v2",
       });
     }

--- a/app/services/export-sha256-sidecar.test.ts
+++ b/app/services/export-sha256-sidecar.test.ts
@@ -3,9 +3,11 @@ import { Effect } from "effect";
 import { FileSystem } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
 import { mkdtempSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  ensureExportDigest,
   readExportDigest,
   sidecarPath,
   writeExportDigest,
@@ -114,6 +116,56 @@ describe("export sha256 sidecar", () => {
     );
 
     expect(read).toBeNull();
+  });
+
+  it("gives an export that has no sidecar a true one", async () => {
+    const { exportPath, bytes } = makeExport("video-bytes");
+
+    const read = await run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* ensureExportDigest(fs, exportPath);
+        return yield* readExportDigest(fs, exportPath, bytes);
+      })
+    );
+
+    expect(read).toMatchObject({
+      sha256: createHash("sha256").update("video-bytes").digest("hex"),
+      bytes,
+    });
+  });
+
+  it("leaves an export that already has a sound sidecar alone", async () => {
+    const { exportPath, bytes } = makeExport();
+
+    // A digest that could not have come from these bytes, so an unconditional
+    // re-digest would overwrite it and this assertion would notice.
+    const read = await run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* writeExportDigest(fs, exportPath, {
+          sha256: SHA,
+          contentHash: CONTENT_HASH,
+          bytes,
+        });
+        yield* ensureExportDigest(fs, exportPath);
+        return yield* readExportDigest(fs, exportPath, bytes);
+      })
+    );
+
+    expect(read).toEqual({ sha256: SHA, contentHash: CONTENT_HASH, bytes });
+  });
+
+  it("never fails the caller when the export is not there to digest", async () => {
+    const result = await run(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* ensureExportDigest(fs, "/nonexistent-directory-for-test/a.mp4");
+        return "did not throw";
+      })
+    );
+
+    expect(result).toBe("did not throw");
   });
 
   it("never fails the caller when the sidecar cannot be written", async () => {

--- a/app/services/export-sha256-sidecar.ts
+++ b/app/services/export-sha256-sidecar.ts
@@ -1,5 +1,7 @@
-import { Effect } from "effect";
+import { Effect, Stream } from "effect";
 import { FileSystem } from "@effect/platform";
+import { createHash } from "node:crypto";
+import { DropboxContentHasher } from "./dropbox-content-hash";
 
 /**
  * The digest of an Exported Video, cached on disk beside the export itself.
@@ -73,6 +75,50 @@ export const readExportDigest = (
   fs.readFileString(sidecarPath(exportPath)).pipe(
     Effect.map((raw) => parseDigest(raw, expectedBytes)),
     Effect.catchAll(() => Effect.succeed(null))
+  );
+
+/** Read an Exported Video once and derive both digests from the one pass. */
+export const computeExportDigest = (
+  fs: FileSystem.FileSystem,
+  exportPath: string
+): Effect.Effect<ExportDigest, never, never> =>
+  Effect.gen(function* () {
+    const sha256Hash = createHash("sha256");
+    const contentHasher = new DropboxContentHasher();
+    const bytes = yield* fs.stream(exportPath).pipe(
+      Stream.runFold(0, (total, chunk) => {
+        sha256Hash.update(chunk);
+        contentHasher.update(chunk);
+        return total + chunk.byteLength;
+      })
+    );
+    return {
+      sha256: sha256Hash.digest("hex"),
+      bytes,
+      contentHash: contentHasher.digest(),
+    };
+  }).pipe(Effect.orDie);
+
+/**
+ * Digest an export the moment it is produced, and bank it beside the file.
+ *
+ * Sidecars used to be written only by an upload, which was sound while every
+ * Publish uploaded everything. Once a Publish can COPY an unchanged Video
+ * inside Dropbox instead, no upload happens — so a sidecar written at upload
+ * time would never be written again, and the coverage that verification
+ * depends on would freeze wherever it stood.
+ *
+ * Writing at export time inverts that: every Exported Video carries its digest
+ * from birth, so the immutability check is free and grows to cover everything.
+ * Best-effort, exactly like the write it replaces.
+ */
+export const digestNewExport = (
+  fs: FileSystem.FileSystem,
+  exportPath: string
+): Effect.Effect<void> =>
+  computeExportDigest(fs, exportPath).pipe(
+    Effect.flatMap((digest) => writeExportDigest(fs, exportPath, digest)),
+    Effect.ignore
   );
 
 /**

--- a/app/services/export-sha256-sidecar.ts
+++ b/app/services/export-sha256-sidecar.ts
@@ -100,7 +100,7 @@ export const computeExportDigest = (
   }).pipe(Effect.orDie);
 
 /**
- * Digest an export the moment it is produced, and bank it beside the file.
+ * Give an export a sidecar if it does not already have a usable one.
  *
  * Sidecars used to be written only by an upload, which was sound while every
  * Publish uploaded everything. Once a Publish can COPY an unchanged Video
@@ -110,16 +110,26 @@ export const computeExportDigest = (
  *
  * Writing at export time inverts that: every Exported Video carries its digest
  * from birth, so the immutability check is free and grows to cover everything.
- * Best-effort, exactly like the write it replaces.
+ * "Every" includes the export the pool finds already on disk and skips — that
+ * is precisely the old export whose sidecar is still missing, so digesting
+ * only the freshly encoded ones would leave the backlog uncovered for ever.
+ *
+ * The read is therefore conditional, not the write: a file that already has a
+ * sound sidecar costs one stat. Best-effort throughout — a digest that cannot
+ * be taken or written costs the next Publish a re-read and is never a reason
+ * to fail this one.
  */
-export const digestNewExport = (
+export const ensureExportDigest = (
   fs: FileSystem.FileSystem,
   exportPath: string
 ): Effect.Effect<void> =>
-  computeExportDigest(fs, exportPath).pipe(
-    Effect.flatMap((digest) => writeExportDigest(fs, exportPath, digest)),
-    Effect.ignore
-  );
+  Effect.gen(function* () {
+    const size = Number((yield* fs.stat(exportPath)).size);
+    const cached = yield* readExportDigest(fs, exportPath, size);
+    if (cached) return;
+    const digest = yield* computeExportDigest(fs, exportPath);
+    yield* writeExportDigest(fs, exportPath, digest);
+  }).pipe(Effect.ignore);
 
 /**
  * Best-effort: a sidecar that cannot be written costs the next Publish a

--- a/app/test-utils/fake-dropbox.ts
+++ b/app/test-utils/fake-dropbox.ts
@@ -29,6 +29,7 @@ type InjectedFailure = {
 export const createFakeDropbox = () => {
   const files = new Map<string, StoredFile>();
   const sessions = new Map<string, { chunks: Buffer[] }>();
+  const copyJobs = new Map<string, unknown[]>();
   const fetchCalls: Array<{ url: string; init: RequestInit }> = [];
   let sessionCounter = 0;
 
@@ -224,6 +225,42 @@ export const createFakeDropbox = () => {
       store(apiArg.commit.path, fullContent);
       return new Response(
         JSON.stringify(fileMetadata(get(apiArg.commit.path)!))
+      );
+    }
+
+    // Copy batch — always answered asynchronously, exactly as the real route
+    // behaves even for a single entry. The copy itself happens server-side
+    // here too: no request body ever carries the bytes.
+    if (urlStr.includes("/2/files/copy_batch_v2")) {
+      const body = JSON.parse(reqInit.body as string);
+      const entries = (body.entries as Array<any>).map((entry) => {
+        const source = get(entry.from_path);
+        if (!source) {
+          return {
+            ".tag": "failure",
+            failure: { ".tag": "relocation_error", reason: "not_found" },
+          };
+        }
+        store(entry.to_path, source.content);
+        return {
+          ".tag": "success",
+          success: fileMetadata(get(entry.to_path)!),
+        };
+      });
+      const jobId = `copy-job-${++sessionCounter}`;
+      copyJobs.set(jobId, entries);
+      return new Response(
+        JSON.stringify({ ".tag": "async_job_id", async_job_id: jobId })
+      );
+    }
+
+    if (urlStr.includes("/2/files/copy_batch/check_v2")) {
+      const body = JSON.parse(reqInit.body as string);
+      return new Response(
+        JSON.stringify({
+          ".tag": "complete",
+          entries: copyJobs.get(body.async_job_id) ?? [],
+        })
       );
     }
 


### PR DESCRIPTION
## The problem

Every Publish addresses its Bundle by a fresh `versionFingerprint`, so it always lands in an empty directory. The only skip check asks "is a file already at *this* address?" — which, for a new release, is never true. Nothing has ever looked at the **previous** Bundle.

So a re-Publish of a finished course uploads all of it again. Measured: a typical course is **80-100 Videos, 25-30 GB**. Change one Video and all of it goes over the wire.

## The fix

Dropbox can duplicate its own blocks server-side. The bytes need never leave the machine.

- **Plan.** Read the Commit receipt. The previous manifest already carries each Video's Export Hash (`hash`), `sha256` and `bytes` — no schema change needed. One recursive listing of that Bundle supplies each file's `content_hash`. Match by Export Hash.
- **Transport.** One `files/copy_batch_v2` call, polled with backoff from 1 s to a 10 s ceiling.
- **Verify.** Every copy's returned `content_hash` is compared with its source's.
- **Cancel the encode too.** The plan is drawn *before* the export pool starts, so a reused Video leaves the export roster as well. Today a re-Publish after export GC re-encodes a Video on the GPU purely to upload bytes Dropbox already had. That was the worst case; it is now the best one.
- **Sidecars move to export time.** They used to be written by an upload. Once a Publish can copy instead, no upload happens — coverage would have frozen at today's 67-of-222. Writing at export time makes the immutability check free and total.

## Rules

| Situation | Behaviour |
|---|---|
| File already at this Bundle's address | Adopt (unchanged) |
| Export Hash found in the previous Bundle | Copy server-side |
| Source vanished, or batch failed | Fall back to upload |
| Copy's content hash ≠ source's | **Fail the Publish** |
| Video with no Clips | Never reused — no Export Hash, no file |
| Manual re-sync (`noExportPhase`) | Reuse applies; highest hit rate |

Reuse never fails a Publish. An absent receipt, an unparseable manifest, or a Bundle archived past its 90-day `archiveTTL` all just yield a smaller plan.

## Verified live before building

A spike against the real API settled three things the docs do not state:

1. `copy_v2` **does** create missing intermediate parent folders (three levels deep, HTTP 200).
2. The response **does** carry `content_hash`, and it matched the source.
3. `copy_batch_v2` is **asynchronous even for one entry**, so polling is unconditional. Check route is `files/copy_batch/check_v2`.

Storage is unchanged: a server-side copy is still billed as a full second file, exactly as the upload was.

## Tests

Three new tests in `course-publish-dropbox-upload.test.ts`, plus copy support in the fake Dropbox:

- an unchanged Video is copied, not uploaded — asserts zero new `.mp4` uploads and one `copy_batch_v2`
- the new manifest's `sha256`/`bytes` come from the old manifest, with no local read
- a vanished source falls back to upload and the Publish still stands

`pnpm typecheck` clean. `pnpm vitest run app/services`: **877 passed, 1 failed** — `course-publish-service-video-tasks.test.ts > "attributes an upload failure…"`, which **fails 8/8 on the base commit too**. Pre-existing, not from this branch.

## Two bugs found on the way — NOT fixed here

1. **Readiness and Publish disagree about zero-Clip Videos.** `course-publish-readiness.ts:97` skips them and reports no blocker; Publish then finds no file and discards the whole Bundle. 624 of 3480 Videos have no Clips (51 of 90 in AI SDK Crash Course v1.0). Probably masked by `includeTodoLessons: false` — unconfirmed.
2. **The shorts renderer and the zero-Clip branch share a namespace.** `render-vertical-video-service.ts:129` writes `{videoId}.mp4` and leaves it (19 files, 1.25 GiB on disk now). That is the exact path the zero-Clip branch reads. An id collision would upload a vertical short as a course asset. The export GC cannot see those files either.

## Left behind

Scratch files from the spike sit at `/AI Hero/Courses/_copy-spike` in Dropbox. This repo has no delete client, so I did not remove them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)