### PR TITLE
cvm search: match a video's body

### DIFF
--- a/app/cli/cli-search.test.ts
+++ b/app/cli/cli-search.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
 import {
   createTestDb,
   truncateAllTables,
@@ -259,6 +260,101 @@ describe("search", () => {
       const err = JSON.parse(stderr);
       expect(err._tag).toBe("NotFoundError");
       expect(err.entity).toBe("lesson");
+    });
+  });
+
+  describe("video body (the shipped article)", () => {
+    /** Author a body onto a video; the seed leaves every body null. */
+    const setBody = (videoId: string, body: string) =>
+      testDb
+        .update(schema.videos)
+        .set({ body })
+        .where(eq(schema.videos.id, videoId));
+
+    it("matches a video's body and returns the VIDEO", async () => {
+      await setBody(s.lessonVideoId, "The satisfies operator narrows a value.");
+
+      const { stdout, stderr, exitCode } = await run(["search", "satisfies"]);
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      const hits = ndjson(stdout) as any[];
+      expect(hits).toHaveLength(1);
+      expect(hits[0]).toMatchObject({
+        kind: "video",
+        id: s.lessonVideoId,
+        lessonId: s.lessonId,
+        courseId: s.courseAId,
+        field: "body",
+      });
+      expect(hits[0].snippet).toContain("satisfies");
+    });
+
+    it("body beats transcript for a video's field label", async () => {
+      await setBody(s.lessonVideoId, "we say hello in the article too");
+
+      const { stdout } = await run(["search", "hello"]);
+      const video = (ndjson(stdout) as any[]).find((h) => h.kind === "video");
+      expect(video).toMatchObject({ id: s.lessonVideoId, field: "body" });
+    });
+
+    it("title beats body for a video's field label", async () => {
+      await setBody(s.lessonVideoId, "an intro to the intro");
+
+      const { stdout } = await run(["search", "intro"]);
+      const video = (ndjson(stdout) as any[]).find((h) => h.kind === "video");
+      expect(video).toMatchObject({ id: s.lessonVideoId, field: "title" });
+    });
+
+    it("never returns an archived video's body", async () => {
+      await setBody(s.archivedLessonVideoId, "buried article text");
+
+      const { stdout, exitCode } = await run(["search", "buried"]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toBe("");
+    });
+
+    it("excludes body hits when --type omits video", async () => {
+      await setBody(s.lessonVideoId, "unique-body-token");
+
+      const { stdout } = await run([
+        "search",
+        "--type",
+        "beat",
+        "unique-body-token",
+      ]);
+      expect(stdout).toBe("");
+    });
+
+    it("finds a body from a scoped lesson search", async () => {
+      await setBody(s.lessonVideoId, "scoped article mentions closures");
+
+      const { stdout, exitCode } = await run([
+        "lesson",
+        "search",
+        s.lessonId,
+        "closures",
+      ]);
+      expect(exitCode).toBe(0);
+      const hits = ndjson(stdout) as any[];
+      expect(hits).toHaveLength(1);
+      expect(hits[0]).toMatchObject({
+        kind: "video",
+        id: s.lessonVideoId,
+        field: "body",
+      });
+    });
+
+    it("excerpts a long body with ellipses around the match", async () => {
+      const long = `${"lorem ipsum ".repeat(20)}BODYNEEDLE${" dolor sit ".repeat(20)}`;
+      await setBody(s.lessonVideoId, long);
+
+      const { stdout } = await run(["search", "BODYNEEDLE"]);
+      const hit = (ndjson(stdout) as any[]).find((h) => h.kind === "video");
+      expect(hit.field).toBe("body");
+      expect(hit.snippet).toContain("BODYNEEDLE");
+      expect(hit.snippet.startsWith("…")).toBe(true);
+      expect(hit.snippet.endsWith("…")).toBe(true);
+      expect(hit.snippet.length).toBeLessThan(long.length);
     });
   });
 

--- a/app/cli/commands/search.ts
+++ b/app/cli/commands/search.ts
@@ -102,17 +102,19 @@ WHAT IS SEARCHED (archived records are never returned; Draft Version only)
   course    name, slug
   section   path, description
   lesson    path, title, description
-  video     path, and its TRANSCRIPT (clip text + chapter names)
+  video     title, its BODY (the shipped article), and its TRANSCRIPT
+            (clip text + chapter names)
   beat      title, description
   pitch     title, description, contentPlan, youtubeTitle,
             youtubeThumbnailDescription, newsletterTitle, tweet
 
 RESULTS (NDJSON — one compact hit per line; empty result prints nothing, exit 0)
   Each hit is self-describing: { kind, id, <identity>, <parent ids>, courseId,
-  field, snippet }. 'field' is the matched field (path beats transcript for a
-  video); 'snippet' is an excerpt around the match (the whole value for short
-  fields). One hit per entity. Hits stream in depth-first tree order (course ->
-  sections -> lessons -> videos -> beats), courses in 'course list' order,
+  field, snippet }. 'field' is the matched field (for a video, title beats body,
+  body beats transcript); 'snippet' is an excerpt around the match (the whole
+  value for short fields). One hit per entity. Hits stream in depth-first tree
+  order (course -> sections -> lessons -> videos -> beats), courses in
+  'course list' order,
   pitches last. Use 'cvm <noun> get <id>' for the full record.
 
 --type (repeatable) narrows result kinds; default is every kind above.

