### PR TITLE
quiz: a duplicate quiz id refuses the publish

### DIFF
--- a/app/cli/commands/course-readiness.ts
+++ b/app/cli/commands/course-readiness.ts
@@ -98,7 +98,10 @@ OUTPUT (one pretty JSON object)
                         "<sectionPath>/<lessonPath>/<title>".
   courseViewLints[]     Lesson Warnings + Video Warnings on the effective
                         output, itemised: { scope, sectionPath, lessonPath,
-                        kind } plus videoTitle when scope is "video".
+                        kind } plus videoTitle when scope is "video". A
+                        course-scope entry belongs to no single video —
+                        { scope: "course", kind: "duplicateQuizId", quizId,
+                        videoPaths[] } names every video sharing one quiz id.
   invalidLessonCombos[] Lessons whose Video roles are ambiguous (e.g. a
                         Solution with no Problem).
   incompleteVideos[]    Shipping Videos missing a required field.

--- a/app/features/course-view/course-view-loader.server.ts
+++ b/app/features/course-view/course-view-loader.server.ts
@@ -7,7 +7,10 @@ import {
   loadLessonFsMaps,
   toSlimVideo,
 } from "@/services/course-loader-fs";
-import { computeLessonWarnings } from "@/services/lesson-warnings";
+import {
+  computeLessonWarnings,
+  findCourseQuizIdCollisions,
+} from "@/services/lesson-warnings";
 import { toExportClips } from "@/services/export-hash";
 import { runtimeLive } from "@/services/layer.server";
 
