### PR TITLE
fix(publish): stop a successful Publish throwing on its last stage

### DIFF
--- a/app/features/upload-manager/upload-progress.ts
+++ b/app/features/upload-manager/upload-progress.ts
@@ -49,6 +49,9 @@ export const PUBLISH_STAGE_BANDS: Record<
   cloning: { start: 6, width: 0 },
   exporting: { start: 10, width: 0 },
   uploading: { start: 10, width: 0 },
+  // The Promote has landed and the `complete` event is one step behind this
+  // one. 100 stays reserved for that event's UPLOAD_SUCCESS.
+  complete: { start: 99, width: 0 },
 };
 
 // The span of a Publish's bar owned by its per-Video tasks. 100 is reserved

--- a/app/features/upload-manager/upload-reducer-stages.test.ts
+++ b/app/features/upload-manager/upload-reducer-stages.test.ts
@@ -424,6 +424,29 @@ describe("UPDATE_PUBLISH_STAGE", () => {
     expect(state.uploads["upload-1"]!.progress).toBe(10);
   });
 
+  // The Publish service emits `complete` as its last stage, one step before
+  // the `complete` event settles the job. The client union used to omit it, so
+  // the band lookup gave undefined and every successful Publish ended in
+  // "Cannot read properties of undefined (reading 'start')".
+  it("should accept the terminal complete stage", () => {
+    const state = reduce(
+      createState({
+        uploads: { "upload-1": createPublishEntry() },
+      }),
+      {
+        type: "UPDATE_PUBLISH_STAGE",
+        uploadId: "upload-1",
+        stage: "complete",
+      }
+    );
+
+    const upload = state.uploads["upload-1"]!;
+    expect(upload.uploadType === "publish" && upload.publishStage).toBe(
+      "complete"
+    );
+    expect(upload.progress).toBe(99);
+  });
+
   it("should not modify state for non-existent upload", () => {
     const initial = createState();
     const state = reduce(initial, {

--- a/app/features/upload-manager/upload-reducer.ts
+++ b/app/features/upload-manager/upload-reducer.ts
@@ -1,3 +1,8 @@
+import type {
+  ExportStage as ExportServiceStage,
+  PublishStage as PublishServiceStage,
+} from "@/services/course-publish-export-events";
+import type { RenderVerticalStage as RenderVerticalServiceStage } from "@/services/render-vertical-video-service";
 import { uploadTypeRegistry } from "./upload-type-registry";
 import {
   BUFFER_STAGE_BANDS,
@@ -25,15 +30,16 @@ export namespace uploadReducer {
     | "render-vertical";
   export type BufferStage =
     "uploading-blob" | "creating-post" | "polling" | "cleaning-up";
-  export type ExportStage =
-    "queued" | "concatenating-clips" | "normalizing-audio";
-  export type RenderVerticalStage =
-    | "concatenating-clips"
-    | "transcribing"
-    | "rendering-overlay"
-    | "compositing";
-  export type PublishStage =
-    "validating" | "exporting" | "uploading" | "freezing" | "cloning";
+  // Every stage union below is the SERVICE's own union, never a restatement of
+  // it. The bands and the labels are total `Record`s over these types, so a
+  // stage the server emits and the client has no band for is a compile error
+  // here rather than an undefined lookup at run time. `PublishStage` was
+  // restated, drifted, and lost `complete` — which the Publish emits after the
+  // Promote, so every successful Publish ended in "Cannot read properties of
+  // undefined (reading 'start')".
+  export type ExportStage = ExportServiceStage;
+  export type RenderVerticalStage = RenderVerticalServiceStage;
+  export type PublishStage = PublishServiceStage;
   // The upload half of a per-Video task under a Publish. It follows the
   // export stages above: encode, then wait for a slot in the upload pool,
   // then move bytes.

--- a/app/features/upload-manager/upload-stage-labels.ts
+++ b/app/features/upload-manager/upload-stage-labels.ts
@@ -27,6 +27,7 @@ const PUBLISH_STAGE_LABELS: Record<uploadReducer.PublishStage, string> = {
   uploading: "Uploading to Dropbox",
   freezing: "Freezing version",
   cloning: "Creating new draft",
+  complete: "Finishing up",
 };
 
 const RENDER_VERTICAL_STAGE_LABELS: Record<

--- a/app/services/course-publish-export-events.ts
+++ b/app/services/course-publish-export-events.ts
@@ -1,5 +1,11 @@
 import { Effect, Schedule } from "effect";
 
+// One Video's encode, stage by stage. `queued` is a position in the pool
+// rather than work, so only the two working stages carry a percentage.
+export type ExportStage =
+  "queued" | "concatenating-clips" | "normalizing-audio";
+export type ExportWorkingStage = Exclude<ExportStage, "queued">;
+
 // The observable surface of a publish/batch-export run. Every emission is a
 // member of this union, so a typo'd event name or a malformed payload fails
 // typecheck instead of silently dropping on the SSE floor.
@@ -10,7 +16,7 @@ export type PublishDetailEvent =
       event: "stage";
       data: {
         videoId: string;
-        stage: "queued" | "concatenating-clips" | "normalizing-audio";
+        stage: ExportStage;
       };
     }
   | { event: "complete"; data: { videoId: string } }
@@ -21,7 +27,7 @@ export type PublishDetailEvent =
       event: "video-progress";
       data: {
         videoId: string;
-        stage: "concatenating-clips" | "normalizing-audio";
+        stage: ExportWorkingStage;
         percent: number;
       };
     }
@@ -102,11 +108,8 @@ export const runObservedExportLoop = <A, E, R>(input: {
   unexportedVideos: Array<{ id: string; title: string }>;
   exportVideo: (
     videoId: string,
-    onStage: (stage: "concatenating-clips" | "normalizing-audio") => void,
-    onProgress: (info: {
-      stage: "concatenating-clips" | "normalizing-audio";
-      percent: number;
-    }) => void
+    onStage: (stage: ExportWorkingStage) => void,
+    onProgress: (info: { stage: ExportWorkingStage; percent: number }) => void
   ) => Effect.Effect<A, E, R>;
   onDetailEvent?: EmitPublishDetailEvent;
   onVideoSettled?: (result: {


### PR DESCRIPTION
## The bug

Every Publish that succeeded ended with a toast:

> Cannot read properties of undefined (reading 'start')

The Publish service emits `onStageChange("complete")` after the Promote (`course-publish-service.ts:594`), one step before the `complete` event settles the job. The upload manager kept its **own** copy of the `PublishStage` union, and that copy never gained `complete`. So `PUBLISH_STAGE_BANDS["complete"]` was `undefined`, and `UPDATE_PUBLISH_STAGE` read `.start` off it.

Two unions with one name, on either side of an SSE boundary that casts rather than checks.

## The fix

Not "add the missing member" — delete the restatements. The upload manager's `PublishStage`, `ExportStage` and `RenderVerticalStage` are now the services' own unions, imported type-only (the same thing `sse-render-vertical-client.ts` already did).

The bands and the labels are total `Record`s over those types, so a stage the server adds is now a **compile error here**, not a run-time throw in the browser. Verified by adding a bogus stage to the service union:

```
app/features/upload-manager/upload-progress.ts:43 - error TS2741: Property 'gloating' is missing ... but required in type 'Record<PublishStage, StageBand>'.
app/features/upload-manager/upload-stage-labels.ts:24 - error TS2741: ...
```

`complete` parks the bar at 99; 100 stays reserved for `UPLOAD_SUCCESS`.

The export stages are named on the service side too — `ExportStage`, and `ExportWorkingStage` for the two that carry a percentage — so the client has one union to point at instead of repeated inline literals.

## Testing

- New regression test in `upload-reducer-stages.test.ts`. Without the band it fails with the exact reported message.
- `pnpm typecheck` clean.
- All 184 upload-manager tests pass.
- Full suite: 2995 pass. 21 failures in `app/cli/cli-segment-writes.test.ts`, `app/cli/cli-backup-coordination.test.ts` and `app/services/course-publish-service-video-tasks.test.ts` — identical on unmodified `main`, so pre-existing and untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)