### PR TITLE
quiz: the Article Writer proposes quizzes

### DIFF
--- a/app/features/article-writer/lint-fix.ts
+++ b/app/features/article-writer/lint-fix.ts
@@ -1,4 +1,8 @@
-import type { LintViolation } from "./lint-rules";
+import {
+  EMPTY_LINT_CONTEXT,
+  type LintContext,
+  type LintViolation,
+} from "./lint-rules";
 
 /**
  * A document that opens with an ATX heading. Shared with the
@@ -57,8 +61,9 @@ export interface LintFixPlan {
 export function planLintFix(opts: {
   document: string | undefined;
   violations: LintViolation[];
+  context?: LintContext;
 }): LintFixPlan {
-  const { document, violations } = opts;
+  const { document, violations, context = EMPTY_LINT_CONTEXT } = opts;
 
   let fixed = document;
   const instructions: string[] = [];
@@ -67,7 +72,7 @@ export function planLintFix(opts: {
     const { deterministicFix, fixInstruction } = violation.rule;
 
     if (deterministicFix && fixed !== undefined) {
-      const repaired = deterministicFix(fixed);
+      const repaired = deterministicFix(fixed, context);
       if (repaired !== fixed) {
         fixed = repaired;
         continue;

--- a/app/features/article-writer/lint-rules.ts
+++ b/app/features/article-writer/lint-rules.ts
@@ -1,5 +1,19 @@
 import { LEADING_HEADING_PATTERN, stripLeadingHeadings } from "./lint-fix";
+import { findTakenQuizIds, fixTakenQuizIds } from "./quiz-lint";
 import type { Mode } from "./types";
+
+/**
+ * What a rule knows beyond the text in front of it.
+ *
+ * A regex sees one document; some rules are about the course around it. The
+ * context carries what the loader could see and the rule could not.
+ */
+export interface LintContext {
+  /** Quiz ids owned by other videos in this course. */
+  courseQuizIds: string[];
+}
+
+export const EMPTY_LINT_CONTEXT: LintContext = { courseQuizIds: [] };
 
 /**
  * Represents a single lint rule that can be applied to article writer output.
@@ -27,7 +41,12 @@ export interface LintRule {
    * is not sent to the model. Only reachable in document modes, where we own
    * the text.
    */