--- a/app/services/db-search-operations.server.ts
+++ b/app/services/db-search-operations.server.ts
@@ -138,6 +138,8 @@ type BeatNode = {
 type VideoNode = {
   id: string;
   title: string;
+  /** The shipped article. Null until a body is authored. */
+  body: string | null;
   lessonId: string;
   beats: BeatNode[];
 };
@@ -174,7 +176,7 @@ const sectionWith = {
       orderBy: asc(lessons.order),
       with: {
         videos: {
-          columns: { id: true, title: true, lessonId: true },
+          columns: { id: true, title: true, body: true, lessonId: true },
           where: eq(videos.archived, false),
           orderBy: asc(videos.title),
           with: {
@@ -202,9 +204,9 @@ export const createSearchOperations = (db: Database) => {
    *
    * Returns hits in depth-first Draft-tree order (course -> sections -> lessons
    * -> videos -> beats), courses in `course list` order, pitches last. One
-   * hit per entity (first matching field wins, path before transcript). When a
-   * scoped `root` id is missing or archived, returns `null` so the CLI can own
-   * not-found detection.
+   * hit per entity (first matching field wins: for a video, title before body
+   * before transcript). When a scoped `root` id is missing or archived, returns
+   * `null` so the CLI can own not-found detection.
    */
   const search = Effect.fn("search")(function* (params: SearchParams) {
     const { root, query, types } = params;
@@ -432,10 +434,14 @@ export const createSearchOperations = (db: Database) => {
 
     const emitVideo = (v: VideoNode, cid: string) => {
       if (want("video")) {
+        // Title, then the shipped body, then the transcript: the shorter and
+        // more deliberate the text, the stronger the signal it is the reason
+        // this video matched.
         const m =
-          (matches(v.title)
-            ? { field: "title", snippet: snippet(v.title) }
-            : null) ?? transcriptMatch.get(v.id);
+          firstMatch([
+            ["title", v.title],
+            ["body", v.body ?? ""],
+          ]) ?? transcriptMatch.get(v.id);
         if (m)
           hits.push({
             kind: "video",


### PR DESCRIPTION
## What

`cvm search` searched a video's **title** and its **transcript**, but never its **body** — the article the lesson ships as. A search for a phrase that lives only in authored prose returned nothing.

The body is now a searched field. Order for a video hit: `title` → `body` → `transcript`. The hit reports `field: "body"` with the usual windowed snippet, and works in the scoped verbs (`cvm course|section|lesson search`) too.

## How

- `db-search-operations.server.ts` — the video selection loads `body`, and `emitVideo` matches it through the shared `firstMatch` helper. No new query: the body sits on the video row that the tree walk already reads.
- `commands/search.ts` — help text for the video line and the field-precedence note.

## Notes

- Body only. The SEO `description` and the internal `script` are still unsearched.
- 7 new cases in `cli-search.test.ts` (33 pass). `typecheck` and `check:file-tokens` clean.
- `cli-segment-writes.test.ts` and `cli-backup-coordination.test.ts` fail 20 tests on this branch — verified identical on `main` with this change stashed, so they are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)