### PR TITLE
commit-maps: render and lint commit maps in lesson bodies

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -271,7 +271,7 @@ _Avoid_: Test, Assessment, Question block, Exercise (reserved for the course's p
 
 **Commit Map**:
 The list of commits a lesson uses, at the top of a **Video**'s `body` — `<CommitMap>` wrapping one or more `<Commit id="…">` commit map entries. Each entry's `id` is a slug naming a lesson commit in the course project repo, which the CVM never reads; `main` is the one id that is not a slug. The first entry is where a reader starts the lesson. Stored verbatim and shipped unparsed by **Publish**, like a **Quiz**, but never rewritten for the preview — an `id` is a plain attribute, so the card reads the markup as authored. Authored by hand; the Article Writer writes one only when asked.
-_Avoid_: Reset point, Checkpoint; not **Course Version** `commitState`, which is Dropbox publish state
+_Avoid_: Checkpoint, Commit list, **Course Version** `commitState` (Dropbox publish state, unrelated). "Reset point" names what the first entry is _for_, never an entry in general — a later entry is a cherry-pick target too.
 
 ### Video destinations
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -269,6 +269,10 @@ _Avoid_: Swap icon, Change icon, Edit icon (an Icon has no edit mode — `canEdi
 A block of questions embedded in a **Video**'s `body`, answered by the reader on aihero.dev. Stored verbatim in the AI Hero authoring contract — `<Quiz>` wrapping one or more `<QuizQuestion data={{ … }} />` tags, each a static object literal — and shipped unparsed by **Publish**, which treats the body as opaque text. The CVM reads it for three jobs only: drawing a static preview card, cutting one question at its exact source range, and linting it. Every question carries an `id` unique across the **Course**, because reader responses are keyed to the id rather than to the question text. Written by the Article Writer in `article` mode; rendered in every preview.
 _Avoid_: Test, Assessment, Question block, Exercise (reserved for the course's practical work)
 
+**Commit Map**:
+The list of commits a lesson uses, at the top of a **Video**'s `body` — `<CommitMap>` wrapping one or more `<Commit id="…">` commit map entries. Each entry's `id` is a slug naming a lesson commit in the course project repo, which the CVM never reads; `main` is the one id that is not a slug. The first entry is where a reader starts the lesson. Stored verbatim and shipped unparsed by **Publish**, like a **Quiz**, but never rewritten for the preview — an `id` is a plain attribute, so the card reads the markup as authored. Authored by hand; the Article Writer writes one only when asked.
+_Avoid_: Reset point, Checkpoint; not **Course Version** `commitState`, which is Dropbox publish state
+
 ### Video destinations
 
 **Skills Changelog**:

--- a/app/features/article-writer/commit-map-card.tsx
+++ b/app/features/article-writer/commit-map-card.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { AlertTriangleIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+/**
+ * The preview's stand-in for a commit map on aihero.dev.
+ *
+ * Deliberately static: the site's card carries a Copy dropdown offering
+ * `pnpm reset <slug>` and `pnpm cherry-pick <slug>`, and this one shows those
+ * commands as plain text. The author is proofreading the map, not resetting a
+ * repo — and the CVM has no repo to reset.
+ */
+export function CommitMapCard({
+  children,
+  problems,
+}: {
+  children: ReactNode;
+  problems: string[];
+}) {
+  return (
+    <div className="my-6 space-y-3 rounded-lg border border-border bg-muted/30 p-4">
+      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Commits
+      </div>
+      {children}
+      <CardProblems problems={problems} />
+    </div>
+  );
+}
+
+/**
+ * One commit map entry.
+ *
+ * `main` is the one id that is not a slug: it names the course repo's starting
+ * point, the state a student clones. The site disables cherry-pick for it,
+ * because there is nothing to cherry-pick onto a branch that is already there.
+ */
+export function CommitEntryCard({
+  id,
+  description,
+  problems,
+}: {
+  id: string | null;
+  description: ReactNode;
+  problems: string[];
+}) {
+  return (
+    <div className="relative rounded-md border border-border bg-background p-3">
+      <div className="font-mono text-sm font-semibold">
+        {id ?? <span className="text-destructive">(no id)</span>}
+      </div>
+
+      <div className="mt-1 text-sm text-muted-foreground [&_p]:my-0">
+        {typeof description === "string" ? (
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {description}
+          </ReactMarkdown>
+        ) : (
+          description
+        )}
+      </div>
+
+      {id ? (
+        <div className="mt-2 space-y-0.5 border-t border-border pt-2 font-mono text-[11px] text-muted-foreground/70">
+          <div>pnpm reset {id}</div>
+          {id === "main" ? null : <div>pnpm cherry-pick {id}</div>}
+        </div>
+      ) : null}
+
+      <CardProblems problems={problems} />
+    </div>
+  );
+}
+
+function CardProblems({ problems }: { problems: string[] }) {
+  if (problems.length === 0) return null;
+
+  return (
+    <ul className="mt-2 space-y-1 rounded-sm bg-destructive/10 p-2 text-xs text-destructive">
+      {problems.map((problem) => (
+        <li key={problem} className="flex items-start gap-1.5">
+          <AlertTriangleIcon className="mt-0.5 size-3 shrink-0" />
+          <span>{problem}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/features/article-writer/commit-map-components.test.tsx
+++ b/app/features/article-writer/commit-map-components.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AIResponse } from "components/ui/kibo-ui/ai/response";
+import { COMMIT_MAP_COMPONENTS } from "./commit-map-components";
+
+/**
+ * The card is checked through the real renderer, not by calling it directly.
+ * Its breach checks read the element tree react-markdown builds, and that tree
+ * is the thing worth pinning: a check written against the wrong element type
+ * fails silently, showing a clean card over broken markup.
+ */
+function render(body: string) {
+  return renderToStaticMarkup(
+    <AIResponse
+      imageBasePath="/videos/1"
+      extraComponents={COMMIT_MAP_COMPONENTS}
+    >
+      {body}
+    </AIResponse>
+  );
+}
+
+const CONTIGUOUS = `<CommitMap>
+  <Commit id="main">The course start</Commit>
+  <Commit id="add-settings-json">See my solution</Commit>
+</CommitMap>`;
+
+const BLANK_LINE = `<CommitMap>
+  <Commit id="main">The course start</Commit>
+
+  <Commit id="add-settings-json">See my solution</Commit>
+</CommitMap>`;
+
+const REPEATED = `<CommitMap>
+  <Commit id="main">The course start</Commit>
+  <Commit id="main">Again</Commit>
+</CommitMap>`;
+
+describe("commit map card", () => {
+  it("draws an entry with its id, description and commands", () => {
+    const html = render(CONTIGUOUS);
+
+    expect(html).toContain("add-settings-json");
+    expect(html).toContain("See my solution");
+    expect(html).toContain("pnpm reset add-settings-json");
+    expect(html).toContain("pnpm cherry-pick add-settings-json");
+  });
+
+  it("offers no cherry-pick for main", () => {
+    const html = render(CONTIGUOUS);
+
+    expect(html).toContain("pnpm reset main");
+    expect(html).not.toContain("pnpm cherry-pick main");
+  });
+
+  it("reports nothing against a contiguous map", () => {
+    expect(render(CONTIGUOUS)).not.toContain("blank line");
+  });
+
+  it("reports a blank line inside the block", () => {
+    // The wrapper the blank line introduces is not a `p` element by the time
+    // it reaches the card — the preview maps `p` to its own component — so the
+    // check reads "not an entry" instead.
+    expect(render(BLANK_LINE)).toContain("blank line");
+  });
+
+  it("still finds a repeated id when a blank line has nested the entries", () => {
+    const html = render(`<CommitMap>
+  <Commit id="main">The course start</Commit>
+
+  <Commit id="main">Again</Commit>
+</CommitMap>`);
+
+    expect(html).toContain("more than once");
+  });
+
+  it("reports a repeated id", () => {
+    expect(render(REPEATED)).toContain("more than once");
+  });
+
+  it("reports an entry with no id", () => {
+    const html = render(`<CommitMap>
+  <Commit>Nameless</Commit>
+</CommitMap>`);
+
+    expect(html).toContain("no id");
+  });
+
+  it("is static — it draws no buttons", () => {
+    expect(render(CONTIGUOUS)).not.toContain("<button");
+  });
+});

--- a/app/features/article-writer/commit-map-components.tsx
+++ b/app/features/article-writer/commit-map-components.tsx
@@ -23,21 +23,38 @@ const DuplicateIdsContext = createContext<ReadonlySet<string>>(new Set());
 
 type SlotProps = HTMLAttributes<HTMLElement> & Record<string, unknown>;
 
-function childIds(children: ReactNode): string[] {
-  return Children.toArray(children)
-    .filter(isValidElement)
-    .map((child) => (child.props as { id?: unknown }).id)
-    .filter((id): id is string => typeof id === "string" && id.length > 0);
+/**
+ * Every entry's id, however deep.
+ *
+ * A blank line nests the entries inside a wrapper, so a walk of the direct
+ * children alone would miss all but the first — and miss them silently, which
+ * is the worst way for a check to fail.
+ */
+function entryIds(children: ReactNode, into: string[] = []): string[] {
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    if (child.type === CommitEntrySlot) {
+      const id = (child.props as { id?: unknown }).id;
+      if (typeof id === "string" && id.length > 0) into.push(id);
+      return;
+    }
+    entryIds((child.props as { children?: ReactNode }).children, into);
+  });
+  return into;
 }
 
 /**
  * A blank line inside the block makes markdown parse the children early and
  * wrap them in a paragraph. Both shapes render, which is exactly why only one
  * of them is legal — the author cannot see the difference without being told.
+ *
+ * The wrapper is found by what it is *not*: an entry. Testing for a `p` element
+ * would never fire, because the preview maps `p` to its own component, so the
+ * element type is that function and never the string.
  */
-function hasParagraphChild(children: ReactNode): boolean {
+function hasWrappedEntries(children: ReactNode): boolean {
   return Children.toArray(children).some(
-    (child) => isValidElement(child) && child.type === "p"
+    (child) => isValidElement(child) && child.type !== CommitEntrySlot
   );
 }
 
@@ -46,12 +63,12 @@ function CommitMapSlot(props: SlotProps) {
 
   const seen = new Set<string>();
   const duplicates = new Set<string>();
-  for (const id of childIds(children)) {
+  for (const id of entryIds(children)) {
     if (seen.has(id)) duplicates.add(id);
     seen.add(id);
   }
 
-  const problems = hasParagraphChild(children)
+  const problems = hasWrappedEntries(children)
     ? [
         "This map has a blank line inside it. Close the gaps — the whole block must be one run of lines.",
       ]

--- a/app/features/article-writer/commit-map-components.tsx
+++ b/app/features/article-writer/commit-map-components.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Children, createContext, isValidElement, useContext } from "react";
+import type { HTMLAttributes, ReactNode } from "react";
+import type { Options } from "react-markdown";
+import { CommitEntryCard, CommitMapCard } from "./commit-map-card";
+
+/**
+ * No rewrite: a commit map goes into the preview exactly as authored.
+ *
+ * Quizzes are rewritten before parsing because `data={{ … }}` is a JS object
+ * literal and an HTML attribute cannot hold one. A commit map carries a plain
+ * `id="…"` attribute and text children, so the HTML parser takes it as it
+ * stands — it only lowercases the tag names, which is why these keys are
+ * `commitmap` and `commit`. Nothing here needs a scanner, and adding one for
+ * symmetry with the quiz would buy nothing.
+ */
+export const COMMIT_MAP_TAG_NAME = "commitmap";
+export const COMMIT_ENTRY_TAG_NAME = "commit";
+
+/** Ids the surrounding map uses more than once. */
+const DuplicateIdsContext = createContext<ReadonlySet<string>>(new Set());
+
+type SlotProps = HTMLAttributes<HTMLElement> & Record<string, unknown>;
+
+function childIds(children: ReactNode): string[] {
+  return Children.toArray(children)
+    .filter(isValidElement)
+    .map((child) => (child.props as { id?: unknown }).id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+}
+
+/**
+ * A blank line inside the block makes markdown parse the children early and
+ * wrap them in a paragraph. Both shapes render, which is exactly why only one
+ * of them is legal — the author cannot see the difference without being told.
+ */
+function hasParagraphChild(children: ReactNode): boolean {
+  return Children.toArray(children).some(
+    (child) => isValidElement(child) && child.type === "p"
+  );
+}
+
+function CommitMapSlot(props: SlotProps) {
+  const children = props.children as ReactNode;
+
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const id of childIds(children)) {
+    if (seen.has(id)) duplicates.add(id);
+    seen.add(id);
+  }
+
+  const problems = hasParagraphChild(children)
+    ? [
+        "This map has a blank line inside it. Close the gaps — the whole block must be one run of lines.",
+      ]
+    : [];
+
+  return (
+    <DuplicateIdsContext.Provider value={duplicates}>
+      <CommitMapCard problems={problems}>{children}</CommitMapCard>
+    </DuplicateIdsContext.Provider>
+  );
+}
+
+function CommitEntrySlot(props: SlotProps) {
+  const duplicates = useContext(DuplicateIdsContext);
+  const rawId = props.id;
+  const id = typeof rawId === "string" && rawId.length > 0 ? rawId : null;
+
+  const problems: string[] = [];
+  if (id === null) {
+    problems.push(
+      'This entry has no id. Give it the slug of the commit it names, or "main" for the course start.'
+    );
+  } else if (duplicates.has(id)) {
+    problems.push("This id appears more than once in the map.");
+  }
+
+  return (
+    <CommitEntryCard
+      id={id}
+      description={props.children as ReactNode}
+      problems={problems}
+    />
+  );
+}
+
+/**
+ * The tag → component map handed to `AIResponse`. A module constant for the
+ * same reason {@link import("./quiz-components").QUIZ_COMPONENTS} is one:
+ * react-markdown uses the mapped value as the React element *type*, so a fresh
+ * object on each render remounts every card.
+ */
+export const COMMIT_MAP_COMPONENTS = {
+  [COMMIT_MAP_TAG_NAME]: CommitMapSlot as unknown,
+  [COMMIT_ENTRY_TAG_NAME]: CommitEntrySlot as unknown,
+} as Options["components"];

--- a/app/features/article-writer/commit-map-syntax.test.ts
+++ b/app/features/article-writer/commit-map-syntax.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  findCommitMapsWithBlankLines,
+  findCommitsMissingId,
+  findCommitsOutsideCommitMap,
+  findRepeatedCommitIds,
+  findUnclosedCommitMaps,
+  parseCommitMaps,
+} from "./commit-map-syntax";
+
+const entry = (id: string | null, description = "Start here") =>
+  id === null
+    ? `  <Commit>${description}</Commit>`
+    : `  <Commit id="${id}">${description}</Commit>`;
+
+const map = (...entries: string[]) =>
+  `<CommitMap>\n${entries.join("\n")}\n</CommitMap>`;
+
+describe("parseCommitMaps", () => {
+  it("reads a map's entries", () => {
+    const blocks = parseCommitMaps(
+      map(entry("main", "The course start"), entry("add-settings-json"))
+    );
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.entries).toEqual([
+      {
+        id: "main",
+        openTag: '<Commit id="main">',
+        description: "The course start",
+      },
+      {
+        id: "add-settings-json",
+        openTag: '<Commit id="add-settings-json">',
+        description: "Start here",
+      },
+    ]);
+  });
+
+  it("keeps markdown in a description as authored", () => {
+    const blocks = parseCommitMaps(
+      map(entry("grill-me-skill", "Added the `/grill-me` skill"))
+    );
+
+    expect(blocks[0]!.entries[0]!.description).toBe(
+      "Added the `/grill-me` skill"
+    );
+  });
+
+  it("does not mistake <CommitMap> for an entry", () => {
+    const blocks = parseCommitMaps(map(entry("main")));
+
+    expect(blocks[0]!.entries).toHaveLength(1);
+  });
+
+  it("reads every map in a body", () => {
+    const blocks = parseCommitMaps(
+      `${map(entry("main"))}\n\nSome prose.\n\n${map(entry("analytics-page"))}`
+    );
+
+    expect(blocks).toHaveLength(2);
+  });
+
+  it("yields no block for an unclosed map", () => {
+    expect(parseCommitMaps(`<CommitMap>\n${entry("main")}`)).toEqual([]);
+  });
+});
+
+describe("findCommitsMissingId", () => {
+  it("finds an entry with no id", () => {
+    expect(findCommitsMissingId(map(entry(null)))).toEqual(["<Commit>"]);
+  });
+
+  it("treats an empty id as missing", () => {
+    expect(
+      findCommitsMissingId(map('  <Commit id="">Nothing</Commit>'))
+    ).toEqual(['<Commit id="">']);
+  });
+
+  it("passes a whole map", () => {
+    expect(
+      findCommitsMissingId(map(entry("main"), entry("run-setup-skill")))
+    ).toEqual([]);
+  });
+});
+
+describe("findRepeatedCommitIds", () => {
+  it("finds an id used twice", () => {
+    expect(findRepeatedCommitIds(map(entry("main"), entry("main")))).toEqual([
+      "main",
+    ]);
+  });
+
+  it("counts across two maps in one body", () => {
+    const text = `${map(entry("main"))}\n\n${map(entry("main"))}`;
+
+    expect(findRepeatedCommitIds(text)).toEqual(["main"]);
+  });
+
+  it("passes distinct ids", () => {
+    expect(
+      findRepeatedCommitIds(map(entry("main"), entry("to-spec-skill")))
+    ).toEqual([]);
+  });
+});
+
+describe("findCommitsOutsideCommitMap", () => {
+  it("finds an entry adrift in the body", () => {
+    expect(
+      findCommitsOutsideCommitMap(`${entry("main")}\n\n${map(entry("main"))}`)
+    ).toEqual(['<Commit id="main">']);
+  });
+
+  it("passes entries inside a map", () => {
+    expect(findCommitsOutsideCommitMap(map(entry("main")))).toEqual([]);
+  });
+
+  it("does not also report the entries of an unclosed map", () => {
+    // The unclosed block is one violation, reported by its own rule. Counting
+    // its entries again would say the same thing three times.
+    const text = `<CommitMap>\n${entry("main")}\n${entry("to-spec-skill")}`;
+
+    expect(findCommitsOutsideCommitMap(text)).toEqual([]);
+  });
+});
+
+describe("findUnclosedCommitMaps", () => {
+  it("finds a map that never closes", () => {
+    expect(findUnclosedCommitMaps(`<CommitMap>\n${entry("main")}`)).toEqual([
+      "<CommitMap>",
+    ]);
+  });
+
+  it("passes a closed map", () => {
+    expect(findUnclosedCommitMaps(map(entry("main")))).toEqual([]);
+  });
+});
+
+describe("findCommitMapsWithBlankLines", () => {
+  it("finds a blank line between entries", () => {
+    const text = `<CommitMap>\n${entry("main")}\n\n${entry("to-spec-skill")}\n</CommitMap>`;
+
+    expect(findCommitMapsWithBlankLines(text)).toEqual(["<CommitMap>"]);
+  });
+
+  it("finds a blank line after the opening tag", () => {
+    const text = `<CommitMap>\n\n${entry("main")}\n</CommitMap>`;
+
+    expect(findCommitMapsWithBlankLines(text)).toEqual(["<CommitMap>"]);
+  });
+
+  it("passes a contiguous block", () => {
+    expect(
+      findCommitMapsWithBlankLines(map(entry("main"), entry("to-spec-skill")))
+    ).toEqual([]);
+  });
+});

--- a/app/features/article-writer/commit-map-syntax.test.ts
+++ b/app/features/article-writer/commit-map-syntax.test.ts
@@ -91,10 +91,10 @@ describe("findRepeatedCommitIds", () => {
     ]);
   });
 
-  it("counts across two maps in one body", () => {
+  it("passes the same id used once in each of two maps", () => {
     const text = `${map(entry("main"))}\n\n${map(entry("main"))}`;
 
-    expect(findRepeatedCommitIds(text)).toEqual(["main"]);
+    expect(findRepeatedCommitIds(text)).toEqual([]);
   });
 
   it("passes distinct ids", () => {

--- a/app/features/article-writer/commit-map-syntax.ts
+++ b/app/features/article-writer/commit-map-syntax.ts
@@ -126,11 +126,17 @@ export function findCommitsMissingId(text: string): string[] {
     .map((entry) => entry.openTag);
 }
 
-/** Ids used more than once across the document's commit maps. */
+/**
+ * Ids a single map uses more than once.
+ *
+ * Counted per map rather than per body: two maps in one body may honestly both
+ * start at the same commit, and a lesson that reset to `main` twice would be
+ * told off for it.
+ */
 export function findRepeatedCommitIds(text: string): string[] {
-  const seen = new Set<string>();
   const repeated = new Set<string>();
   for (const block of parseCommitMaps(text)) {
+    const seen = new Set<string>();
     for (const entry of block.entries) {
       if (entry.id === null) continue;
       if (seen.has(entry.id)) repeated.add(entry.id);

--- a/app/features/article-writer/commit-map-syntax.ts
+++ b/app/features/article-writer/commit-map-syntax.ts
@@ -1,0 +1,177 @@
+/**
+ * Reading a commit map out of a lesson body.
+ *
+ * A commit map is stored verbatim in the AI Hero authoring contract, the same
+ * way a quiz is — but it carries no JS object literal, only an HTML attribute
+ * and text children. So this file is a scanner and nothing more: there is no
+ * `parseObjectLiteral` here, and there should never be one. The preview does
+ * not rewrite commit maps either, because `<Commit id="…">` survives the HTML
+ * parser intact. See `commit-map-components.tsx`.
+ *
+ * Everything here reads the *stored* text, not the preview's. The card sees a
+ * block the parser already accepted; these functions are what the lint uses to
+ * find the blocks it would not accept.
+ */
+
+const OPEN_TAG = "<CommitMap>";
+const CLOSE_TAG = "</CommitMap>";
+
+/** `<Commit …>`, but never `<CommitMap>` — `\b` refuses the longer name. */
+const ENTRY_PATTERN = /<Commit\b([^>]*)>([\s\S]*?)<\/Commit>/g;
+const ENTRY_OPEN_PATTERN = /<Commit\b[^>]*>/g;
+const ID_ATTRIBUTE = /\bid\s*=\s*"([^"]*)"/;
+const BLANK_LINE = /\n[ \t]*\n/;
+
+/** One `<Commit>` inside a map — a commit map entry. */
+export interface CommitMapEntry {
+  /** The slug the `id` attribute carries, or null when it is missing or empty. */
+  id: string | null;
+  /** The raw opening tag, so a violation can point the author at the line. */
+  openTag: string;
+  /** The entry's description, as authored. */
+  description: string;
+}
+
+export interface CommitMapBlock {
+  /** Offset of the `<CommitMap>` that opens the block. */
+  start: number;
+  /** Offset just past the `</CommitMap>` that closes it. */
+  end: number;
+  entries: CommitMapEntry[];
+  /**
+   * A blank line inside the block, which changes how markdown parses it: the
+   * children stop arriving as one raw string and gain a paragraph wrapper.
+   */
+  hasBlankLine: boolean;
+}
+
+interface CommitMapScan {
+  blocks: CommitMapBlock[];
+  /** Offsets of `<CommitMap>` tags that are never closed. */
+  unclosedStarts: number[];
+}
+
+function parseEntries(inner: string): CommitMapEntry[] {
+  const entries: CommitMapEntry[] = [];
+  ENTRY_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ENTRY_PATTERN.exec(inner)) !== null) {
+    const attributes = match[1] ?? "";
+    const id = ID_ATTRIBUTE.exec(attributes)?.[1] ?? "";
+    entries.push({
+      id: id.length > 0 ? id : null,
+      openTag: `<Commit${attributes}>`,
+      description: (match[2] ?? "").trim(),
+    });
+  }
+  return entries;
+}
+
+/**
+ * Every commit map in the text, plus the opening tags that never close.
+ *
+ * An unclosed block yields no `CommitMapBlock`: half a map has no entries worth
+ * reporting on, and the lint that cares about it reads `unclosedStarts`.
+ */
+export function scanCommitMaps(text: string): CommitMapScan {
+  const blocks: CommitMapBlock[] = [];
+  const unclosedStarts: number[] = [];
+
+  let at = 0;
+  while (true) {
+    const start = text.indexOf(OPEN_TAG, at);
+    if (start === -1) break;
+
+    const closeAt = text.indexOf(CLOSE_TAG, start + OPEN_TAG.length);
+    if (closeAt === -1) {
+      unclosedStarts.push(start);
+      break;
+    }
+
+    const inner = text.slice(start + OPEN_TAG.length, closeAt);
+    blocks.push({
+      start,
+      end: closeAt + CLOSE_TAG.length,
+      entries: parseEntries(inner),
+      hasBlankLine: BLANK_LINE.test(inner),
+    });
+    at = closeAt + CLOSE_TAG.length;
+  }
+
+  return { blocks, unclosedStarts };
+}
+
+/** The commit maps that are whole. */
+export function parseCommitMaps(text: string): CommitMapBlock[] {
+  return scanCommitMaps(text).blocks;
+}
+
+/**
+ * The spans a `<Commit>` may legally sit in. An unclosed `<CommitMap>` covers
+ * everything after it, so its entries are reported once — as an unclosed block
+ * — rather than a second time as entries adrift.
+ */
+function coveredRanges(scan: CommitMapScan, textLength: number) {
+  return [
+    ...scan.blocks.map((block) => ({ start: block.start, end: block.end })),
+    ...scan.unclosedStarts.map((start) => ({ start, end: textLength })),
+  ];
+}
+
+/** Entries whose `id` attribute is missing or empty. */
+export function findCommitsMissingId(text: string): string[] {
+  return parseCommitMaps(text)
+    .flatMap((block) => block.entries)
+    .filter((entry) => entry.id === null)
+    .map((entry) => entry.openTag);
+}
+
+/** Ids used more than once across the document's commit maps. */
+export function findRepeatedCommitIds(text: string): string[] {
+  const seen = new Set<string>();
+  const repeated = new Set<string>();
+  for (const block of parseCommitMaps(text)) {
+    for (const entry of block.entries) {
+      if (entry.id === null) continue;
+      if (seen.has(entry.id)) repeated.add(entry.id);
+      seen.add(entry.id);
+    }
+  }
+  return [...repeated];
+}
+
+/** `<Commit>` tags that sit outside any `<CommitMap>`. */
+export function findCommitsOutsideCommitMap(text: string): string[] {
+  const scan = scanCommitMaps(text);
+  const covered = coveredRanges(scan, text.length);
+
+  const adrift: string[] = [];
+  ENTRY_OPEN_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ENTRY_OPEN_PATTERN.exec(text)) !== null) {
+    const at = match.index;
+    const inside = covered.some((range) => at >= range.start && at < range.end);
+    if (!inside) adrift.push(match[0]);
+  }
+  return adrift;
+}
+
+/**
+ * `<CommitMap>` tags with no closing tag.
+ *
+ * This is the worst breach of the lot: aihero.dev compiles a lesson body as
+ * real MDX, and an unclosed tag makes the whole body fall back to escaped
+ * markdown — every tag in the lesson visible as text. It is also the breach a
+ * half-written document always has, which is why its rule never runs while the
+ * writer is streaming.
+ */
+export function findUnclosedCommitMaps(text: string): string[] {
+  return scanCommitMaps(text).unclosedStarts.map(() => OPEN_TAG);
+}
+
+/** Commit maps broken by a blank line. */
+export function findCommitMapsWithBlankLines(text: string): string[] {
+  return parseCommitMaps(text)
+    .filter((block) => block.hasBlankLine)
+    .map(() => OPEN_TAG);
+}

--- a/app/features/article-writer/lint-rules.ts
+++ b/app/features/article-writer/lint-rules.ts
@@ -1,3 +1,10 @@
+import {
+  findCommitMapsWithBlankLines,
+  findCommitsMissingId,
+  findCommitsOutsideCommitMap,
+  findRepeatedCommitIds,
+  findUnclosedCommitMaps,
+} from "./commit-map-syntax";
 import { LEADING_HEADING_PATTERN, stripLeadingHeadings } from "./lint-fix";
 import { findTakenQuizIds, fixTakenQuizIds } from "./quiz-lint";
 import type { Mode } from "./types";
@@ -11,9 +18,14 @@ import type { Mode } from "./types";
 export interface LintContext {
   /** Quiz ids owned by other videos in this course. */
   courseQuizIds: string[];
+  /** Whether the text is still arriving from the model. */
+  isStreaming: boolean;
 }
 
-export const EMPTY_LINT_CONTEXT: LintContext = { courseQuizIds: [] };
+export const EMPTY_LINT_CONTEXT: LintContext = {
+  courseQuizIds: [],
+  isStreaming: false,
+};
 
 /**
  * Represents a single lint rule that can be applied to article writer output.
@@ -35,6 +47,15 @@ export interface LintRule {
   required?: boolean;
   /** Optional filter to exclude false-positive matches. Return true to keep the match. */
   matchFilter?: (match: string) => boolean;
+  /**
+   * Skips the rule while the model is still writing.
+   *
+   * A rule about the *shape* of a block is transiently false all the way
+   * through a document being written — an unclosed tag is the normal state of
+   * a tag half-arrived. Reporting it would make the Fix count cry wolf on
+   * every keystroke, so these rules read the settled document only.
+   */
+  skipWhileStreaming?: boolean;
   /**
    * Optional deterministic repair. When present, and when it actually changes
    * the document, the fix is applied directly and the rule's `fixInstruction`
@@ -195,6 +216,66 @@ export const BASE_LINT_RULES: LintRule[] = [
       fixTakenQuizIds(text, context.courseQuizIds),
     fixInstruction: (matches) =>
       `Rename these quiz ids — another lesson in the course already uses them: ${matches.join(", ")}`,
+  },
+  // The commit map rules. All of them read the block's shape, so all of them
+  // wait for the writer to stop. None has a deterministic fix: only the author
+  // knows which slug a broken entry meant.
+  {
+    id: "commit-map-unclosed",
+    name: "Unclosed Commit Map",
+    description:
+      "A <CommitMap> with no closing tag escapes the whole lesson body on the site",
+    modes: null,
+    // Never scanned: `detect` reads the block structure, which a regex cannot.
+    pattern: /(?!)/,
+    skipWhileStreaming: true,
+    detect: (text) => findUnclosedCommitMaps(text),
+    fixInstruction:
+      "Close the <CommitMap> block with </CommitMap>. Left open, the site renders the entire lesson body as escaped text.",
+  },
+  {
+    id: "commit-map-blank-line",
+    name: "Blank Line In Commit Map",
+    description: "A commit map must be one unbroken run of lines",
+    modes: null,
+    pattern: /(?!)/,
+    skipWhileStreaming: true,
+    detect: (text) => findCommitMapsWithBlankLines(text),
+    fixInstruction:
+      "Remove the blank lines inside the <CommitMap> block. The opening tag, every <Commit>, and the closing tag must sit on consecutive lines.",
+  },
+  {
+    id: "commit-missing-id",
+    name: "Commit Without An Id",
+    description: "Every commit map entry names a commit by its slug",
+    modes: null,
+    pattern: /(?!)/,
+    skipWhileStreaming: true,
+    detect: (text) => findCommitsMissingId(text),
+    fixInstruction: (matches) =>
+      `Give these <Commit> entries an id — the slug of the commit they name, or "main" for the course start: ${matches.join(", ")}`,
+  },
+  {
+    id: "commit-id-repeated",
+    name: "Repeated Commit Id",
+    description: "A commit map names each commit once",
+    modes: null,
+    pattern: /(?!)/,
+    skipWhileStreaming: true,
+    detect: (text) => findRepeatedCommitIds(text),
+    fixInstruction: (matches) =>
+      `Remove the duplicate entries — the map names these commits more than once: ${matches.join(", ")}`,
+  },
+  {
+    id: "commit-outside-commit-map",
+    name: "Commit Outside A Commit Map",
+    description: "A <Commit> only means anything inside a <CommitMap>",
+    modes: null,
+    pattern: /(?!)/,
+    skipWhileStreaming: true,
+    detect: (text) => findCommitsOutsideCommitMap(text),
+    fixInstruction: (matches) =>
+      `Move these <Commit> entries inside a <CommitMap> block: ${matches.join(", ")}`,
   },
 ];
 

--- a/app/features/article-writer/preview-component-maps.ts
+++ b/app/features/article-writer/preview-component-maps.ts
@@ -1,0 +1,26 @@
+/**
+ * The custom tags a preview renders.
+ *
+ * Quizzes and commit maps render in every document preview: a body carrying
+ * one shows it whatever mode wrote it. Screenshot placeholders need clips to
+ * resolve to, so they come as a separate map.
+ *
+ * Module constants, and they must stay constants: react-markdown uses a mapped
+ * value as the React element *type*, so a fresh object on each render unmounts
+ * and remounts every card.
+ */
+
+import type { Options } from "react-markdown";
+import { CHOOSE_SCREENSHOT_COMPONENTS } from "./choose-screenshot-components";
+import { COMMIT_MAP_COMPONENTS } from "./commit-map-components";
+import { QUIZ_COMPONENTS } from "./quiz-components";
+
+export const PREVIEW_COMPONENTS = {
+  ...QUIZ_COMPONENTS,
+  ...COMMIT_MAP_COMPONENTS,
+} as Options["components"];
+
+export const PREVIEW_COMPONENTS_WITH_SCREENSHOTS = {
+  ...PREVIEW_COMPONENTS,
+  ...CHOOSE_SCREENSHOT_COMPONENTS,
+} as Options["components"];

--- a/app/features/article-writer/writable-field.tsx
+++ b/app/features/article-writer/writable-field.tsx
@@ -13,7 +13,7 @@ import type { Mode, WriterView } from "./types";
 import type { WriterFieldId } from "./writer-engine-utils";
 import { FIELD_MODES } from "./writer-engine-utils";
 import { WriterModal } from "./writer-modal";
-import { QUIZ_COMPONENTS } from "./quiz-components";
+import { PREVIEW_COMPONENTS } from "./preview-component-maps";
 import { preprocessDocumentPreview } from "./document-preview-markdown";
 import {
   WRITER_URL_UPDATE,
@@ -23,9 +23,9 @@ import {
 } from "./writer-url-state";
 
 /**
- * The inline preview draws quiz cards but resolves no screenshot placeholders —
- * it has no clips to offer. A module constant so the memoised preview keeps its
- * identity across renders.
+ * The inline preview draws quiz and commit map cards but resolves no screenshot
+ * placeholders — it has no clips to offer. A module constant so the memoised
+ * preview keeps its identity across renders.
  */
 const previewQuizzes = (md: string) =>
   preprocessDocumentPreview(md, { screenshots: false });
@@ -200,7 +200,7 @@ export function WritableField({
                 {draft ? (
                   <AIResponse
                     imageBasePath={context.fullPath}
-                    extraComponents={QUIZ_COMPONENTS}
+                    extraComponents={PREVIEW_COMPONENTS}
                     preprocessMarkdown={previewQuizzes}
                   >
                     {draft}

--- a/app/features/article-writer/writer-engine.tsx
+++ b/app/features/article-writer/writer-engine.tsx
@@ -16,8 +16,7 @@ import { WriteChat } from "./write-chat";
 import { DocumentPanel } from "./document-panel";
 import { useDocumentFlow } from "./use-document-flow";
 import { useRemoveDocumentBlock } from "./use-remove-document-block";
-import { useLint, useLintFix } from "@/hooks/use-lint";
-import type { LintContext } from "./lint-rules";
+import { useLint, useLintContext, useLintFix } from "@/hooks/use-lint";
 import { useBannedPhrases } from "@/hooks/use-banned-phrases";
 import { useMessageQueue } from "./use-message-queue";
 import { partsToText } from "./write-utils";
@@ -32,15 +31,14 @@ import {
   type DocumentPreviewOptions,
 } from "./document-preview-markdown";
 import {
-  CHOOSE_SCREENSHOT_COMPONENTS,
   ChooseScreenshotProvider,
   type ChooseScreenshotRuntime,
 } from "./choose-screenshot-components";
 import {
-  QUIZ_COMPONENTS,
-  QuizProvider,
-  type QuizRuntime,
-} from "./quiz-components";
+  PREVIEW_COMPONENTS,
+  PREVIEW_COMPONENTS_WITH_SCREENSHOTS,
+} from "./preview-component-maps";
+import { QuizProvider, type QuizRuntime } from "./quiz-components";
 import { removeQuizQuestion } from "./quiz-syntax";
 import type { WriteToolbarProps } from "./write-toolbar";
 import type { WriterFieldId } from "./writer-engine-utils";
@@ -239,15 +237,9 @@ export function WriterEngine({
 
   const hasScreenshots = indexedClips.length > 0 && isDocumentMode;
 
-  // Quizzes render in every document preview: a body carrying one shows it
-  // whatever mode wrote it. Screenshot placeholders need clips to resolve to.
-  const docExtraComponents = useMemo(
-    () =>
-      hasScreenshots
-        ? { ...QUIZ_COMPONENTS, ...CHOOSE_SCREENSHOT_COMPONENTS }
-        : QUIZ_COMPONENTS,
-    [hasScreenshots]
-  );
+  const docExtraComponents = hasScreenshots
+    ? PREVIEW_COMPONENTS_WITH_SCREENSHOTS
+    : PREVIEW_COMPONENTS;
 
   // The document is a single scope, so the message id plays no part in its keys.
   const docScreenshotRuntime = useMemo(
@@ -398,12 +390,10 @@ export function WriterEngine({
       .find((m) => m.role === "assistant")?.parts ?? []
   );
 
-  // Quiz id uniqueness is a fact about the course, which the loader knows and
-  // a regex over one document never could.
-  const lintContext = useMemo(
-    (): LintContext => ({ courseQuizIds: context.quizIds ?? [] }),
-    [context.quizIds]
-  );
+  const lintContext = useLintContext({
+    courseQuizIds: context.quizIds,
+    isStreaming: isGenerating,
+  });
 
   const { violations } = useLint(
     isDocumentMode && document ? document : lastAssistantMessageText,

--- a/app/hooks/use-lint.ts
+++ b/app/hooks/use-lint.ts
@@ -27,6 +27,24 @@ import type { Mode } from "@/features/article-writer/types";
  * const plan = planLintFix({ document, violations });
  * ```
  */
+/**
+ * What the rules know beyond the document in front of them.
+ *
+ * Quiz id uniqueness is a fact about the course, which the loader knows and a
+ * regex over one document never could. Streaming is a fact about the text: the
+ * rules about a block's shape wait for it to settle.
+ */
+export function useLintContext(opts: {
+  courseQuizIds: string[] | undefined;
+  isStreaming: boolean;
+}): LintContext {
+  const { courseQuizIds, isStreaming } = opts;
+  return useMemo(
+    () => ({ courseQuizIds: courseQuizIds ?? [], isStreaming }),
+    [courseQuizIds, isStreaming]
+  );
+}
+
 export function useLint(
   text: string | null,
   mode: Mode,
@@ -51,6 +69,12 @@ export function useLint(
     for (const rule of rules) {
       // Skip rules that don't apply to this mode
       if (rule.modes !== null && !rule.modes.includes(mode)) {
+        continue;
+      }
+
+      // A half-written block breaks every rule about its shape. Those rules
+      // read the settled document, so the Fix count means something.
+      if (rule.skipWhileStreaming && context.isStreaming) {
         continue;
       }
 

--- a/app/prompts/commit-map-instructions.ts
+++ b/app/prompts/commit-map-instructions.ts
@@ -1,0 +1,37 @@
+/**
+ * What the Article Writer knows about commit maps.
+ *
+ * The syntax here is one of two live copies — the other is the
+ * `commit-maps.md` reference in the `creating-content` skill, which holds the
+ * same contract for agents drafting outside this app. Change both.
+ *
+ * Note the shape of this prompt: the restraint comes first. The writer must
+ * recognise a commit map and be able to author one correctly on request, and
+ * must never volunteer one — only the person editing the course repo knows
+ * which commits a lesson has.
+ */
+
+export const COMMIT_MAP_INSTRUCTIONS = `
+## Commit Maps
+
+Some lessons open with a commit map: the list of commits in the course project repo that the lesson uses.
+
+**Never write one unless you are asked to.** You cannot know which commits a lesson has — that lives in the course repo, which you cannot see. If a lesson has no commit map, leave it that way. If a lesson already has one, leave it alone: do not reword its descriptions, reorder its entries, or move it.
+
+When you are asked for one, this is the shape:
+
+<CommitMap>
+  <Commit id="analytics-tickets">Start the lesson — the PRD turned into multi-phase tickets</Commit>
+  <Commit id="implement-skill">See my solution — the \`/implement\` skill added</Commit>
+</CommitMap>
+
+The rules:
+
+- It goes at the **top of the body**, before the first line of prose. It is navigation: the reader needs it before they start, not after.
+- Each \`id\` is a **slug** — the id of a commit in the course project repo, in kebab-case. It names what the commit does to the tree (\`add-settings-json\`), not the lesson it appears in. Never invent a slug. Use the ones you are given.
+- \`main\` is the one legal id that is not a slug. It names the course's starting point, the state a student first clones.
+- The **first entry is the reset point** — where a student goes to start the lesson. Later entries are the other points the lesson mentions, in the order the lesson reaches them.
+- Each description says what the reader gets by going there, in the lesson's own terms — "Start the lesson — …", "See my solution — …". It is not the commit's message. Markdown works inside it; backticks for file and skill names.
+- **No blank lines anywhere inside the block.** The opening tag, every \`<Commit>\`, and the closing tag sit on consecutive lines. A blank line changes how the page parses, and an unclosed \`<CommitMap>\` breaks the entire lesson body.
+- Each commit appears once. A \`<Commit>\` outside a \`<CommitMap>\` means nothing.
+`.trim();

--- a/app/prompts/generate-article.ts
+++ b/app/prompts/generate-article.ts
@@ -1,3 +1,4 @@
+import { COMMIT_MAP_INSTRUCTIONS } from "./commit-map-instructions";
 import { getImageInstructions } from "./image-instructions";
 import { getQuizInstructions } from "./quiz-instructions";
 import { getLinkInstructions, type GlobalLink } from "./link-instructions";
@@ -80,6 +81,8 @@ ${getLinkInstructions(opts.links)}
 ${SCREENSHOT_INSTRUCTIONS}
 
 ${getQuizInstructions(opts.existingQuizIds ?? [])}
+
+${COMMIT_MAP_INSTRUCTIONS}
 
 ## IMPORTANT INSTRUCTIONS
 


### PR DESCRIPTION
A commit map is the list of commits a lesson uses, at the top of the body:

```
<CommitMap>
  <Commit id="analytics-tickets">Start the lesson — the PRD turned into multi-phase tickets</Commit>
  <Commit id="implement-skill">See my solution — the `/implement` skill added</Commit>
</CommitMap>
```

The contract is aihero.dev's and already ships there (`components/mdx/commit-map.tsx`, registered in `compile-mdx.tsx`). This is the CVM catching up, so a map stops rendering as raw text where it is authored. The ids are slugs naming lesson commits in the course project repo; `main` is the one id that is not a slug.

## No rewrite pipeline

A quiz is rewritten before parsing because `data={{ … }}` is a JS object literal an HTML attribute cannot hold. An `id` is a plain attribute, so the markup survives `rehype-raw` as authored — parse5 just lowercases the tag names, which is why the two components register as `commitmap` and `commit`. There is no scanner in the render path and there should not be one; the comment in `commit-map-components.tsx` says so, because the obvious wrong move here is building one for symmetry with the quiz.

## Lint

Shape only: an unclosed block, a blank line inside it, a missing or repeated id, an entry adrift of its map. These matter more than they look — aihero.dev compiles a body as real MDX, so a malformed block escapes the **entire** lesson body into visible tag soup.

Writer-side, so nothing refuses a publish. Every course-view warning is a gate (`collectCourseViewLints(...).length` *is* the gate), and a commit map should not be one.

New `skipWhileStreaming` flag on `LintRule`: a rule about a block's shape is transiently false all the way through a document being written, so it reads the settled document only. It is honoured next to the existing `modes` check and fed by `isStreaming` on `LintContext`.

## Deliberately not done

- **Slug existence is unchecked.** The CVM cannot see the course repo, and a cached slug list would be wrong the moment `live-run-through` is rebased — which is routine. That starts with a `course.repo_url` migration, not a lint rule.
- **No MDX compile check.** The CVM has no MDX compiler and has never parsed JSX; `useLint` is synchronous. The shape lint catches the same real failures.
- **The lesson page runs no lint** — `useLint` has one caller. The card renders in both surfaces, so a malformed map is still visible where it is authored; only the Fix count is writer-only.

`writer-engine.tsx` crossed the 5500-token pre-commit ceiling, so the preview component maps moved to `preview-component-maps.ts` and the lint context wiring to `useLintContext`.

## Testing

`commit-map-syntax.test.ts` — 19 tests. Typecheck clean; 244 tests pass across `app/features/article-writer` and `app/hooks`.

Three files fail on this branch (`cli-segment-writes`, `cli-backup-coordination`, `course-publish-service-video-tasks`, 21 tests). They fail identically on an unmodified `main` worktree — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