-  deterministicFix?: (text: string) => string;
+  deterministicFix?: (text: string, context: LintContext) => string;
+  /**
+   * Replaces the `pattern` scan for a rule a regex cannot express. Returns one
+   * entry per offending thing found, which become the violation's `matches`.
+   */
+  detect?: (text: string, context: LintContext) => string[];
 }
 
 /**
@@ -162,6 +181,20 @@ export const BASE_LINT_RULES: LintRule[] = [
     fixInstruction:
       "Remove the markdown heading from the start of the content. Do not start with a heading - begin directly with the content.",
     deterministicFix: stripLeadingHeadings,
+  },
+  {
+    id: "quiz-id-taken",
+    name: "Quiz Id Taken",
+    description:
+      "A quiz id must be unique across the course — reader answers are keyed to it",
+    modes: null,
+    // Never scanned: `detect` sees the course, which a regex cannot.
+    pattern: /(?!)/,
+    detect: (text, context) => findTakenQuizIds(text, context.courseQuizIds),
+    deterministicFix: (text, context) =>
+      fixTakenQuizIds(text, context.courseQuizIds),
+    fixInstruction: (matches) =>
+      `Rename these quiz ids — another lesson in the course already uses them: ${matches.join(", ")}`,
   },
 ];
 

--- a/app/features/article-writer/quiz-ids.test.ts
+++ b/app/features/article-writer/quiz-ids.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectCourseQuizIdUses,
+  findQuizIdCollisions,
+  nextFreeQuizId,
+  renameCollidingQuizIds,
+} from "./quiz-ids";
+import { collectQuizIds } from "./quiz-syntax";
+import { findTakenQuizIds, maskQuizNonProse } from "./quiz-lint";
+
+const question = (id: string) => `  <QuizQuestion data={{
+    id: "${id}",
+    question: "Which one?",
+    type: "multiple-choice",
+    choices: [
+      { answer: "a", label: "Option one" },
+      { answer: "b", label: "Option two" }
+    ],
+    correct: "a",
+    answer: "Because."
+  }} />`;
+
+const quiz = (...ids: string[]) =>
+  `<Quiz>\n${ids.map(question).join("\n")}\n</Quiz>`;
+
+describe("collectCourseQuizIdUses", () => {
+  it("names the video each id came from", () => {
+    expect(
+      collectCourseQuizIdUses([
+        { videoId: "v1", videoTitle: "Explainer", body: quiz("a") },
+        { videoId: "v2", videoTitle: "Problem", body: null },
+      ])
+    ).toEqual([{ id: "a", videoId: "v1", videoTitle: "Explainer" }]);
+  });
+});
+
+describe("findQuizIdCollisions", () => {
+  it("reports an id two videos share, naming both", () => {
+    const collisions = findQuizIdCollisions(
+      collectCourseQuizIdUses([
+        { videoId: "v1", videoTitle: "One", body: quiz("shared") },
+        { videoId: "v2", videoTitle: "Two", body: quiz("shared") },
+      ])
+    );
+    expect(collisions).toHaveLength(1);
+    expect(collisions[0]!.id).toBe("shared");
+    expect(collisions[0]!.uses.map((use) => use.videoTitle)).toEqual([
+      "One",
+      "Two",
+    ]);
+  });
+
+  it("reports an id one body repeats", () => {
+    expect(
+      findQuizIdCollisions(
+        collectCourseQuizIdUses([
+          { videoId: "v1", videoTitle: "One", body: quiz("twice", "twice") },
+        ])
+      )
+    ).toHaveLength(1);
+  });
+
+  it("says nothing when every id is unique", () => {
+    expect(
+      findQuizIdCollisions(
+        collectCourseQuizIdUses([
+          { videoId: "v1", videoTitle: "One", body: quiz("a", "b") },
+          { videoId: "v2", videoTitle: "Two", body: quiz("c") },
+        ])
+      )
+    ).toEqual([]);
+  });
+});
+
+describe("nextFreeQuizId", () => {
+  it("suffixes a taken id", () => {
+    expect(nextFreeQuizId("subagents", new Set(["subagents"]))).toBe(
+      "subagents-2"
+    );
+  });
+
+  it("walks past a taken suffix", () => {
+    expect(
+      nextFreeQuizId("subagents", new Set(["subagents", "subagents-2"]))
+    ).toBe("subagents-3");
+  });
+
+  it("counts on from an already-suffixed id rather than stacking", () => {
+    expect(nextFreeQuizId("subagents-2", new Set(["subagents-2"]))).toBe(
+      "subagents-3"
+    );
+  });
+});
+
+describe("renameCollidingQuizIds", () => {
+  it("renames only the id the course already owns", () => {
+    const body = quiz("taken", "free");
+    expect(collectQuizIds(renameCollidingQuizIds(body, ["taken"]))).toEqual([
+      "taken-2",
+      "free",
+    ]);
+  });
+
+  it("keeps the first use and renames the repeat", () => {
+    expect(collectQuizIds(renameCollidingQuizIds(quiz("dup", "dup"), []))).toEqual(
+      ["dup", "dup-2"]
+    );
+  });
+
+  it("leaves a clean document untouched", () => {
+    const body = quiz("a", "b");
+    expect(renameCollidingQuizIds(body, ["c"])).toBe(body);
+  });
+});
+
+describe("findTakenQuizIds", () => {
+  it("finds an id another video owns", () => {
+    expect(findTakenQuizIds(quiz("taken"), ["taken"])).toEqual(["taken"]);
+  });
+
+  it("finds an id the document repeats", () => {
+    expect(findTakenQuizIds(quiz("dup", "dup"), [])).toEqual(["dup"]);
+  });
+
+  it("passes a clean document", () => {
+    expect(findTakenQuizIds(quiz("a"), ["b"])).toEqual([]);
+  });
+});
+
+describe("maskQuizNonProse", () => {
+  const body = `Some prose.\n\n${quiz("em-dash-id")}\n\nMore prose.`;
+
+  it("keeps the question and the explanation", () => {
+    const masked = maskQuizNonProse(body);
+    expect(masked).toContain("Which one?");
+    expect(masked).toContain("Because.");
+  });
+
+  it("hides the id and the JSX around it", () => {
+    const masked = maskQuizNonProse(body);
+    expect(masked).not.toContain("em-dash-id");
+    expect(masked).not.toContain("QuizQuestion");
+    expect(masked).not.toContain("multiple-choice");
+  });
+
+  it("leaves the prose around the quiz alone", () => {
+    const masked = maskQuizNonProse(body);
+    expect(masked).toContain("Some prose.");
+    expect(masked).toContain("More prose.");
+  });
+
+  it("returns a quiz-free document unchanged", () => {
+    expect(maskQuizNonProse("Just prose.")).toBe("Just prose.");
+  });
+});

--- a/app/features/article-writer/quiz-ids.ts
+++ b/app/features/article-writer/quiz-ids.ts
@@ -1,0 +1,117 @@
+/**
+ * Quiz ids across a whole course.
+ *
+ * An id is the key a reader's answers are stored against, so two questions
+ * sharing one silently merge two questions' response history — damage that is
+ * invisible on the page. Uniqueness is therefore a property of the course, not
+ * of a body, and every check that can see the course lives here.
+ */
+
+import { collectQuizIds, parseQuizBlocks } from "./quiz-syntax";
+
+/** One video's use of one quiz id. */
+export interface QuizIdUse {
+  id: string;
+  videoId: string;
+  videoTitle: string;
+  lessonTitle?: string | null;
+}
+
+export interface QuizIdCollision {
+  id: string;
+  uses: QuizIdUse[];
+}
+
+export interface VideoBody {
+  videoId: string;
+  videoTitle: string;
+  lessonTitle?: string | null;
+  body: string | null;
+}
+
+/** Every quiz id in a course, one entry per use, in reading order. */
+export function collectCourseQuizIdUses(videos: VideoBody[]): QuizIdUse[] {
+  return videos.flatMap((video) =>
+    collectQuizIds(video.body ?? "").map((id) => ({
+      id,
+      videoId: video.videoId,
+      videoTitle: video.videoTitle,
+      lessonTitle: video.lessonTitle,
+    }))
+  );
+}
+
+/**
+ * Ids used more than once anywhere in the course — including twice inside one
+ * body, which is the same damage by a shorter route.
+ */
+export function findQuizIdCollisions(uses: QuizIdUse[]): QuizIdCollision[] {
+  const byId = new Map<string, QuizIdUse[]>();
+  for (const use of uses) {
+    const existing = byId.get(use.id);
+    if (existing) existing.push(use);
+    else byId.set(use.id, [use]);
+  }
+
+  return [...byId.entries()]
+    .filter(([, group]) => group.length > 1)
+    .map(([id, group]) => ({ id, uses: group }));
+}
+
+/**
+ * The first free id built from a taken one.
+ *
+ * A numeric suffix, deliberately: an id names a concept, and `-2` names
+ * nothing, but it is unique on the first try. A model rename is a round trip
+ * that can collide again, and the rule exists to protect response data rather
+ * than to write good ids. A suffix appearing at all says two lessons test the
+ * same concept — a content problem no id was going to fix.
+ */
+export function nextFreeQuizId(id: string, taken: Set<string>): string {
+  const stem = /-(\d+)$/.exec(id) ? id.replace(/-\d+$/, "") : id;
+  for (let suffix = 2; ; suffix++) {
+    const candidate = `${stem}-${suffix}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+/**
+ * Renames every colliding id in one document.
+ *
+ * `taken` holds the ids already spoken for elsewhere in the course. The first
+ * use of an id in this document keeps it unless the course already has it;
+ * later uses are suffixed, so a rewrite never renames a question that was fine.
+ */
+export function renameCollidingQuizIds(
+  body: string,
+  taken: Iterable<string>
+): string {
+  const reserved = new Set(taken);
+  const edits: { start: number; end: number; id: string }[] = [];
+
+  for (const block of parseQuizBlocks(body)) {
+    for (const question of block.questions) {
+      const id = question.data?.id;
+      if (!id) continue;
+      if (!reserved.has(id)) {
+        reserved.add(id);
+        continue;
+      }
+      const replacement = nextFreeQuizId(id, reserved);
+      reserved.add(replacement);
+      edits.push({ start: question.start, end: question.end, id: replacement });
+    }
+  }
+
+  // Applied last-first so each splice leaves the earlier offsets valid.
+  let out = body;
+  for (const edit of edits.reverse()) {
+    const tag = out.slice(edit.start, edit.end);
+    out =
+      out.slice(0, edit.start) +
+      tag.replace(/(\bid\s*:\s*["'])[^"']*(["'])/, `$1${edit.id}$2`) +
+      out.slice(edit.end);
+  }
+
+  return out;
+}

--- a/app/features/article-writer/quiz-lint.ts
+++ b/app/features/article-writer/quiz-lint.ts
@@ -1,0 +1,69 @@
+/**
+ * What the prose linters may see of a quiz, and the one lint that is about
+ * quizzes rather than prose.
+ */
+
+import { parseQuizBlocks } from "./quiz-syntax";
+import { collectQuizIds } from "./quiz-syntax";
+import { renameCollidingQuizIds } from "./quiz-ids";
+
+/**
+ * Hides everything in a quiz except the prose a reader sees.
+ *
+ * A banned phrase inside a question is a real violation, so the linters read
+ * `question` and `answer`. An id, a choice's `answer` key and the JSX around
+ * them are structure: a rule matching there would report a violation whose fix
+ * breaks the block. Replaced rather than removed so a phrase cannot be formed
+ * by two fragments meeting.
+ */
+export function maskQuizNonProse(text: string): string {
+  const blocks = parseQuizBlocks(text);
+  if (blocks.length === 0) return text;
+
+  let out = "";
+  let at = 0;
+  for (const block of blocks) {
+    out += text.slice(at, block.start);
+    for (const question of block.questions) {
+      const data = question.data;
+      if (!data) continue;
+      out += `\n${data.question ?? ""}\n${data.answer ?? ""}\n`;
+      for (const choice of data.choices ?? []) out += `${choice.label}\n`;
+    }
+    at = block.end;
+  }
+  return out + text.slice(at);
+}
+
+/** Ids used more than once in one document. */
+export function findRepeatedQuizIds(text: string): string[] {
+  const seen = new Set<string>();
+  const repeated = new Set<string>();
+  for (const id of collectQuizIds(text)) {
+    if (seen.has(id)) repeated.add(id);
+    seen.add(id);
+  }
+  return [...repeated];
+}
+
+/**
+ * Quiz ids in this document that another video in the course already owns, plus
+ * any the document repeats itself.
+ */
+export function findTakenQuizIds(
+  text: string,
+  courseQuizIds: Iterable<string>
+): string[] {
+  const taken = new Set(courseQuizIds);
+  const clashes = new Set(findRepeatedQuizIds(text));
+  for (const id of collectQuizIds(text)) if (taken.has(id)) clashes.add(id);
+  return [...clashes];
+}
+
+/** Renames the clashing ids, leaving the first honest use of each alone. */
+export function fixTakenQuizIds(
+  text: string,
+  courseQuizIds: Iterable<string>
+): string {
+  return renameCollidingQuizIds(text, courseQuizIds);
+}

--- a/app/features/article-writer/types.ts
+++ b/app/features/article-writer/types.ts
@@ -88,4 +88,6 @@ export interface WriterContext {
   beats: Array<{ kind: BeatKind; title: string; description: string }>;
   /** The video's script — the base Matt improvised from. Empty when unwritten. */
   script: string;
+  /** Quiz ids owned by other videos in this course — none of them are free. */
+  quizIds?: string[];
 }

--- a/app/features/article-writer/writer-engine.tsx
+++ b/app/features/article-writer/writer-engine.tsx
@@ -17,6 +17,7 @@ import { DocumentPanel } from "./document-panel";
 import { useDocumentFlow } from "./use-document-flow";
 import { useRemoveDocumentBlock } from "./use-remove-document-block";
 import { useLint, useLintFix } from "@/hooks/use-lint";
+import type { LintContext } from "./lint-rules";
 import { useBannedPhrases } from "@/hooks/use-banned-phrases";
 import { useMessageQueue } from "./use-message-queue";
 import { partsToText } from "./write-utils";
@@ -397,10 +398,18 @@ export function WriterEngine({
       .find((m) => m.role === "assistant")?.parts ?? []
   );
 
+  // Quiz id uniqueness is a fact about the course, which the loader knows and
+  // a regex over one document never could.
+  const lintContext = useMemo(
+    (): LintContext => ({ courseQuizIds: context.quizIds ?? [] }),
+    [context.quizIds]
+  );
+
   const { violations } = useLint(
     isDocumentMode && document ? document : lastAssistantMessageText,
     mode,
-    bannedPhrases
+    bannedPhrases,
+    lintContext
   );
 
   const handleSend = useCallback(
@@ -431,6 +440,7 @@ export function WriterEngine({
     documentRef,
     updateDocument,
     submitMessage: handleSubmit,
+    context: lintContext,
   });
 
   const handleRegenerate = useCallback(() => {

--- a/app/hooks/use-lint.ts
+++ b/app/hooks/use-lint.ts
@@ -1,11 +1,14 @@
 import { useCallback, useMemo, type RefObject } from "react";
 import {
+  EMPTY_LINT_CONTEXT,
   LINT_RULES,
   getLintRulesWithPhrases,
+  type LintContext,
   type LintViolation,
   type BannedPhrase,
 } from "@/features/article-writer/lint-rules";
 import { planLintFix } from "@/features/article-writer/lint-fix";
+import { maskQuizNonProse } from "@/features/article-writer/quiz-lint";
 import type { Mode } from "@/features/article-writer/types";
 
 /**
@@ -27,7 +30,8 @@ import type { Mode } from "@/features/article-writer/types";
 export function useLint(
   text: string | null,
   mode: Mode,
-  customPhrases?: BannedPhrase[]
+  customPhrases?: BannedPhrase[],
+  context: LintContext = EMPTY_LINT_CONTEXT
 ) {
   const rules = useMemo(() => {
     if (customPhrases) {
@@ -40,6 +44,9 @@ export function useLint(
     if (!text) return [];
 
     const results: LintViolation[] = [];
+    // Prose rules read a quiz's question and explanation only — a match on an
+    // id or on the JSX around it would carry a fix that breaks the block.
+    const prose = maskQuizNonProse(text);
 
     for (const rule of rules) {
       // Skip rules that don't apply to this mode
@@ -47,8 +54,16 @@ export function useLint(
         continue;
       }
 
+      if (rule.detect) {
+        const found = rule.detect(text, context);
+        if (found.length > 0) {
+          results.push({ rule, count: found.length, matches: found });
+        }
+        continue;
+      }
+
       // Check for matches
-      let matches = text.match(rule.pattern);
+      let matches = prose.match(rule.pattern);
 
       // Apply optional match filter to remove false positives
       if (matches && rule.matchFilter) {
@@ -78,7 +93,7 @@ export function useLint(
     }
 
     return results;
-  }, [text, mode, rules]);
+  }, [text, mode, rules, context]);
 
   return { violations };
 }
@@ -99,6 +114,7 @@ export function useLintFix(opts: {
   documentRef: RefObject<string | undefined>;
   updateDocument: (document: string) => void;
   submitMessage: (text: string) => void;
+  context?: LintContext;
 }) {
   const {
     violations,
@@ -106,13 +122,22 @@ export function useLintFix(opts: {
     documentRef,
     updateDocument,
     submitMessage,
+    context = EMPTY_LINT_CONTEXT,
   } = opts;
   return useCallback(() => {
     const plan = planLintFix({
       document: isDocumentMode ? documentRef.current : undefined,
       violations,
+      context,
     });
     if (plan.document !== null) updateDocument(plan.document);
     if (plan.message) submitMessage(plan.message);
-  }, [violations, isDocumentMode, documentRef, updateDocument, submitMessage]);
+  }, [
+    violations,
+    isDocumentMode,
+    documentRef,
+    updateDocument,
+    submitMessage,
+    context,
+  ]);
 }

--- a/app/prompts/generate-article.ts
+++ b/app/prompts/generate-article.ts
@@ -1,4 +1,5 @@
 import { getImageInstructions } from "./image-instructions";
+import { getQuizInstructions } from "./quiz-instructions";
 import { getLinkInstructions, type GlobalLink } from "./link-instructions";
 import { SCREENSHOT_INSTRUCTIONS } from "./screenshot-instructions";
 import { ARTICLE_SOURCE_HIERARCHY } from "./source-hierarchy";
@@ -29,6 +30,8 @@ export const generateArticlePrompt = (opts: {
   sectionNames?: string[];
   courseStructure?: string;
   links: GlobalLink[];
+  /** Quiz ids owned by other videos in this course — none of them are free. */
+  existingQuizIds?: string[];
 }) => {
   const transcriptSection = getTranscriptSection(opts.transcript);
 
@@ -75,6 +78,8 @@ ${getImageInstructions(opts.images)}
 ${getLinkInstructions(opts.links)}
 
 ${SCREENSHOT_INSTRUCTIONS}
+
+${getQuizInstructions(opts.existingQuizIds ?? [])}
 
 ## IMPORTANT INSTRUCTIONS
 

--- a/app/prompts/quiz-instructions.ts
+++ b/app/prompts/quiz-instructions.ts
@@ -1,0 +1,57 @@
+/**
+ * How the Article Writer authors a quiz.
+ *
+ * The syntax here is one of two live copies — the other is the `quizzes.md`
+ * reference in the `creating-content` skill, which holds the same contract for
+ * agents drafting outside this app. Change both.
+ */
+
+export const getQuizInstructions = (existingQuizIds: string[]) => {
+  const takenSection =
+    existingQuizIds.length > 0
+      ? `These ids are already used elsewhere in the course. Do not reuse any of them:
+
+${existingQuizIds.map((id) => `- ${id}`).join("\n")}
+
+`
+      : "";
+
+  return `
+## Quizzes
+
+End the article with one quiz. It goes at the very end of the body, after the last section, and holds two to four questions.
+
+A question tests one of two things, and nothing else:
+
+- A **decision** the reader has to make — two ways of working, both of which a real person would try.
+- A **recall** of a fact a later lesson depends on: a flag, a default, a limit. The reader walks back through the article to answer it, and that walk is the point.
+
+Write the choices like this:
+
+- Every wrong choice is something a real reader would actually do. A choice nobody would pick makes the question free.
+- The correct answer is the same length as the wrong ones. A reader who spots the longest choice never reads the question.
+- The explanation says why the wrong choices are wrong, not only why the right one is right.
+
+Each question carries an \`id\` that names the concept it tests — \`subagent-context-isolation\`, never \`quiz-1\`. Reader answers are keyed to the id, so it must be unique across the whole course.
+
+${takenSection}Write the quiz exactly like this, with every value a literal — no variables, no spreads, no expressions:
+
+<Quiz>
+  <QuizQuestion data={{
+    id: "unique-identifier",
+    question: "The prompt text",
+    type: "multiple-choice",
+    choices: [
+      { answer: "a", label: "Option one" },
+      { answer: "b", label: "Option two" }
+    ],
+    correct: "a",
+    answer: "Explanation shown after answering"
+  }} />
+</Quiz>
+
+\`type\` is always \`"multiple-choice"\`. A question needs two or more choices, each with a short stable \`answer\` key and a \`label\`. \`correct\` names one choice's \`answer\`; an array of them makes the question multi-select, graded as an exact set — every correct answer and no others, or no credit — so use it only where that severity is earned.
+
+Two optional fields: \`allowMultiple\` shows checkboxes when only one answer is correct, and \`shuffleChoices\` (default true) can be set false to hold the authored order. Choice order is shuffled for the reader, so where you put the correct answer makes no difference.
+`.trim();
+};

--- a/app/routes/videos.$videoId.completions.ts
+++ b/app/routes/videos.$videoId.completions.ts
@@ -129,6 +129,7 @@ export const action = async (args: Route.ActionArgs) => {
       imageFiles: videoContext.imageFiles,
       youtubeChapters: videoContext.youtubeChapters,
       sectionNames: videoContext.sectionNames,
+      existingQuizIds: videoContext.existingQuizIds,
       links,
       courseStructure: courseStructureText,
       aiHeroUrl: parsed.aiHeroUrl,

--- a/app/routes/videos.$videoId.document-completions.ts
+++ b/app/routes/videos.$videoId.document-completions.ts
@@ -175,6 +175,7 @@ export const action = async (args: Route.ActionArgs) => {
       code: videoContext.textFiles,
       imageFiles: videoContext.imageFiles,
       sectionNames: videoContext.sectionNames,
+      existingQuizIds: videoContext.existingQuizIds,
       links,
       courseStructure: courseStructureText,
       memory: parsed.memory,

--- a/app/services/course-quiz-ids.server.ts
+++ b/app/services/course-quiz-ids.server.ts
@@ -1,0 +1,33 @@
+import { Effect } from "effect";
+import { CourseOperationsService } from "@/services/db-course-operations.server";
+import {
+  collectCourseQuizIdUses,
+  type QuizIdUse,
+} from "@/features/article-writer/quiz-ids";
+
+/** Every quiz id used in one course version, with the video that uses it. */
+export const loadCourseQuizIdUses = Effect.fn("loadCourseQuizIdUses")(
+  function* (versionId: string) {
+    const courseOps = yield* CourseOperationsService;
+    const bodies = yield* courseOps.getCourseVideoBodies(versionId);
+    return collectCourseQuizIdUses(bodies) satisfies QuizIdUse[];
+  }
+);
+
+/**
+ * The ids one video may not use, because another video in its course already
+ * does. Its own ids are excluded — rewriting a body must not collide with the
+ * version of itself it is replacing.
+ */
+export const loadOtherVideosQuizIds = Effect.fn("loadOtherVideosQuizIds")(
+  function* (opts: { versionId: string; videoId: string }) {
+    const uses = yield* loadCourseQuizIdUses(opts.versionId);
+    return [
+      ...new Set(
+        uses
+          .filter((use) => use.videoId !== opts.videoId)
+          .map((use) => use.id)
+      ),
+    ];
+  }
+);

--- a/app/services/db-course-operations.server.ts
+++ b/app/services/db-course-operations.server.ts
@@ -508,9 +508,58 @@ export const createCourseOperations = (db: Database) => {
     yield* makeDbCall(() => db.delete(courses).where(eq(courses.id, repoId)));
   });
 
+  /**
+   * Every non-archived video's body in one course version.
+   *
+   * Read by both readers of quiz ids: the writer, which needs to know which ids
+   * are taken before it invents one, and the course lint, which refuses a
+   * publish when two videos share one.
+   */
+  const getCourseVideoBodies = Effect.fn("getCourseVideoBodies")(function* (
+    versionId: string
+  ) {
+    const rows = yield* makeDbCall(() =>
+      db.query.sections.findMany({
+        where: and(
+          eq(sections.repoVersionId, versionId),
+          isNull(sections.archivedAt)
+        ),
+        columns: { id: true, title: true },
+        with: {
+          lessons: {
+            where: eq(lessons.archived, false),
+            columns: { id: true, title: true },
+            with: {
+              videos: {
+                where: eq(videos.archived, false),
+                columns: { id: true, title: true, body: true },
+                orderBy: asc(videos.title),
+              },
+            },
+            orderBy: asc(lessons.order),
+          },
+        },
+        orderBy: asc(sections.order),
+      })
+    );
+
+    return rows.flatMap((section) =>
+      section.lessons.flatMap((lesson) =>
+        lesson.videos.map((video) => ({
+          videoId: video.id,
+          videoTitle: video.title,
+          lessonTitle: lesson.title,
+          sectionTitle: section.title,
+          body: video.body,
+        }))
+      )
+    );
+  });
+
   const duplicateCourse = makeDuplicateCourse(db);
 
   return {
+    getCourseVideoBodies,
     getCourseById,
     getCourseWithSectionsById,
     getCourseStructureById,

--- a/app/services/document-writing-agent.ts
+++ b/app/services/document-writing-agent.ts
@@ -97,6 +97,8 @@ export type DocumentWritingContext = {
   code: TextWritingAgentCodeFile[];
   imageFiles: TextWritingAgentImageFile[];
   sectionNames?: string[];
+  /** Quiz ids owned by other videos in this course. */
+  existingQuizIds?: string[];
   links?: GlobalLink[];
   courseStructure?: string;
   memory?: string;
@@ -159,6 +161,7 @@ export const buildDocumentWritingSystemMessage = (
           sectionNames: props.sectionNames,
           courseStructure: props.courseStructure,
           links,
+          existingQuizIds: props.existingQuizIds,
         });
     }
   })();