@@ -82,6 +85,15 @@ export function courseViewEffect(input: {
     const slimCourse = selectedCourse
       ? (() => {
           const { versions, sections, ...courseRest } = selectedCourse;
+          // A duplicate quiz id belongs to no single video, so it cannot come
+          // out of computeVideoWarnings. One walk of the course names every
+          // video in a clash, and each of them carries the warning on its row —
+          // the pair is only fixable when both ends are visible.
+          const videosInQuizIdClash = new Set(
+            findCourseQuizIdCollisions(sections).flatMap((collision) =>
+              collision.uses.map((use) => use.videoId)
+            )
+          );
           return {
             ...courseRest,
             sections: sections.map((section) => {
@@ -92,7 +104,18 @@ export function courseViewEffect(input: {
                   const { videos, ...lessonRest } = lesson;
                   return {
                     ...lessonRest,
-                    videos: videos.map(toSlimVideo),
+                    videos: videos.map((video) => {
+                      const slim = toSlimVideo(video);
+                      return videosInQuizIdClash.has(video.id)
+                        ? {
+                            ...slim,
+                            warnings: [
+                              ...slim.warnings,
+                              { kind: "duplicateQuizId" as const },
+                            ],
+                          }
+                        : slim;
+                    }),
                     lessonWarnings: computeLessonWarnings({ videos }),
                   };
                 }),

--- a/app/features/course-view/video-warning-labels.ts
+++ b/app/features/course-view/video-warning-labels.ts
@@ -4,6 +4,7 @@ export const VIDEO_WARNING_LABELS: Record<VideoWarning["kind"], string> = {
   missingChapters: "Missing chapters",
   missingBody: "Missing lesson body",
   missingDescription: "Missing SEO description",
+  duplicateQuizId: "Duplicate quiz id",
 };
 
 export function videoWarningLabel(warnings: VideoWarning[]): string {

--- a/app/routes/_app.courses.$courseId.publish.tsx
+++ b/app/routes/_app.courses.$courseId.publish.tsx
@@ -319,33 +319,50 @@ export default function Component(props: Route.ComponentProps) {
               </span>
             </div>
             <ul className="space-y-1.5">
-              {courseViewLints.map((lint, index) => (
-                <li
-                  key={`${lint.sectionPath}/${lint.lessonPath}/${
-                    lint.scope === "video" ? lint.videoTitle : "lesson"
-                  }/${lint.kind}/${index}`}
-                  className="text-xs text-muted-foreground"
-                >
-                  <span className="font-medium text-foreground">
-                    {lint.scope === "video"
-                      ? lint.videoTitle
-                      : lint.lessonPath || "Lesson"}
-                  </span>{" "}
-                  <span className="text-amber-500">
-                    (
-                    {lint.scope === "video"
-                      ? VIDEO_WARNING_LABELS[lint.kind]
-                      : LESSON_WARNING_LABELS[lint.kind]}
-                    )
-                  </span>
-                  <span className="block text-muted-foreground/70">
-                    {lint.sectionPath}
-                    {lint.scope === "video" && lint.lessonPath
-                      ? ` / ${lint.lessonPath}`
-                      : ""}
-                  </span>
-                </li>
-              ))}
+              {courseViewLints.map((lint, index) =>
+                lint.scope === "course" ? (
+                  <li
+                    key={`course/${lint.quizId}/${index}`}
+                    className="text-xs text-muted-foreground"
+                  >
+                    <span className="font-medium text-foreground">
+                      {lint.quizId}
+                    </span>{" "}
+                    <span className="text-amber-500">
+                      ({VIDEO_WARNING_LABELS[lint.kind]})
+                    </span>
+                    <span className="block text-muted-foreground/70">
+                      {lint.videoPaths.join(" · ")}
+                    </span>
+                  </li>
+                ) : (
+                  <li
+                    key={`${lint.sectionPath}/${lint.lessonPath}/${
+                      lint.scope === "video" ? lint.videoTitle : "lesson"
+                    }/${lint.kind}/${index}`}
+                    className="text-xs text-muted-foreground"
+                  >
+                    <span className="font-medium text-foreground">
+                      {lint.scope === "video"
+                        ? lint.videoTitle
+                        : lint.lessonPath || "Lesson"}
+                    </span>{" "}
+                    <span className="text-amber-500">
+                      (
+                      {lint.scope === "video"
+                        ? VIDEO_WARNING_LABELS[lint.kind]
+                        : LESSON_WARNING_LABELS[lint.kind]}
+                      )
+                    </span>
+                    <span className="block text-muted-foreground/70">
+                      {lint.sectionPath}
+                      {lint.scope === "video" && lint.lessonPath
+                        ? ` / ${lint.lessonPath}`
+                        : ""}
+                    </span>
+                  </li>
+                )
+              )}
             </ul>
           </div>
         )}

--- a/app/services/lesson-warnings.test.ts
+++ b/app/services/lesson-warnings.test.ts
@@ -325,3 +325,86 @@ describe("collectCourseViewLints", () => {
     });
   });
 });
+
+describe("course-scope quiz id lints", () => {
+  const quiz = (id: string) => `<Quiz>
+  <QuizQuestion data={{
+    id: "${id}",
+    question: "Which one?",
+    type: "multiple-choice",
+    choices: [
+      { answer: "a", label: "One" },
+      { answer: "b", label: "Two" }
+    ],
+    correct: "a",
+    answer: "Because."
+  }} />
+</Quiz>`;
+
+  const videoWith = (title: string, body: string) => ({
+    id: title,
+    title,
+    body,
+    description: "A description.",
+    lessonId: "lesson-1",
+    clips: [{ order: "a1", archived: false }],
+    chapters: [{ order: "a0", archived: false }],
+  });
+
+  const course = (bodies: [string, string][]) => [
+    {
+      path: "01-intro",
+      lessons: [
+        {
+          path: "01-a",
+          videos: bodies.map(([title, body]) => videoWith(title, body)),
+        },
+      ],
+    },
+  ];
+
+  it("raises one lint naming both videos that share an id", () => {
+    const lints = collectCourseViewLints(
+      course([
+        ["Explainer", quiz("shared")],
+        ["Solution", quiz("shared")],
+      ])
+    ).filter((lint) => lint.scope === "course");
+
+    expect(lints).toEqual([
+      {
+        scope: "course",
+        kind: "duplicateQuizId",
+        quizId: "shared",
+        videoPaths: ["01-intro/01-a/Explainer", "01-intro/01-a/Solution"],
+      },
+    ]);
+  });
+
+  it("raises nothing when every id is unique", () => {
+    expect(
+      collectCourseViewLints(
+        course([
+          ["Explainer", quiz("first")],
+          ["Solution", quiz("second")],
+        ])
+      ).filter((lint) => lint.scope === "course")
+    ).toEqual([]);
+  });
+
+  it("blocks a publish by counting toward the course-view lints", () => {
+    const clean = computeCourseViewLintCount(
+      course([
+        ["Explainer", quiz("first")],
+        ["Solution", quiz("second")],
+      ])
+    );
+    const clashing = computeCourseViewLintCount(
+      course([
+        ["Explainer", quiz("shared")],
+        ["Solution", quiz("shared")],
+      ])
+    );
+    expect(clashing).toBe(clean + 1);
+  });
+});

--- a/app/services/lesson-warnings.ts
+++ b/app/services/lesson-warnings.ts
@@ -1,4 +1,9 @@
 import { computeVideoWarnings, type VideoWarningKind } from "./video-warnings";
+import {
+  collectCourseQuizIdUses,
+  findQuizIdCollisions,
+  type VideoBody,
+} from "@/features/article-writer/quiz-ids";
 
 export type LessonWarningKind =
   | "solutionWithoutProblem"
@@ -80,6 +85,7 @@ export const computeLessonWarnings = (input: {
 };
 
 type LintVideo = {
+  id?: string;
   title: string;
   archived?: boolean;
   lessonId?: string | null;
@@ -99,6 +105,19 @@ type LintSection = { path?: string; lessons: LintLesson[] };
  * body, or SEO description).
  */
 export type CourseViewLint =
+  | {
+      /**
+       * A problem belonging to no single video — the first lint of this shape.
+       * A duplicate quiz id is a property of a *pair* of videos, so it is
+       * reported once, naming both, rather than half-reported on each.
+       */
+      scope: "course";
+      kind: "duplicateQuizId";
+      /** The id two or more videos share. */
+      quizId: string;
+      /** Every video using it, as `section/lesson/title`. */
+      videoPaths: string[];
+    }
   | {
       scope: "lesson";
       sectionPath: string;
@@ -159,7 +178,41 @@ export function collectCourseViewLints(
       }
     }
   }
+
+  for (const collision of findCourseQuizIdCollisions(sections)) {
+    lints.push({
+      scope: "course",
+      kind: "duplicateQuizId",
+      quizId: collision.id,
+      videoPaths: collision.uses.map((use) => use.videoTitle),
+    });
+  }
+
   return lints;
+}
+
+/**
+ * Quiz ids shared by two or more videos anywhere in the course.
+ *
+ * Shared with the course view, which flags each offending video row: one walk
+ * so a row and the publish gate can never disagree about what clashes.
+ */
+export function findCourseQuizIdCollisions(sections: LintSection[]) {
+  const bodies: VideoBody[] = [];
+  for (const section of sections) {
+    for (const lesson of section.lessons) {
+      for (const video of lesson.videos) {
+        if (video.archived) continue;
+        bodies.push({
+          videoId: video.id ?? video.title,
+          // The full path, so a lint names a video the reader can find.
+          videoTitle: `${section.path ?? ""}/${lesson.path ?? ""}/${video.title}`,
+          body: video.body ?? null,
+        });
+      }
+    }
+  }
+  return findQuizIdCollisions(collectCourseQuizIdUses(bodies));
 }
 
 export function computeCourseViewLintCount(sections: LintSection[]): number {

--- a/app/services/video-warnings.ts
+++ b/app/services/video-warnings.ts
@@ -1,5 +1,13 @@
 export type VideoWarningKind =
-  "missingChapters" | "missingBody" | "missingDescription";
+  | "missingChapters"
+  | "missingBody"
+  | "missingDescription"
+  /**
+   * A quiz id this video shares with another. Unlike its siblings this one is
+   * not computable from the video alone — see collectCourseViewLints, which
+   * raises it from the whole-course walk.
+   */
+  | "duplicateQuizId";
 
 export type VideoWarning = { kind: VideoWarningKind };
 


### PR DESCRIPTION
Third of three. **Stacked on `quiz-authoring` (#1523)**, which is stacked on `quiz-render` (#1522).

## The new shape

`CourseViewLint` has only ever described a lesson or a video. A duplicate quiz id belongs to neither — it is a property of a *pair* of videos — so this adds a third scope:

```ts
{ scope: "course", kind: "duplicateQuizId", quizId, videoPaths: string[] }
```

Reported once, naming every video in the clash. Put it on the rows alone and you have one problem shown twice, each half unfixable on its own.

## Where it lands

- **Publish** — a non-zero `courseViewLintCount` already raises `PublishValidationError`, so joining that walk is the whole gate. Deliberate: the contract says a changed id orphans response data, and a duplicate silently merges two questions' history.
- **Publish page** — rendered in the existing warnings list, showing the id and every video using it.
- **Course view** — each offending video row carries a `duplicateQuizId` warning, from the same `findCourseQuizIdCollisions` walk, so a row and the gate cannot drift. The existing course-warning badge counts it for free.
- **`cvm course-readiness`** — the entry appears in `courseViewLints[]`; the help text documents the course scope.

## Checks

`pnpm typecheck` clean. `pnpm vitest run app/services app/features/article-writer app/hooks` — 1111 pass. One failure, `course-publish-service-video-tasks.test.ts` ("attributes an upload failure to the one Video whose bytes never landed"), is **pre-existing**: it fails identically on `quiz-render` before any change in this branch, and concerns Dropbox upload attribution rather than lints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)