### PR TITLE
quiz: render Quiz blocks in the document preview

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -263,6 +263,12 @@ _Avoid_: Glyph, Symbol, Image (icons are deliberately not assets — ADR 0003)
 Pointing an **Icon** already on the canvas at a different glyph, from the **Command Palette** with exactly one Icon selected. Rewrites the shape's `name` and nothing else, so the size it was resized to, its position, rotation, colour, dash, parent frame and bound arrows all survive — the difference from inserting a second Icon and deleting the first. Absent from the palette for any other selection, since two Icons or a mixed selection has no unambiguous target.
 _Avoid_: Swap icon, Change icon, Edit icon (an Icon has no edit mode — `canEdit` is false)
 
+### Lesson body
+
+**Quiz**:
+A block of questions embedded in a **Video**'s `body`, answered by the reader on aihero.dev. Stored verbatim in the AI Hero authoring contract — `<Quiz>` wrapping one or more `<QuizQuestion data={{ … }} />` tags, each a static object literal — and shipped unparsed by **Publish**, which treats the body as opaque text. The CVM reads it for three jobs only: drawing a static preview card, cutting one question at its exact source range, and linting it. Every question carries an `id` unique across the **Course**, because reader responses are keyed to the id rather than to the question text. Written by the Article Writer in `article` mode; rendered in every preview.
+_Avoid_: Test, Assessment, Question block, Exercise (reserved for the course's practical work)
+
 ### Video destinations
 
 **Skills Changelog**:

--- a/app/features/article-writer/choose-screenshot-markdown.ts
+++ b/app/features/article-writer/choose-screenshot-markdown.ts
@@ -1,5 +1,20 @@
+import {
+  applyPreviewRewrites,
+  mapPreviewOffset,
+  type PreviewRewrite,
+} from "./preview-rewrites";
+
 /** Matches the JSX-style tag the writer agent emits. */
 const CHOOSE_SCREENSHOT_TAG = /<ChooseScreenshot\s+([^>]*?)\/>/g;
+
+/** Each screenshot placeholder as a rewrite the preview applies. */
+export function collectChooseScreenshotRewrites(md: string): PreviewRewrite[] {
+  return [...md.matchAll(CHOOSE_SCREENSHOT_TAG)].map((match) => ({
+    start: match.index,
+    end: match.index + match[0].length,
+    replacement: toHtmlTag(match[1] ?? ""),
+  }));
+}
 
 function toHtmlTag(attrs: string): string {
   const htmlAttrs = attrs
@@ -20,9 +35,7 @@ function toHtmlTag(attrs: string): string {
  * Into:     <choosescreenshot clipindex="1" alt="test"></choosescreenshot>
  */
 export function preprocessChooseScreenshotMarkdown(md: string): string {
-  return md.replace(CHOOSE_SCREENSHOT_TAG, (_match, attrs: string) =>
-    toHtmlTag(attrs)
-  );
+  return applyPreviewRewrites(md, collectChooseScreenshotRewrites(md));
 }
 
 /**
@@ -39,14 +52,5 @@ export function mapPreprocessedOffsetToSource(
   md: string,
   offset: number
 ): number {
-  let shift = 0;
-  for (const match of md.matchAll(CHOOSE_SCREENSHOT_TAG)) {
-    const sourceLength = match[0].length;
-    const renderedLength = toHtmlTag(match[1] ?? "").length;
-    const renderedStart = match.index + shift;
-    // The offset falls before or inside this tag — no further shift applies.
-    if (renderedStart + renderedLength > offset) break;
-    shift += renderedLength - sourceLength;
-  }
-  return offset - shift;
+  return mapPreviewOffset(collectChooseScreenshotRewrites(md), offset).source;
 }

--- a/app/features/article-writer/document-preview-markdown.test.ts
+++ b/app/features/article-writer/document-preview-markdown.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapDocumentPreviewOffsetToSource,
+  preprocessDocumentPreview,
+} from "./document-preview-markdown";
+import { decodeQuizPayload, QUIZ_TAG_NAME } from "./quiz-markdown";
+
+const quiz = `<Quiz>
+  <QuizQuestion data={{
+    id: "only",
+    question: "Which one?",
+    type: "multiple-choice",
+    choices: [
+      { answer: "a", label: "One" },
+      { answer: "b", label: "Two" }
+    ],
+    correct: "a",
+    answer: "Because."
+  }} />
+</Quiz>`;
+
+const options = { screenshots: true };
+
+describe("preprocessDocumentPreview", () => {
+  it("collapses a quiz block into one tag", () => {
+    const result = preprocessDocumentPreview(`Intro.\n\n${quiz}\n`, options);
+    expect(result).toContain(`<${QUIZ_TAG_NAME} payload="`);
+    expect(result).not.toContain("QuizQuestion");
+    expect(result).toContain("Intro.");
+  });
+
+  it("carries each question's source offset in the payload", () => {
+    const source = `Intro.\n\n${quiz}\n`;
+    const result = preprocessDocumentPreview(source, options);
+    const payload = decodeQuizPayload(
+      /payload="([^"]*)"/.exec(result)![1] as string
+    );
+    expect(payload.questions).toHaveLength(1);
+    expect(source.slice(payload.questions[0]!.start)).toMatch(/^<QuizQuestion/);
+    expect(payload.questions[0]!.problems).toEqual([]);
+  });
+
+  it("leaves an unclosed block as text", () => {
+    const half = `<Quiz>\n  <QuizQuestion data={{ id: "hal`;
+    expect(preprocessDocumentPreview(half, options)).toBe(half);
+  });
+
+  it("rewrites quizzes and screenshots together", () => {
+    const source = `${quiz}\n\n<ChooseScreenshot clipIndex={1} alt="a" />`;
+    const result = preprocessDocumentPreview(source, options);
+    expect(result).toContain(`<${QUIZ_TAG_NAME} payload="`);
+    expect(result).toContain("<choosescreenshot");
+  });
+
+  it("leaves screenshots alone when they are switched off", () => {
+    const source = `<ChooseScreenshot clipIndex={1} alt="a" />`;
+    expect(preprocessDocumentPreview(source, { screenshots: false })).toBe(
+      source
+    );
+  });
+});
+
+describe("mapDocumentPreviewOffsetToSource", () => {
+  it("maps an offset after a quiz back to the source", () => {
+    const source = `${quiz}\n\nAfter the quiz.`;
+    const preview = preprocessDocumentPreview(source, options);
+    const previewOffset = preview.indexOf("After the quiz.");
+    expect(
+      mapDocumentPreviewOffsetToSource(source, previewOffset, options)
+    ).toBe(source.indexOf("After the quiz."));
+  });
+
+  it("refuses an offset inside a quiz", () => {
+    const source = `${quiz}\n\nAfter.`;
+    const preview = preprocessDocumentPreview(source, options);
+    const insideQuiz = preview.indexOf(`<${QUIZ_TAG_NAME}`) + 5;
+    expect(
+      mapDocumentPreviewOffsetToSource(source, insideQuiz, options)
+    ).toBeUndefined();
+  });
+
+  it("maps offsets in a document with no rewrites unchanged", () => {
+    expect(mapDocumentPreviewOffsetToSource("Plain text.", 6, options)).toBe(6);
+  });
+});

--- a/app/features/article-writer/document-preview-markdown.ts
+++ b/app/features/article-writer/document-preview-markdown.ts
@@ -1,0 +1,51 @@
+/**
+ * What the document preview actually parses.
+ *
+ * One entry point for every rewrite the preview needs, so the offsets the
+ * remove buttons report can always be mapped back. Quizzes are always rewritten
+ * — a body carrying one renders it whatever mode wrote it — while screenshot
+ * placeholders only apply where clips exist to fill them.
+ */
+
+import { collectChooseScreenshotRewrites } from "./choose-screenshot-markdown";
+import {
+  applyPreviewRewrites,
+  mapPreviewOffset,
+  type PreviewRewrite,
+} from "./preview-rewrites";
+import { collectQuizRewrites } from "./quiz-markdown";
+
+export interface DocumentPreviewOptions {
+  /** Whether `<ChooseScreenshot>` placeholders are live for this document. */
+  screenshots: boolean;
+}
+
+function collect(md: string, opts: DocumentPreviewOptions): PreviewRewrite[] {
+  return [
+    ...collectQuizRewrites(md),
+    ...(opts.screenshots ? collectChooseScreenshotRewrites(md) : []),
+  ];
+}
+
+export function preprocessDocumentPreview(
+  md: string,
+  opts: DocumentPreviewOptions
+): string {
+  return applyPreviewRewrites(md, collect(md, opts));
+}
+
+/**
+ * Translates a preview offset back to the stored document.
+ *
+ * Returns `undefined` for an offset inside a rewritten span — a quiz is cut by
+ * its own button at a known source range, never by a block range that happens
+ * to overlap it.
+ */
+export function mapDocumentPreviewOffsetToSource(
+  md: string,
+  offset: number,
+  opts: DocumentPreviewOptions
+): number | undefined {
+  const mapped = mapPreviewOffset(collect(md, opts), offset);
+  return mapped.inside ? undefined : mapped.source;
+}

--- a/app/features/article-writer/preview-rewrites.ts
+++ b/app/features/article-writer/preview-rewrites.ts
@@ -1,0 +1,58 @@
+/**
+ * The one mechanism for showing the preview something other than what is
+ * stored.
+ *
+ * `react-markdown` parses HTML, not JSX, so every JSX-style tag the writer
+ * emits — a screenshot placeholder, a quiz — is swapped for a plain lowercase
+ * tag before parsing. Each swap shifts every offset after it, and the preview's
+ * remove buttons report offsets, so the shifts have to be reversible. Holding
+ * all swaps in one list is what makes that possible: a second, independent
+ * preprocessor would silently corrupt the first one's arithmetic.
+ */
+
+/** A span of source replaced by something else before the preview parses it. */
+export interface PreviewRewrite {
+  start: number;
+  end: number;
+  replacement: string;
+}
+
+/** Applies every rewrite, innermost details untouched. Order does not matter. */
+export function applyPreviewRewrites(
+  source: string,
+  rewrites: PreviewRewrite[]
+): string {
+  const ordered = [...rewrites].sort((a, b) => a.start - b.start);
+  let out = "";
+  let at = 0;
+  for (const rewrite of ordered) {
+    if (rewrite.start < at) continue; // overlapping — first one wins
+    out += source.slice(at, rewrite.start) + rewrite.replacement;
+    at = rewrite.end;
+  }
+  return out + source.slice(at);
+}
+
+/**
+ * Translates an offset in the rewritten document back to the source.
+ *
+ * `inside` marks an offset that lands within a replacement rather than after
+ * it. Such an offset has no honest source position — the whole replaced span is
+ * one indivisible thing — so a caller wanting to cut text must refuse.
+ */
+export function mapPreviewOffset(
+  rewrites: PreviewRewrite[],
+  offset: number
+): { source: number; inside: boolean } {
+  const ordered = [...rewrites].sort((a, b) => a.start - b.start);
+  let shift = 0;
+  for (const rewrite of ordered) {
+    const renderedStart = rewrite.start + shift;
+    const renderedEnd = renderedStart + rewrite.replacement.length;
+    if (renderedEnd > offset) {
+      return { source: offset - shift, inside: renderedStart <= offset };
+    }
+    shift += rewrite.replacement.length - (rewrite.end - rewrite.start);
+  }
+  return { source: offset - shift, inside: false };
+}

--- a/app/features/article-writer/quiz-card.tsx
+++ b/app/features/article-writer/quiz-card.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { AlertTriangleIcon, CheckIcon, XIcon } from "lucide-react";
+import type { QuizCardQuestion } from "./quiz-markdown";
+
+/**
+ * The preview's stand-in for a quiz on aihero.dev.
+ *
+ * Deliberately static and fully revealed: every choice, the correct one marked,
+ * the explanation open. The author is proofreading the quiz, not sitting it —
+ * hiding the explanation behind a click would mean clicking every question to
+ * read the body.
+ */
+export function QuizCard({
+  questions,
+  onRemoveQuestion,
+}: {
+  questions: QuizCardQuestion[];
+  onRemoveQuestion?: (questionStart: number) => void;
+}) {
+  if (questions.length === 0) return null;
+
+  return (
+    <div className="my-6 space-y-3 rounded-lg border border-border bg-muted/30 p-4">
+      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Quiz
+      </div>
+      {questions.map((question) => (
+        <QuizQuestionCard
+          key={question.start}
+          question={question}
+          onRemove={onRemoveQuestion}
+        />
+      ))}
+    </div>
+  );
+}
+
+function QuizQuestionCard({
+  question,
+  onRemove,
+}: {
+  question: QuizCardQuestion;
+  onRemove?: (questionStart: number) => void;
+}) {
+  const { data, problems } = question;
+  const correct = new Set(
+    data ? (Array.isArray(data.correct) ? data.correct : [data.correct]) : []
+  );
+
+  return (
+    <div className="relative rounded-md border border-border bg-background p-3">
+      {onRemove ? (
+        <button
+          type="button"
+          aria-label="Remove question"
+          title="Remove question"
+          onClick={() => onRemove(question.start)}
+          className="absolute right-2 top-2 flex size-5 items-center justify-center rounded-md border border-border bg-background text-muted-foreground shadow-sm hover:text-destructive"
+        >
+          <XIcon className="size-3" />
+        </button>
+      ) : null}
+
+      {data ? (
+        <>
+          <div className="pr-7 font-medium">{data.question}</div>
+          <ul className="mt-2 space-y-1">
+            {(data.choices ?? []).map((choice) => (
+              <li
+                key={choice.answer}
+                className={cn(
+                  "flex items-start gap-2 rounded-sm px-2 py-1 text-sm",
+                  correct.has(choice.answer)
+                    ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+                    : "text-muted-foreground"
+                )}
+              >
+                <span className="mt-0.5 flex size-4 shrink-0 items-center justify-center">
+                  {correct.has(choice.answer) ? (
+                    <CheckIcon className="size-3.5" />
+                  ) : (
+                    <span className="size-2 rounded-full border border-current" />
+                  )}
+                </span>
+                <span>{choice.label}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-2 border-t border-border pt-2 text-sm text-muted-foreground">
+            {data.answer}
+          </div>
+          <div className="mt-2 font-mono text-[11px] text-muted-foreground/70">
+            {data.id}
+          </div>
+        </>
+      ) : (
+        <div className="pr-7 text-sm text-muted-foreground">
+          This question could not be read.
+        </div>
+      )}
+
+      {problems.length > 0 ? (
+        <ul className="mt-2 space-y-1 rounded-sm bg-destructive/10 p-2 text-xs text-destructive">
+          {problems.map((problem) => (
+            <li key={problem} className="flex items-start gap-1.5">
+              <AlertTriangleIcon className="mt-0.5 size-3 shrink-0" />
+              <span>{problem}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/app/features/article-writer/quiz-components.tsx
+++ b/app/features/article-writer/quiz-components.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { HTMLAttributes, ReactNode } from "react";
+import type { Options } from "react-markdown";
+import { QuizCard } from "./quiz-card";
+import { decodeQuizPayload, QUIZ_TAG_NAME } from "./quiz-markdown";
+
+/**
+ * What a rendered quiz needs beyond its own payload. It travels by context so
+ * the component map below can stay a frozen module constant — see
+ * {@link QUIZ_COMPONENTS}.
+ */
+export interface QuizRuntime {
+  /** Cuts the question starting at this source offset. Absent means read-only. */
+  onRemoveQuestion?: (questionStart: number) => void;
+}
+
+const RuntimeContext = createContext<QuizRuntime>({});
+
+/** Wrap whatever renders the markdown to make the cards' X buttons live. */
+export function QuizProvider({
+  runtime,
+  children,
+}: {
+  runtime: QuizRuntime;
+  children: ReactNode;
+}) {
+  return (
+    <RuntimeContext.Provider value={runtime}>
+      {children}
+    </RuntimeContext.Provider>
+  );
+}
+
+function QuizSlot(
+  props: HTMLAttributes<HTMLElement> & Record<string, unknown>
+) {
+  const runtime = useContext(RuntimeContext);
+  const payload = decodeQuizPayload((props.payload as string) ?? "");
+
+  return (
+    <QuizCard
+      questions={payload.questions}
+      onRemoveQuestion={runtime.onRemoveQuestion}
+    />
+  );
+}
+
+/**
+ * The tag → component map handed to `AIResponse`. A module constant, and it
+ * must stay one: react-markdown uses the mapped value as the React element
+ * *type*, so a fresh object on each render unmounts and remounts every card.
+ */
+export const QUIZ_COMPONENTS = {
+  [QUIZ_TAG_NAME]: QuizSlot as unknown,
+} as Options["components"];

--- a/app/features/article-writer/quiz-markdown.ts
+++ b/app/features/article-writer/quiz-markdown.ts
@@ -1,0 +1,71 @@
+/**
+ * Turning stored `<Quiz>` blocks into something the preview can parse.
+ *
+ * Each block collapses to a single `<quizblock>` tag carrying its questions as
+ * one encoded attribute. The questions keep their *source* offsets, so the card
+ * can cut a question at the exact span it came from without asking the offset
+ * mapper anything.
+ */
+
+import type { PreviewRewrite } from "./preview-rewrites";
+import {
+  parseQuizBlocks,
+  validateQuizQuestion,
+  type QuizQuestionData,
+} from "./quiz-syntax";
+
+/** One question as the rendered card receives it. */
+export interface QuizCardQuestion {
+  /** Source offset of the question's `<QuizQuestion` — the handle for cutting it. */
+  start: number;
+  data?: QuizQuestionData;
+  /** Why the tag could not be read, or how it breaks the contract. */
+  problems: string[];
+}
+
+export interface QuizCardPayload {
+  questions: QuizCardQuestion[];
+}
+
+export const QUIZ_TAG_NAME = "quizblock";
+
+/** Builds the preview's replacement for every complete quiz block. */
+export function collectQuizRewrites(source: string): PreviewRewrite[] {
+  return parseQuizBlocks(source).map((block) => {
+    const payload: QuizCardPayload = {
+      questions: block.questions.map((question) => ({
+        start: question.start,
+        data: question.data,
+        problems: question.error
+          ? [question.error]
+          : question.data
+            ? validateQuizQuestion(question.data)
+            : ["The question could not be read."],
+      })),
+    };
+    return {
+      start: block.start,
+      end: block.end,
+      replacement: `<${QUIZ_TAG_NAME} payload="${encodeQuizPayload(payload)}"></${QUIZ_TAG_NAME}>`,
+    };
+  });
+}
+
+/**
+ * Encodes a payload for an HTML attribute.
+ *
+ * `encodeURIComponent` rather than entity escaping: quiz prose carries quotes,
+ * angle brackets and newlines, and percent-encoding survives every one of them
+ * through the HTML parser unchanged.
+ */
+export function encodeQuizPayload(payload: QuizCardPayload): string {
+  return encodeURIComponent(JSON.stringify(payload));
+}
+
+export function decodeQuizPayload(attribute: string): QuizCardPayload {
+  try {
+    return JSON.parse(decodeURIComponent(attribute)) as QuizCardPayload;
+  } catch {
+    return { questions: [] };
+  }
+}

--- a/app/features/article-writer/quiz-syntax.test.ts
+++ b/app/features/article-writer/quiz-syntax.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectQuizIds,
+  parseObjectLiteral,
+  parseQuizBlocks,
+  removeQuizQuestion,
+  validateQuizQuestion,
+  type QuizQuestionData,
+} from "./quiz-syntax";
+
+const question = (id: string, extra = "") => `  <QuizQuestion data={{
+    id: "${id}",
+    question: "Which one?",
+    type: "multiple-choice",
+    choices: [
+      { answer: "a", label: "Option one" },
+      { answer: "b", label: "Option two" }
+    ],
+    correct: "a",
+    answer: "Because."${extra}
+  }} />`;
+
+const quiz = (...ids: string[]) =>
+  `<Quiz>\n${ids.map((id) => question(id)).join("\n")}\n</Quiz>`;
+
+describe("parseQuizBlocks", () => {
+  it("reads a question's data", () => {
+    const blocks = parseQuizBlocks(quiz("first"));
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.questions[0]!.data).toMatchObject({
+      id: "first",
+      type: "multiple-choice",
+      correct: "a",
+      choices: [
+        { answer: "a", label: "Option one" },
+        { answer: "b", label: "Option two" },
+      ],
+    });
+  });
+
+  it("locates the block in the source", () => {
+    const source = `Intro.\n\n${quiz("first")}\n\nOutro.`;
+    const block = parseQuizBlocks(source)[0]!;
+    expect(source.slice(block.start, block.end)).toBe(quiz("first"));
+  });
+
+  it("reads several questions in one block", () => {
+    expect(parseQuizBlocks(quiz("a", "b", "c"))[0]!.questions).toHaveLength(3);
+  });
+
+  it("skips a block that never closes, which is the streaming case", () => {
+    expect(parseQuizBlocks(`<Quiz>\n${question("half")}`)).toEqual([]);
+  });
+
+  it("holds a brace inside prose", () => {
+    const source = `<Quiz>
+  <QuizQuestion data={{
+    id: "braces",
+    question: "What does {} mean?",
+    type: "multiple-choice",
+    choices: [
+      { answer: "a", label: "An empty object }" },
+      { answer: "b", label: "A block" }
+    ],
+    correct: "a",
+    answer: "It is an empty object literal."
+  }} />
+</Quiz>`;
+    const data = parseQuizBlocks(source)[0]!.questions[0]!.data!;
+    expect(data.question).toBe("What does {} mean?");
+    expect(data.choices[0]!.label).toBe("An empty object }");
+  });
+
+  it("holds an angle bracket inside prose", () => {
+    const source = `<Quiz>
+  <QuizQuestion data={{
+    id: "angles",
+    question: "Is a < b?",
+    type: "multiple-choice",
+    choices: [
+      { answer: "a", label: "Yes" },
+      { answer: "b", label: "No" }
+    ],
+    correct: "a",
+    answer: "Yes, when a is smaller."
+  }} />
+</Quiz>`;
+    expect(parseQuizBlocks(source)[0]!.questions[0]!.data!.question).toBe(
+      "Is a < b?"
+    );
+  });
+
+  it("reports a question it cannot read", () => {
+    const source = `<Quiz>
+  <QuizQuestion data={{ id: someVariable }} />
+</Quiz>`;
+    expect(parseQuizBlocks(source)[0]!.questions[0]!.error).toBeTruthy();
+  });
+});
+
+describe("parseObjectLiteral", () => {
+  it("reads nested literals", () => {
+    expect(
+      parseObjectLiteral(`{ a: [1, true, null], b: { c: 'x' }, }`)
+    ).toEqual({ value: { a: [1, true, null], b: { c: "x" } } });
+  });
+
+  it("rejects a spread", () => {
+    expect(parseObjectLiteral(`{ ...base, id: "x" }`)).toHaveProperty("error");
+  });
+
+  it("rejects a function call", () => {
+    expect(parseObjectLiteral(`{ id: makeId() }`)).toHaveProperty("error");
+  });
+
+  it("rejects a conditional", () => {
+    expect(parseObjectLiteral(`{ id: flag ? "a" : "b" }`)).toHaveProperty(
+      "error"
+    );
+  });
+});
+
+describe("validateQuizQuestion", () => {
+  const valid: QuizQuestionData = {
+    id: "valid",
+    question: "Which one?",
+    type: "multiple-choice",
+    choices: [
+      { answer: "a", label: "One" },
+      { answer: "b", label: "Two" },
+    ],
+    correct: "a",
+    answer: "Because.",
+  };
+
+  it("passes a question that meets the contract", () => {
+    expect(validateQuizQuestion(valid)).toEqual([]);
+  });
+
+  it("rejects fewer than two choices", () => {
+    expect(
+      validateQuizQuestion({ ...valid, choices: [valid.choices[0]!] })
+    ).toContain("A question needs two or more choices.");
+  });
+
+  it("rejects two choices sharing an answer", () => {
+    expect(
+      validateQuizQuestion({
+        ...valid,
+        choices: [valid.choices[0]!, { answer: "a", label: "Two" }],
+      })
+    ).toContainEqual(expect.stringContaining("share the answer"));
+  });
+
+  it("rejects a correct value with no matching choice", () => {
+    expect(validateQuizQuestion({ ...valid, correct: "z" })).toContainEqual(
+      expect.stringContaining("not a choice")
+    );
+  });
+
+  it("rejects an empty explanation", () => {
+    expect(validateQuizQuestion({ ...valid, answer: "  " })).toContain(
+      "`answer` is empty."
+    );
+  });
+
+  it("rejects a type other than multiple-choice", () => {
+    expect(validateQuizQuestion({ ...valid, type: "freeform" })).toContain(
+      "`type` must be `multiple-choice`."
+    );
+  });
+
+  it("accepts a multi-select question", () => {
+    expect(validateQuizQuestion({ ...valid, correct: ["a", "b"] })).toEqual([]);
+  });
+});
+
+describe("collectQuizIds", () => {
+  it("lists every id in source order", () => {
+    expect(collectQuizIds(`${quiz("a", "b")}\n\n${quiz("c")}`)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+});
+
+describe("removeQuizQuestion", () => {
+  it("cuts one question and leaves its siblings", () => {
+    const source = quiz("a", "b");
+    const target = parseQuizBlocks(source)[0]!.questions[1]!;
+    const result = removeQuizQuestion(source, target.start);
+    expect(collectQuizIds(result)).toEqual(["a"]);
+    expect(result).toContain("</Quiz>");
+  });
+
+  it("takes the block with the last question", () => {
+    const source = `Intro.\n\n${quiz("only")}\n\nOutro.`;
+    const target = parseQuizBlocks(source)[0]!.questions[0]!;
+    const result = removeQuizQuestion(source, target.start);
+    expect(result).not.toContain("Quiz");
+    expect(result).toContain("Intro.");
+    expect(result).toContain("Outro.");
+  });
+
+  it("leaves the document alone when the offset names no question", () => {
+    const source = quiz("a");
+    expect(removeQuizQuestion(source, 9999)).toBe(source);
+  });
+});

--- a/app/features/article-writer/quiz-syntax.ts
+++ b/app/features/article-writer/quiz-syntax.ts
@@ -1,0 +1,399 @@
+/**
+ * Reading and writing the `<Quiz>` blocks embedded in a lesson body.
+ *
+ * The body stores the AI Hero authoring contract verbatim — JSX tags carrying a
+ * `data={{ ... }}` object literal — and ships it to AI Hero unparsed. Nothing
+ * here rewrites what is stored: the scan exists so the preview can draw a card,
+ * so a question can be cut at its exact source range, and so the linters can say
+ * what is wrong with a block.
+ *
+ * A regex cannot do this job. Question and explanation prose contains `}`, `>`
+ * and quotes, so the block is found by matching braces with string awareness.
+ */
+
+/** One choice a reader can pick. */
+export interface QuizChoice {
+  answer: string;
+  label: string;
+}
+
+/** The object literal inside one `<QuizQuestion data={{ ... }} />`. */
+export interface QuizQuestionData {
+  id: string;
+  question: string;
+  type: string;
+  choices: QuizChoice[];
+  /** A string for a single answer; an array makes the question multi-select. */
+  correct: string | string[];
+  answer: string;
+  allowMultiple?: boolean;
+  shuffleChoices?: boolean;
+}
+
+/**
+ * One `<QuizQuestion />` tag, located in the source.
+ *
+ * `data` is absent when the tag's object literal could not be read at all —
+ * `error` then says why. A tag that parses but breaks the contract still
+ * carries its `data`; ask {@link validateQuizQuestion} about those.
+ */
+export interface QuizQuestionBlock {
+  /** Offset of `<QuizQuestion` in the source. */
+  start: number;
+  /** Offset just past the closing `/>`. */
+  end: number;
+  data?: QuizQuestionData;
+  error?: string;
+}
+
+/** One `<Quiz>…</Quiz>` region, located in the source. */
+export interface QuizBlock {
+  /** Offset of `<Quiz>` in the source. */
+  start: number;
+  /** Offset just past the closing `</Quiz>`. */
+  end: number;
+  questions: QuizQuestionBlock[];
+}
+
+const QUIZ_OPEN = /<Quiz\s*>/g;
+const QUIZ_CLOSE = "</Quiz>";
+const QUESTION_OPEN = /<QuizQuestion\b/g;
+
+/**
+ * Walks a `{`-delimited span, returning the offset just past its matching `}`.
+ *
+ * Quotes are honoured so a brace inside prose does not close the span. Returns
+ * `undefined` when the span never closes — the streaming case, where the writer
+ * has emitted half a block.
+ */
+function matchBraces(source: string, open: number): number | undefined {
+  let depth = 0;
+  let quote: string | undefined;
+  for (let i = open; i < source.length; i++) {
+    const char = source[i]!;
+    if (quote) {
+      if (char === "\\") i++;
+      else if (char === quote) quote = undefined;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "{") depth++;
+    else if (char === "}") {
+      depth--;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Finds every complete `<Quiz>` block in a document.
+ *
+ * An unclosed block is skipped entirely, which is what keeps a streaming
+ * document legible: until `</Quiz>` arrives the fragment stays untouched and
+ * renders as ordinary text.
+ */
+export function parseQuizBlocks(source: string): QuizBlock[] {
+  const blocks: QuizBlock[] = [];
+  QUIZ_OPEN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = QUIZ_OPEN.exec(source)) !== null) {
+    const start = match.index;
+    const bodyStart = start + match[0].length;
+    const closeAt = source.indexOf(QUIZ_CLOSE, bodyStart);
+    if (closeAt === -1) break;
+
+    const end = closeAt + QUIZ_CLOSE.length;
+    blocks.push({
+      start,
+      end,
+      questions: parseQuestions(source, bodyStart, closeAt),
+    });
+    QUIZ_OPEN.lastIndex = end;
+  }
+
+  return blocks;
+}
+
+function parseQuestions(
+  source: string,
+  from: number,
+  to: number
+): QuizQuestionBlock[] {
+  const questions: QuizQuestionBlock[] = [];
+  QUESTION_OPEN.lastIndex = from;
+  let match: RegExpExecArray | null;
+
+  while ((match = QUESTION_OPEN.exec(source)) !== null) {
+    if (match.index >= to) break;
+    const start = match.index;
+
+    const dataAt = source.indexOf("data=", start);
+    const braceAt = dataAt === -1 ? -1 : source.indexOf("{", dataAt);
+    if (braceAt === -1 || braceAt >= to) {
+      questions.push({ start, end: to, error: "The tag has no `data` prop." });
+      break;
+    }
+
+    const braceEnd = matchBraces(source, braceAt);
+    if (braceEnd === undefined || braceEnd > to) {
+      questions.push({
+        start,
+        end: to,
+        error: "The `data` prop never closes.",
+      });
+      break;
+    }
+
+    const selfClose = source.indexOf("/>", braceEnd);
+    const end = selfClose === -1 || selfClose > to ? braceEnd : selfClose + 2;
+
+    // `data={{ … }}` — the outer brace is the JSX expression, the inner one the
+    // object literal we actually want.
+    const expression = source.slice(braceAt + 1, braceEnd - 1).trim();
+    const parsed = parseObjectLiteral(expression);
+
+    questions.push(
+      "error" in parsed
+        ? { start, end, error: parsed.error }
+        : { start, end, data: parsed.value as QuizQuestionData }
+    );
+    QUESTION_OPEN.lastIndex = end;
+  }
+
+  return questions;
+}
+
+type ParseResult = { value: unknown } | { error: string };
+
+/**
+ * Reads a static JavaScript object literal.
+ *
+ * Only literals are accepted — strings, numbers, booleans, `null`, arrays and
+ * objects. A spread, a variable, a call or a conditional is rejected rather
+ * than evaluated, which is both the contract's rule and the reason this is a
+ * parser and not an `eval`.
+ */
+export function parseObjectLiteral(source: string): ParseResult {
+  let at = 0;
+
+  const fail = (message: string): ParseResult => ({ error: message });
+
+  const skipSpace = () => {
+    while (at < source.length && /\s/.test(source[at]!)) at++;
+  };
+
+  const readString = (): ParseResult => {
+    const quote = source[at]!;
+    at++;
+    let out = "";
+    while (at < source.length) {
+      const char = source[at]!;
+      if (char === "\\") {
+        const next = source[at + 1];
+        out +=
+          next === "n"
+            ? "\n"
+            : next === "t"
+              ? "\t"
+              : next === "r"
+                ? "\r"
+                : (next ?? "");
+        at += 2;
+        continue;
+      }
+      if (char === quote) {
+        at++;
+        return { value: out };
+      }
+      out += char;
+      at++;
+    }
+    return fail("A string never closes.");
+  };
+
+  const readValue = (): ParseResult => {
+    skipSpace();
+    const char = source[at];
+    if (char === undefined) return fail("The value is missing.");
+    if (char === '"' || char === "'" || char === "`") return readString();
+    if (char === "{") return readObject();
+    if (char === "[") return readArray();
+
+    const word = /^(true|false|null)\b/.exec(source.slice(at));
+    if (word) {
+      at += word[0].length;
+      return {
+        value: word[0] === "true" ? true : word[0] === "false" ? false : null,
+      };
+    }
+
+    const number = /^-?\d+(\.\d+)?/.exec(source.slice(at));
+    if (number) {
+      at += number[0].length;
+      return { value: Number(number[0]) };
+    }
+
+    return fail(
+      "Only literal values are allowed — a spread, variable, call or conditional cannot be read."
+    );
+  };
+
+  const readArray = (): ParseResult => {
+    at++; // [
+    const out: unknown[] = [];
+    for (;;) {
+      skipSpace();
+      if (source[at] === "]") {
+        at++;
+        return { value: out };
+      }
+      const item = readValue();
+      if ("error" in item) return item;
+      out.push(item.value);
+      skipSpace();
+      if (source[at] === ",") at++;
+      else if (source[at] !== "]") return fail("An array item is malformed.");
+    }
+  };
+
+  const readObject = (): ParseResult => {
+    at++; // {
+    const out: Record<string, unknown> = {};
+    for (;;) {
+      skipSpace();
+      if (source[at] === "}") {
+        at++;
+        return { value: out };
+      }
+      if (source[at] === ".") return fail("A spread is not allowed in `data`.");
+
+      let key: string;
+      const char = source[at];
+      if (char === '"' || char === "'") {
+        const read = readString();
+        if ("error" in read) return read;
+        key = read.value as string;
+      } else {
+        const name = /^[A-Za-z_$][\w$]*/.exec(source.slice(at));
+        if (!name) return fail("A key is malformed.");
+        key = name[0];
+        at += key.length;
+      }
+
+      skipSpace();
+      if (source[at] !== ":") return fail(`The key \`${key}\` has no value.`);
+      at++;
+
+      const value = readValue();
+      if ("error" in value) return value;
+      out[key] = value.value;
+
+      skipSpace();
+      if (source[at] === ",") at++;
+      else if (source[at] !== "}") return fail("A property is malformed.");
+    }
+  };
+
+  skipSpace();
+  if (source[at] !== "{") return fail("The `data` prop holds no object.");
+  const result = readObject();
+  if ("error" in result) return result;
+  skipSpace();
+  if (at !== source.length) return fail("There is text after the object.");
+  return result;
+}
+
+/**
+ * Checks one question against the AI Hero contract, ignoring id uniqueness —
+ * that is a property of the whole course, not of one block, and lives with the
+ * linters that can see the course.
+ */
+export function validateQuizQuestion(data: QuizQuestionData): string[] {
+  const problems: string[] = [];
+
+  if (!data.id?.trim()) problems.push("`id` is missing.");
+  if (!data.question?.trim()) problems.push("`question` is empty.");
+  if (!data.answer?.trim()) problems.push("`answer` is empty.");
+  if (data.type !== "multiple-choice")
+    problems.push("`type` must be `multiple-choice`.");
+
+  const choices = Array.isArray(data.choices) ? data.choices : [];
+  if (choices.length < 2)
+    problems.push("A question needs two or more choices.");
+
+  const seen = new Set<string>();
+  for (const choice of choices) {
+    if (!choice?.answer?.trim() || !choice?.label?.trim()) {
+      problems.push("A choice has an empty `answer` or `label`.");
+      continue;
+    }
+    if (seen.has(choice.answer))
+      problems.push(`Two choices share the answer \`${choice.answer}\`.`);
+    seen.add(choice.answer);
+  }
+
+  const correct = Array.isArray(data.correct) ? data.correct : [data.correct];
+  if (correct.length === 0 || correct.some((value) => !value)) {
+    problems.push("`correct` is missing.");
+  } else {
+    for (const value of correct) {
+      if (!seen.has(value))
+        problems.push(`\`correct\` names \`${value}\`, which is not a choice.`);
+    }
+  }
+
+  return problems;
+}
+
+/** Every quiz id in a document, in source order, skipping unreadable tags. */
+export function collectQuizIds(source: string): string[] {
+  return parseQuizBlocks(source).flatMap((block) =>
+    block.questions.flatMap((question) =>
+      question.data?.id ? [question.data.id] : []
+    )
+  );
+}
+
+/**
+ * Cuts one question out of a document.
+ *
+ * The block goes with its last question: an empty `<Quiz></Quiz>` renders as
+ * nothing and would only have to be deleted by hand afterwards.
+ */
+export function removeQuizQuestion(source: string, questionStart: number) {
+  const block = parseQuizBlocks(source).find(
+    (candidate) =>
+      questionStart >= candidate.start && questionStart < candidate.end
+  );
+  if (!block) return source;
+
+  const question = block.questions.find(
+    (candidate) => candidate.start === questionStart
+  );
+  if (!question) return source;
+
+  const [start, end] =
+    block.questions.length === 1
+      ? [block.start, block.end]
+      : [question.start, question.end];
+
+  return cut(source, start, end);
+}
+
+/** Removes a span along with the blank line it leaves behind. */
+function cut(source: string, start: number, end: number): string {
+  let from = start;
+  while (from > 0 && (source[from - 1] === " " || source[from - 1] === "\t"))
+    from--;
+  let to = end;
+  while (to < source.length && (source[to] === " " || source[to] === "\t"))
+    to++;
+  if (source[to] === "\n") to++;
+  if (from > 0 && source[from - 1] === "\n" && source[to] === "\n") to++;
+  return source.slice(0, from) + source.slice(to);
+}

--- a/app/features/article-writer/use-remove-document-block.ts
+++ b/app/features/article-writer/use-remove-document-block.ts
@@ -1,6 +1,9 @@
 import { useCallback, type MutableRefObject } from "react";
 import type { RemoveBlockHandler } from "components/ui/kibo-ui/ai/response";
-import { mapPreprocessedOffsetToSource } from "./choose-screenshot-markdown";
+import {
+  mapDocumentPreviewOffsetToSource,
+  type DocumentPreviewOptions,
+} from "./document-preview-markdown";
 import { removeMarkdownBlock } from "./remove-markdown-block";
 
 /**
@@ -15,31 +18,40 @@ export function useRemoveDocumentBlock({
   documentRef,
   updateDocument,
   isGenerating,
-  hasScreenshotPreprocessing,
+  previewOptions,
 }: {
   documentRef: MutableRefObject<string | undefined>;
   updateDocument: (content: string) => void;
   isGenerating: boolean;
   /**
-   * Whether the preview parsed `preprocessChooseScreenshotMarkdown(document)`
-   * rather than the document itself — if so the reported offsets need mapping
-   * back before they can index into the stored document.
+   * What the preview rewrote before parsing. The offsets it reports index into
+   * the rewritten string, so they need mapping back before they can cut the
+   * stored document.
    */
-  hasScreenshotPreprocessing: boolean;
+  previewOptions: DocumentPreviewOptions;
 }): RemoveBlockHandler | undefined {
   const removeBlock = useCallback<RemoveBlockHandler>(
     ({ start, end }) => {
       const currentDoc = documentRef.current;
       if (!currentDoc) return;
-      const toSource = (offset: number) =>
-        hasScreenshotPreprocessing
-          ? mapPreprocessedOffsetToSource(currentDoc, offset)
-          : offset;
-      updateDocument(
-        removeMarkdownBlock(currentDoc, toSource(start), toSource(end))
+
+      const from = mapDocumentPreviewOffsetToSource(
+        currentDoc,
+        start,
+        previewOptions
       );
+      const to = mapDocumentPreviewOffsetToSource(
+        currentDoc,
+        end,
+        previewOptions
+      );
+      // Either end landing inside a rewritten span means the block overlaps a
+      // quiz, which is cut by its own control rather than by this one.
+      if (from === undefined || to === undefined) return;
+
+      updateDocument(removeMarkdownBlock(currentDoc, from, to));
     },
-    [documentRef, updateDocument, hasScreenshotPreprocessing]
+    [documentRef, updateDocument, previewOptions]
   );
 
   return isGenerating ? undefined : removeBlock;

--- a/app/features/article-writer/writable-field.tsx
+++ b/app/features/article-writer/writable-field.tsx
@@ -13,12 +13,22 @@ import type { Mode, WriterView } from "./types";
 import type { WriterFieldId } from "./writer-engine-utils";
 import { FIELD_MODES } from "./writer-engine-utils";
 import { WriterModal } from "./writer-modal";
+import { QUIZ_COMPONENTS } from "./quiz-components";
+import { preprocessDocumentPreview } from "./document-preview-markdown";
 import {
   WRITER_URL_UPDATE,
   applyWriterUrlState,
   readWriterUrlState,
   type WriterUrlState,
 } from "./writer-url-state";
+
+/**
+ * The inline preview draws quiz cards but resolves no screenshot placeholders —
+ * it has no clips to offer. A module constant so the memoised preview keeps its
+ * identity across renders.
+ */
+const previewQuizzes = (md: string) =>
+  preprocessDocumentPreview(md, { screenshots: false });
 
 interface WritableFieldPropsBase {
   videoId: string;
@@ -188,7 +198,11 @@ export function WritableField({
             <div className="scrollbar scrollbar-track-transparent scrollbar-thumb-muted h-full overflow-y-auto p-4">
               <div className="max-w-[75ch]">
                 {draft ? (
-                  <AIResponse imageBasePath={context.fullPath}>
+                  <AIResponse
+                    imageBasePath={context.fullPath}
+                    extraComponents={QUIZ_COMPONENTS}
+                    preprocessMarkdown={previewQuizzes}
+                  >
                     {draft}
                   </AIResponse>
                 ) : (

--- a/app/features/article-writer/writer-engine.tsx
+++ b/app/features/article-writer/writer-engine.tsx
@@ -26,12 +26,21 @@ import {
   removeChooseScreenshot,
   hasUnresolvedScreenshots,
 } from "./choose-screenshot-mutations";
-import { preprocessChooseScreenshotMarkdown } from "./choose-screenshot-markdown";
+import {
+  preprocessDocumentPreview,
+  type DocumentPreviewOptions,
+} from "./document-preview-markdown";
 import {
   CHOOSE_SCREENSHOT_COMPONENTS,
   ChooseScreenshotProvider,
   type ChooseScreenshotRuntime,
 } from "./choose-screenshot-components";
+import {
+  QUIZ_COMPONENTS,
+  QuizProvider,
+  type QuizRuntime,
+} from "./quiz-components";
+import { removeQuizQuestion } from "./quiz-syntax";
 import type { WriteToolbarProps } from "./write-toolbar";
 import type { WriterFieldId } from "./writer-engine-utils";
 import {
@@ -227,10 +236,17 @@ export function WriterEngine({
     [documentRef, updateDocument]
   );
 
-  const docExtraComponents =
-    indexedClips.length === 0 || !isDocumentMode
-      ? undefined
-      : CHOOSE_SCREENSHOT_COMPONENTS;
+  const hasScreenshots = indexedClips.length > 0 && isDocumentMode;
+
+  // Quizzes render in every document preview: a body carrying one shows it
+  // whatever mode wrote it. Screenshot placeholders need clips to resolve to.
+  const docExtraComponents = useMemo(
+    () =>
+      hasScreenshots
+        ? { ...QUIZ_COMPONENTS, ...CHOOSE_SCREENSHOT_COMPONENTS }
+        : QUIZ_COMPONENTS,
+    [hasScreenshots]
+  );
 
   // The document is a single scope, so the message id plays no part in its keys.
   const docScreenshotRuntime = useMemo(
@@ -255,17 +271,36 @@ export function WriterEngine({
     ]
   );
 
-  const docPreprocessMarkdown = useMemo(() => {
-    if (!docExtraComponents) return undefined;
-    return (md: string) => preprocessChooseScreenshotMarkdown(md);
-  }, [docExtraComponents]);
+  const previewOptions = useMemo(
+    (): DocumentPreviewOptions => ({ screenshots: hasScreenshots }),
+    [hasScreenshots]
+  );
+
+  const docPreprocessMarkdown = useMemo(
+    () => (md: string) => preprocessDocumentPreview(md, previewOptions),
+    [previewOptions]
+  );
 
   const handleRemoveDocBlock = useRemoveDocumentBlock({
     documentRef,
     updateDocument,
     isGenerating,
-    hasScreenshotPreprocessing: docPreprocessMarkdown !== undefined,
+    previewOptions,
   });
+
+  const docQuizRuntime = useMemo(
+    (): QuizRuntime => ({
+      // Mid-stream the next chunk would overwrite the cut, so the card's X waits.
+      onRemoveQuestion: isGenerating
+        ? undefined
+        : (questionStart: number) => {
+            const currentDoc = documentRef.current;
+            if (currentDoc)
+              updateDocument(removeQuizQuestion(currentDoc, questionStart));
+          },
+    }),
+    [documentRef, updateDocument, isGenerating]
+  );
 
   // Persist messages on stream completion
   const prevStatusRef = useRef(status);
@@ -539,15 +574,17 @@ export function WriterEngine({
               onOpenPanel={() => onViewChange?.("context")}
             />
             <ChooseScreenshotProvider runtime={docScreenshotRuntime}>
-              <DocumentPanel
-                variant="modal"
-                document={document}
-                fullPath={fullPath}
-                extraComponents={docExtraComponents}
-                preprocessMarkdown={docPreprocessMarkdown}
-                onRemoveBlock={handleRemoveDocBlock}
-                onDocumentChange={updateDocument}
-              />
+              <QuizProvider runtime={docQuizRuntime}>
+                <DocumentPanel
+                  variant="modal"
+                  document={document}
+                  fullPath={fullPath}
+                  extraComponents={docExtraComponents}
+                  preprocessMarkdown={docPreprocessMarkdown}
+                  onRemoveBlock={handleRemoveDocBlock}
+                  onDocumentChange={updateDocument}
+                />
+              </QuizProvider>
             </ChooseScreenshotProvider>
           </div>
         </div>
@@ -671,16 +708,18 @@ export function WriterEngine({
           <WriteChat {...chatProps} className="w-2/5" />
           <div className="w-3/5 flex flex-col border-l">
             <ChooseScreenshotProvider runtime={docScreenshotRuntime}>
-              <DocumentPanel
-                document={document}
-                fullPath={fullPath}
-                extraComponents={docExtraComponents}
-                preprocessMarkdown={docPreprocessMarkdown}
-                onRemoveBlock={handleRemoveDocBlock}
-                onDocumentChange={updateDocument}
-                violations={violations}
-                onFixLintViolations={handleFixLintViolations}
-              />
+              <QuizProvider runtime={docQuizRuntime}>
+                <DocumentPanel
+                  document={document}
+                  fullPath={fullPath}
+                  extraComponents={docExtraComponents}
+                  preprocessMarkdown={docPreprocessMarkdown}
+                  onRemoveBlock={handleRemoveDocBlock}
+                  onDocumentChange={updateDocument}
+                  violations={violations}
+                  onFixLintViolations={handleFixLintViolations}
+                />
+              </QuizProvider>
             </ChooseScreenshotProvider>
           </div>
         </>


### PR DESCRIPTION
First of three CVM branches adding quiz authoring. This one is **render only** — hand-write a `<Quiz>` block into a lesson body and it draws.

## What lands

- `quiz-syntax.ts` — brace-matching scan for `<Quiz>` blocks, a strict object-literal reader (literals only; a spread, variable, call or conditional is rejected rather than evaluated), the contract validator, and per-question removal.
- `quiz-markdown.ts` / `quiz-card.tsx` / `quiz-components.tsx` — the preview card. Static and fully revealed: the author is proofreading the quiz, not sitting it.
- `preview-rewrites.ts` + `document-preview-markdown.ts` — one list for every rewrite the preview applies, replacing the screenshot preprocessor's private offset arithmetic.

## Why a scan and not MDX

The preview renders **mid-stream**, on truncated tool-call input, every chunk. `@mdx-js/mdx` throws on unclosed JSX, a stray `<`, or an open `{` — so a quiz would throw for its whole streaming life, and existing bodies containing `a < b` would throw permanently. MDX also passes components no `node` and no `position`, which is the entire premise of the hover-X delete. Staying on `react-markdown` costs one scan; migrating costs a different renderer.

## Offsets

Two rewriters mean the screenshot mapper's linear shift replay is no longer sufficient — its regex cannot span a multi-line block, and an offset landing inside a collapsed quiz would map into the middle of the source. Both rewriters now feed one sorted list, and `mapDocumentPreviewOffsetToSource` returns `undefined` for an offset inside a replacement. A block range overlapping a quiz is refused rather than cut.

## Note

The inline `WritableField` preview now passes `extraComponents`, which turns on `rehype-raw` there. Raw HTML in a body renders in the inline field as it already does in the writer.

## Checks

`pnpm typecheck` clean. `pnpm vitest run app/features/article-writer components/ui/kibo-ui` — 205 pass, including the existing screenshot and removable-block tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)