--- a/app/services/text-writing-agent.ts
+++ b/app/services/text-writing-agent.ts
@@ -1,4 +1,5 @@
 import { sortByOrder } from "@/lib/sort-by-order";
+import { loadOtherVideosQuizIds } from "@/services/course-quiz-ids.server";
 import { formatOnScreenLinks } from "@/lib/transcript-builder";
 import { generateArticlePrompt } from "@/prompts/generate-article";
 import { generateArticlePlanPrompt } from "@/prompts/generate-article-plan";
@@ -52,6 +53,8 @@ export const createTextWritingAgent = (props: {
   imageFiles: TextWritingAgentImageFile[];
   youtubeChapters?: { timestamp: string; name: string }[];
   sectionNames?: string[];
+  /** Quiz ids owned by other videos in this course. */
+  existingQuizIds?: string[];
   links?: GlobalLink[];
   courseStructure?: string;
   aiHeroUrl?: string;
@@ -193,6 +196,7 @@ export const createTextWritingAgent = (props: {
           sectionNames: props.sectionNames,
           courseStructure: props.courseStructure,
           links,
+          existingQuizIds: props.existingQuizIds,
         });
     }
   })();
@@ -448,6 +452,15 @@ export const acquireTextWritingContext = Effect.fn("acquireVideoContext")(
           .filter((section) => enabledSectionIds.has(section.id))
           .map((section) => section.name);
 
+    // The ids already spoken for elsewhere in this course. The writer needs
+    // them to invent a free one; without them a clash only surfaces at publish.
+    const existingQuizIds = lesson
+      ? yield* loadOtherVideosQuizIds({
+          versionId: lesson.section.repoVersionId,
+          videoId: props.videoId,
+        })
+      : [];
+
     return {
       textFiles,
       imageFiles,
@@ -456,6 +469,7 @@ export const acquireTextWritingContext = Effect.fn("acquireVideoContext")(
       lessonPath,
       youtubeChapters,
       sectionNames,
+      existingQuizIds,
     };
   }
 );

--- a/app/services/video-posting-context.server.ts
+++ b/app/services/video-posting-context.server.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import { loadOtherVideosQuizIds } from "@/services/course-quiz-ids.server";
 import path from "path";
 import { VideoOperationsService } from "@/services/db-video-operations.server";
 import { CourseOperationsService } from "@/services/db-course-operations.server";
@@ -208,6 +209,8 @@ export interface WriterContextData {
   }>;
   /** The video's script — the base Matt improvised from. Empty when unwritten. */
   script: string;
+  /** Quiz ids owned by other videos in this course. */
+  quizIds: string[];
 }
 
 export const loadWriterContext = Effect.fn("loadWriterContext")(function* (
@@ -258,6 +261,7 @@ export const loadWriterContext = Effect.fn("loadWriterContext")(function* (
       links: globalLinks,
       beats,
       script: video.script ?? "",
+      quizIds: [],
     } satisfies WriterContextData;
   }
 
@@ -265,6 +269,11 @@ export const loadWriterContext = Effect.fn("loadWriterContext")(function* (
   const relLessonDir = yield* versionOps.resolveLessonDir(lesson.id);
   const [currentSectionPath = "", currentLessonPath = ""] =
     relLessonDir.split("/");
+
+  const quizIds = yield* loadOtherVideosQuizIds({
+    versionId: section.repoVersion.id,
+    videoId,
+  });
 
   const [courseStructure, repoWithSections] = yield* Effect.all(
     [
@@ -294,5 +303,6 @@ export const loadWriterContext = Effect.fn("loadWriterContext")(function* (
     links: globalLinks,
     beats,
     script: video.script ?? "",
+    quizIds,
   } satisfies WriterContextData;
 });


### PR DESCRIPTION
Second of three. **Stacked on `quiz-render` (#1522)** — review that first.

## Authoring

`app/prompts/quiz-instructions.ts` carries the contract and the doctrine into the **article** prompt only. Skill-building is left alone: that body is the steps the reader is about to perform.

The syntax is deliberately a second copy of the `creating-content` skill's `quizzes.md` (article drafting moves out of the CVM later, and the skill has to stand alone). Each file names the other.

## Ids

`getCourseVideoBodies(versionId)` is the one query behind both readers of quiz ids. From it:

- **Into the prompt** — the ids other videos own, so the writer picks a free one.
- **Into the lint** — `quiz-id-taken` flags a collision as you type, with a deterministic suffix fix (`subagent-context-isolation-2`). The suffix names nothing, and that is accepted: the rule protects response data keyed to the id, and a suffix appearing at all says two lessons test the same concept — a content problem no id was going to fix.

The rename works by source offset and keeps the *first* honest use, renaming the repeat.

## Lint scoping

`LintRule` gains `detect` (for a rule a regex cannot express) and a `LintContext` (what the loader knows and the document does not). Prose rules now scan a masked document where a quiz shows only its `question`, `answer` and choice labels — an em-dash fix landing on an `id` or on the JSX would break the block.

## Checks

`pnpm typecheck` clean. `pnpm vitest run app/features/article-writer app/hooks` — 225 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)