### PR TITLE
Clip Zoom — a static 115% zoom on camera clips

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -157,7 +157,7 @@ _Avoid_: Missing Opening Chapter (the former name), Missing opening section, No 
 ### Video export and hashing
 
 **Export Hash**:
-A SHA256 hash derived from a video's clip filenames, timestamps, clip order, long-pause flags, format, and the Export Version Key; determines whether a video needs re-export. It must name everything the renderer acts on — a clip property that changes the exported bytes but not the hash leaves a stale export addressable, and the Publish ships it.
+A SHA256 hash derived from a video's clip filenames, timestamps, clip order, long-pause flags, **Clip Zoom**, format, and the Export Version Key; determines whether a video needs re-export. It must name everything the renderer acts on — a clip property that changes the exported bytes but not the hash leaves a stale export addressable, and the Publish ships it.
 _Avoid_: Content hash, Video hash
 
 **Exported Video**:
@@ -185,6 +185,10 @@ _Avoid_: Pause Length (former name — reused "Pause", now the clip-level held p
 **Pause**:
 A clip-level marker (`none`/`long`) that inserts a short held pause after a **Clip** in the edit — `long` holds ~0.18s, `none` is an ordinary clip. Toggled per clip, shown as an ellipsis ("…"). An enum, not a boolean, so it can gain more lengths later. Distinct from **Silence Length** (the recording cut threshold).
 _Avoid_: Beat (former `beatType`), Silence Length, Gap, Hold
+
+**Clip Zoom**:
+A clip-level marker (`none`/`subtle`) that renders a **Clip** at 115% of frame — cropped centrally in x, biased above centre in y — so that a run of face-only camera clips has some visual change across its cuts. Legal only where the Clip's recorded `scene` is a camera scene (`Camera` or `TikTok Face`); every other scene, and a Clip with no recorded scene at all, is refused. An enum, not a boolean, so it can gain more levels later — the 115% itself is a constant in one file, deliberately not encoded in the value names, so retuning the shot is not a migration. One shared rect (`app/features/videos/clip-zoom.ts`), expressed as fractions of the frame rather than pixels, is formatted into both the editor preview's CSS transform and the export's ffmpeg `crop`, which is what makes the preview honest about what the **Publish** will ship. The crop is applied before the normalising `scale`, so a source larger than the output frame spends surplus resolution rather than upscaling. Part of the **Export Hash**, emitted only when not `none`. Set per clip in the editor or with `cvm clip update --zoom`.
+_Avoid_: Punch-in, Ken Burns (implies an animated move; this one is static), Scale, Crop
 
 **Insertion Point**:
 The position in a video timeline where new clips or chapters will be added (start, after-clip, after-chapter, end).

--- a/app/cli/commands/clip.ts
+++ b/app/cli/commands/clip.ts
@@ -8,7 +8,13 @@ import {
   emitObject,
   notFound,
   notFoundMany,
+  parseError,
 } from "@/cli/helpers";
+import { withBackupCoordination } from "@/cli/backup-coordinator";
+import {
+  CLIP_ZOOM_TYPES,
+  type ClipZoomType,
+} from "@/features/videos/clip-zoom";
 
 /**
  * clip — a timestamped slice of source footage inside a Video.
@@ -41,6 +47,7 @@ import {
  *   transcribedAt    when `text` was last produced (null = not transcribed)
  *   scene / profile  optional capture metadata
  *   pauseType         held pause after clip; "none" or "long"
+ *   zoomType          Clip Zoom; "none" or "subtle" (camera scenes only)
  *   diagramSnapshotId pinned DiagramSnapshot filmed against this clip, if any
  *   archived         always false in CLI output (archived rows are hidden)
  *   createdAt        row creation timestamp
@@ -48,6 +55,12 @@ import {
  * VERBS:
  *   clip list --video <videoId>   every active clip on a Video, timeline order
  *   clip get <id...>              one or more clips by id (variadic)
+ *   clip update <id> --zoom <t>   set the Clip Zoom (the ONLY writable field)
+ *
+ * `update` is deliberately the narrowest possible write. A Clip's text is
+ * recorded truth (the Transcript is derived from it) and its timings are the
+ * cut — none of that is the CLI's to rewrite. Only the Clip Zoom, an editorial
+ * choice about the shot, is writable here, and only on a camera scene.
  *
  * Clips are leaf timeline rows — there is no `clip tree`. To explore a Video's
  * structure use `video tree`, then resolve ids with `clip get`.
@@ -78,8 +91,30 @@ scoping and archived clips are always hidden (no --archived flag).
 Verbs:
   clip list --video <videoId>   every active clip on a Video, in timeline order (NDJSON)
   clip get <id...>              fetch one or more clips by id (variadic)
+  clip update <id> --zoom <t>   set the Clip Zoom ("none" | "subtle")
 
-There is no 'clip tree' (clips are leaves) — use 'video tree' then 'clip get'.`;
+'update' accepts --zoom and nothing else: a clip's text is recorded truth and its timings are the
+cut, neither of which the CLI rewrites. There is no 'clip tree' (clips are leaves) — use
+'video tree' then 'clip get'.`;
+
+const UPDATE_HELP = `Set a Clip's Clip Zoom.
+
+A Clip Zoom renders the clip slightly tighter than frame, so a run of face-only camera clips has
+some visual change across its cuts. Levels: "none" (as filmed) and "subtle".
+
+Only camera scenes can be zoomed — 'Camera' and 'TikTok Face'. Anything else (a 'Code' clip, or a
+clip filmed before CVM recorded scenes and so having none) is refused with exit 3; the message says
+which of the two it was. The zoom reaches the Export Hash, so setting it marks the Video for
+re-export, and it shows in the editor preview exactly as it will export.
+
+Examples:
+  cvm clip update clip_abc --zoom subtle
+  cvm clip update clip_abc --zoom none
+
+  # Zoom every camera clip on a video:
+  cvm clip list --video vid_123 \
+    | jq -r 'select(.scene == "Camera") | .id' \
+    | xargs -n1 -I{} cvm clip update {} --zoom subtle`;
 
 const LIST_HELP = `List every active (non-archived) Clip on a Video, in timeline order.
 
@@ -158,7 +193,47 @@ const getCmd = Command.make("get", { ids }, ({ ids }) =>
   })
 ).pipe(Command.withDescription(detail(GET_HELP)));
 
+const zoomOpt = Options.choice("zoom", CLIP_ZOOM_TYPES).pipe(
+  Options.withDescription(
+    `Clip Zoom to set: ${CLIP_ZOOM_TYPES.join(" | ")}. Camera scenes only.`
+  )
+);
+
+const idArg = Args.text({ name: "id" });
+
+const updateCmd = Command.make(
+  "update",
+  { id: idArg, zoom: zoomOpt },
+  ({ id, zoom }) =>
+    withBackupCoordination(
+      Effect.gen(function* () {
+        const clipOps = yield* ClipOperationsService;
+
+        // Resolve first, so a bad id is a clean not-found (exit 2) rather than
+        // arriving as a service failure. Archived clips are deleted as far as
+        // this noun is concerned, so they are not-found too.
+        const [existing] = yield* clipOps.getClipsByIds([id]);
+        if (!existing || existing.archived) {
+          return yield* notFound("clip", id);
+        }
+
+        // setClipZoom re-checks eligibility — it is the service that owns the
+        // rule. Translating its failure here is only about the exit code: an
+        // ineligible clip is bad input (exit 3), not an internal fault.
+        const updated = yield* clipOps
+          .setClipZoom(id, zoom satisfies ClipZoomType)
+          .pipe(
+            Effect.catchTag("ClipNotZoomableError", (e) =>
+              parseError(e.message, "clip")
+            )
+          );
+
+        yield* emitObject(updated);
+      })
+    )
+).pipe(Command.withDescription(detail(UPDATE_HELP)));
+
 export const clipCommand = Command.make("clip").pipe(
   Command.withDescription(detail(CLIP_HELP)),
-  Command.withSubcommands([listCmd, getCmd])
+  Command.withSubcommands([listCmd, getCmd, updateCmd])
 );

--- a/app/db/migrations/0012_add_clip_zoom_type.sql
+++ b/app/db/migrations/0012_add_clip_zoom_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "course-video-manager_clip" ADD COLUMN "zoom_type" varchar(255) DEFAULT 'none' NOT NULL;

--- a/app/db/migrations/meta/0012_snapshot.json
+++ b/app/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1725 @@
+{
+  "id": "42103420-4488-4934-92f9-3b36bece700d",
+  "prevId": "7633e6ef-b979-4bec-85de-8924912929fa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.course-video-manager_ai_hero_auth": {
+      "name": "course-video-manager_ai_hero_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_beat": {
+      "name": "course-video-manager_beat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'definition'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "order": {
+          "name": "order",
+          "type": "varchar(255) COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_beat_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_beat_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_beat",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": ["video_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_chapter": {
+      "name": "course-video-manager_chapter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "varchar(255) COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_chapter_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_chapter_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_chapter",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": ["video_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_clip_web_link": {
+      "name": "course-video-manager_clip_web_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clip_id": {
+          "name": "clip_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_clip_web_link_clip_id_course-video-manager_clip_id_fk": {
+          "name": "course-video-manager_clip_web_link_clip_id_course-video-manager_clip_id_fk",
+          "tableFrom": "course-video-manager_clip_web_link",
+          "tableTo": "course-video-manager_clip",
+          "columnsFrom": ["clip_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_clip": {
+      "name": "course-video-manager_clip",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "video_filename": {
+          "name": "video_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_start_time": {
+          "name": "source_start_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_end_time": {
+          "name": "source_end_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order": {
+          "name": "order",
+          "type": "varchar(255) COLLATE \"C\"",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcribed_at": {
+          "name": "transcribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scene": {
+          "name": "scene",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_type": {
+          "name": "pause_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "zoom_type": {
+          "name": "zoom_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "diagram_snapshot_id": {
+          "name": "diagram_snapshot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clip_diagram_snapshot_id_idx": {
+          "name": "clip_diagram_snapshot_id_idx",
+          "columns": [
+            {
+              "expression": "diagram_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_clip_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_clip_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_clip",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": ["video_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course-video-manager_clip_diagram_snapshot_id_course-video-manager_diagram_snapshot_id_fk": {
+          "name": "course-video-manager_clip_diagram_snapshot_id_course-video-manager_diagram_snapshot_id_fk",
+          "tableFrom": "course-video-manager_clip",
+          "tableTo": "course-video-manager_diagram_snapshot",
+          "columnsFrom": ["diagram_snapshot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_course_version": {
+      "name": "course-video-manager_course_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "commit_state": {
+          "name": "commit_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "course_version_one_pending_uniq": {
+          "name": "course_version_one_pending_uniq",
+          "columns": [
+            {
+              "expression": "course_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course-video-manager_course_version\".\"commit_state\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_course_version_course_id_course-video-manager_course_id_fk": {
+          "name": "course-video-manager_course_version_course_id_course-video-manager_course_id_fk",
+          "tableFrom": "course-video-manager_course_version",
+          "tableTo": "course-video-manager_course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_course": {
+      "name": "course-video-manager_course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "memory": {
+          "name": "memory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "course_slug_uniq": {
+          "name": "course_slug_uniq",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "NOT \"course-video-manager_course\".\"archived\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_deliverable": {
+      "name": "course-video-manager_deliverable",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_deliverable_course": {
+      "name": "course-video-manager_deliverable_course",
+      "schema": "",
+      "columns": {
+        "deliverable_id": {
+          "name": "deliverable_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_deliverable_course_deliverable_id_course-video-manager_deliverable_id_fk": {
+          "name": "course-video-manager_deliverable_course_deliverable_id_course-video-manager_deliverable_id_fk",
+          "tableFrom": "course-video-manager_deliverable_course",
+          "tableTo": "course-video-manager_deliverable",
+          "columnsFrom": ["deliverable_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course-video-manager_deliverable_course_course_id_course-video-manager_course_id_fk": {
+          "name": "course-video-manager_deliverable_course_course_id_course-video-manager_course_id_fk",
+          "tableFrom": "course-video-manager_deliverable_course",
+          "tableTo": "course-video-manager_course",
+          "columnsFrom": ["course_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course-video-manager_deliverable_course_deliverable_id_course_id_pk": {
+          "name": "course-video-manager_deliverable_course_deliverable_id_course_id_pk",
+          "columns": ["deliverable_id", "course_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_deliverable_pitch": {
+      "name": "course-video-manager_deliverable_pitch",
+      "schema": "",
+      "columns": {
+        "deliverable_id": {
+          "name": "deliverable_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pitch_id": {
+          "name": "pitch_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_deliverable_pitch_deliverable_id_course-video-manager_deliverable_id_fk": {
+          "name": "course-video-manager_deliverable_pitch_deliverable_id_course-video-manager_deliverable_id_fk",
+          "tableFrom": "course-video-manager_deliverable_pitch",
+          "tableTo": "course-video-manager_deliverable",
+          "columnsFrom": ["deliverable_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course-video-manager_deliverable_pitch_pitch_id_course-video-manager_pitch_id_fk": {
+          "name": "course-video-manager_deliverable_pitch_pitch_id_course-video-manager_pitch_id_fk",
+          "tableFrom": "course-video-manager_deliverable_pitch",
+          "tableTo": "course-video-manager_pitch",
+          "columnsFrom": ["pitch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "course-video-manager_deliverable_pitch_deliverable_id_pitch_id_pk": {
+          "name": "course-video-manager_deliverable_pitch_deliverable_id_pitch_id_pk",
+          "columns": ["deliverable_id", "pitch_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_diagram_component": {
+      "name": "course-video-manager_diagram_component",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene_fragment": {
+          "name": "scene_fragment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_diagram_snapshot": {
+      "name": "course-video-manager_diagram_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "diagram_id": {
+          "name": "diagram_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scene": {
+          "name": "scene",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preserved": {
+          "name": "preserved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(search_text, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "diagram_snapshot_diagram_id_content_hash_idx": {
+          "name": "diagram_snapshot_diagram_id_content_hash_idx",
+          "columns": [
+            {
+              "expression": "diagram_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "diagram_snapshot_search_vector_idx": {
+          "name": "diagram_snapshot_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_diagram_snapshot_diagram_id_course-video-manager_diagram_id_fk": {
+          "name": "course-video-manager_diagram_snapshot_diagram_id_course-video-manager_diagram_id_fk",
+          "tableFrom": "course-video-manager_diagram_snapshot",
+          "tableTo": "course-video-manager_diagram",
+          "columnsFrom": ["diagram_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_diagram": {
+      "name": "course-video-manager_diagram",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled 1'"
+        },
+        "head_scene": {
+          "name": "head_scene",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_text": {
+          "name": "search_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(search_text, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "diagram_search_vector_idx": {
+          "name": "diagram_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_dropbox_auth": {
+      "name": "course-video-manager_dropbox_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_lesson": {
+      "name": "course-video-manager_lesson",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_version_lesson_id": {
+          "name": "previous_version_lesson_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authoring_status": {
+          "name": "authoring_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order": {
+          "name": "order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "lesson_section_order_uniq": {
+          "name": "lesson_section_order_uniq",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "NOT \"course-video-manager_lesson\".\"archived\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_lesson_section_id_course-video-manager_section_id_fk": {
+          "name": "course-video-manager_lesson_section_id_course-video-manager_section_id_fk",
+          "tableFrom": "course-video-manager_lesson",
+          "tableTo": "course-video-manager_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_link": {
+      "name": "course-video-manager_link",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "course-video-manager_link_url_unique": {
+          "name": "course-video-manager_link_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_pitch": {
+      "name": "course-video-manager_pitch",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "content_plan": {
+          "name": "content_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "youtube_title": {
+          "name": "youtube_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "youtube_thumbnail_description": {
+          "name": "youtube_thumbnail_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "newsletter_title": {
+          "name": "newsletter_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "tweet": {
+          "name": "tweet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "effort": {
+          "name": "effort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_section": {
+      "name": "course-video-manager_section",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "course_version_id": {
+          "name": "course_version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_version_section_id": {
+          "name": "previous_version_section_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order": {
+          "name": "order",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "section_version_order_uniq": {
+          "name": "section_version_order_uniq",
+          "columns": [
+            {
+              "expression": "course_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"course-video-manager_section\".\"archived_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_section_course_version_id_course-video-manager_course_version_id_fk": {
+          "name": "course-video-manager_section_course_version_id_course-video-manager_course_version_id_fk",
+          "tableFrom": "course-video-manager_section",
+          "tableTo": "course-video-manager_course_version",
+          "columnsFrom": ["course_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_thumbnail": {
+      "name": "course-video-manager_thumbnail",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layers": {
+          "name": "layers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_for_upload": {
+          "name": "selected_for_upload",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_thumbnail_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_thumbnail_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_thumbnail",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": ["video_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_video_post": {
+      "name": "course-video-manager_video_post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remote_id": {
+          "name": "remote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course-video-manager_video_post_video_id_course-video-manager_video_id_fk": {
+          "name": "course-video-manager_video_post_video_id_course-video-manager_video_id_fk",
+          "tableFrom": "course-video-manager_video_post",
+          "tableTo": "course-video-manager_video",
+          "columnsFrom": ["video_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_video": {
+      "name": "course-video-manager_video",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lesson_id": {
+          "name": "lesson_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pitch_id": {
+          "name": "pitch_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_footage_path": {
+          "name": "original_footage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_description": {
+          "name": "video_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'landscape'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "video_lesson_title_uniq": {
+          "name": "video_lesson_title_uniq",
+          "columns": [
+            {
+              "expression": "lesson_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "NOT \"course-video-manager_video\".\"archived\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "video_pitch_id_idx": {
+          "name": "video_pitch_id_idx",
+          "columns": [
+            {
+              "expression": "pitch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course-video-manager_video_lesson_id_course-video-manager_lesson_id_fk": {
+          "name": "course-video-manager_video_lesson_id_course-video-manager_lesson_id_fk",
+          "tableFrom": "course-video-manager_video",
+          "tableTo": "course-video-manager_lesson",
+          "columnsFrom": ["lesson_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course-video-manager_video_pitch_id_course-video-manager_pitch_id_fk": {
+          "name": "course-video-manager_video_pitch_id_course-video-manager_pitch_id_fk",
+          "tableFrom": "course-video-manager_video",
+          "tableTo": "course-video-manager_pitch",
+          "columnsFrom": ["pitch_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course-video-manager_youtube_auth": {
+      "name": "course-video-manager_youtube_auth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/db/migrations/meta/_journal.json
+++ b/app/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1785332138628,
       "tag": "0011_flimsy_mindworm",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1786112545920,
+      "tag": "0012_add_clip_zoom_type",
+      "breakpoints": true
     }
   ]
 }

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -290,6 +290,11 @@ export const clips = createTable(
     scene: varchar("scene", { length: 255 }),
     profile: varchar("profile", { length: 255 }),
     pauseType: varchar("pause_type", { length: 255 }).notNull().default("none"),
+    /**
+     * Clip Zoom — "none" or "subtle". Legal only on a camera scene; see
+     * `app/features/videos/clip-zoom.ts` for the rule and for the shot itself.
+     */
+    zoomType: varchar("zoom_type", { length: 255 }).notNull().default("none"),
     diagramSnapshotId: varchar("diagram_snapshot_id", {
       length: 255,
     }).references(() => diagramSnapshots.id, { onDelete: "set null" }),

--- a/app/features/video-editor/clip-state-reducer-diagram-pin.test.ts
+++ b/app/features/video-editor/clip-state-reducer-diagram-pin.test.ts
@@ -34,6 +34,7 @@ const createClipOnDatabase = (
   profile: "main-camera",
   insertionOrder: 1,
   pauseType: "none",
+  zoomType: "none",
   diagramSnapshotId: null,
   diagramName: null,
   webLinks: [],

--- a/app/features/video-editor/clip-state-reducer-effect-clips.test.ts
+++ b/app/features/video-editor/clip-state-reducer-effect-clips.test.ts
@@ -35,6 +35,7 @@ const createClipOnDatabase = (
   profile: "main-camera",
   insertionOrder: 1,
   pauseType: "none",
+  zoomType: "none",
   diagramSnapshotId: null,
   diagramName: null,
   webLinks: [],

--- a/app/features/video-editor/clip-state-reducer-recording.ts
+++ b/app/features/video-editor/clip-state-reducer-recording.ts
@@ -1,4 +1,5 @@
 import type { PauseType } from "@/services/video-processing-service";
+import { resolveClipZoomType } from "@/features/videos/clip-zoom";
 import { DEFAULT_SILENCE_LENGTH } from "@/silence-detection-constants";
 import { shouldSnapshot } from "@/lib/snapshot-rule";
 import {
@@ -436,6 +437,7 @@ const handleNewDatabaseClips = (
           profile: frontendClip.profile,
           insertionOrder: frontendClip.insertionOrder,
           pauseType: frontendClip.pauseType,
+          zoomType: resolveClipZoomType(databaseClip.zoomType),
           diagramSnapshotId: databaseClip.diagramSnapshotId ?? null,
           diagramName: null,
           webLinks: [],
@@ -461,6 +463,7 @@ const handleNewDatabaseClips = (
           profile: frontendClip.profile,
           insertionOrder: frontendClip.insertionOrder,
           pauseType: frontendClip.pauseType,
+          zoomType: resolveClipZoomType(databaseClip.zoomType),
           diagramSnapshotId: databaseClip.diagramSnapshotId ?? null,
           diagramName: null,
           webLinks: [],
@@ -485,6 +488,7 @@ const handleNewDatabaseClips = (
         databaseId: databaseClip.id,
         insertionOrder: state.insertionOrder + 1,
         pauseType: databaseClip.pauseType as PauseType,
+        zoomType: resolveClipZoomType(databaseClip.zoomType),
         diagramSnapshotId: databaseClip.diagramSnapshotId ?? null,
         diagramName: null,
         webLinks: [],

--- a/app/features/video-editor/clip-state-reducer.ts
+++ b/app/features/video-editor/clip-state-reducer.ts
@@ -22,6 +22,7 @@ import {
   isChapterAction,
 } from "./clip-state-reducer-chapters";
 import { DELETED_CLIPS_SESSION_ID } from "./video-editor-selectors";
+import { canZoomClip, type ClipZoomType } from "@/features/videos/clip-zoom";
 
 export namespace clipStateReducer {
   export type State = ClipReducerState;
@@ -335,6 +336,34 @@ export const clipStateReducer: EffectReducer<
         ),
       };
     }
+    case "toggle-zoom-for-clip": {
+      const item = state.items.find((c) => c.frontendId === action.clipId);
+
+      // Only a persisted clip can be zoomed: the write needs a database id,
+      // and the eligibility rule reads the clip's recorded scene.
+      if (!item || item.type !== "on-database" || !canZoomClip(item.scene)) {
+        return state;
+      }
+
+      const newZoomType: ClipZoomType =
+        item.zoomType === "none" ? "subtle" : "none";
+
+      exec({
+        type: "update-zoom",
+        clipId: item.databaseId,
+        zoomType: newZoomType,
+      });
+
+      return {
+        ...state,
+        items: state.items.map((c) =>
+          c.frontendId === action.clipId && c.type === "on-database"
+            ? { ...c, zoomType: newZoomType }
+            : c
+        ),
+      };
+    }
+
     case "move-clip": {
       const clipIndex = state.items.findIndex(
         (c) => c.frontendId === action.clipId
@@ -401,6 +430,9 @@ export const clipStateReducer: EffectReducer<
               profile: item.profile,
               insertionOrder: item.insertionOrder,
               pauseType: item.pauseType,
+              // Effect Clips are white noise — never a camera scene, so never
+              // zoomable. The field exists; the value can only ever be "none".
+              zoomType: "none",
               diagramSnapshotId: null,
               diagramName: null,
               webLinks: [],

--- a/app/features/video-editor/clip-state-reducer.types.ts
+++ b/app/features/video-editor/clip-state-reducer.types.ts
@@ -1,5 +1,6 @@
 import type { DB } from "@/db/schema";
 import type { PauseType } from "@/services/video-processing-service";
+import type { ClipZoomType } from "@/features/videos/clip-zoom";
 import type { SilenceLength } from "@/silence-detection-constants";
 import type { BrowserLinkEvent, CapturedWebLink } from "@/lib/clip-web-link";
 import type { Brand } from "./utils";
@@ -35,6 +36,11 @@ export type ClipOnDatabase = {
   profile: string | null;
   insertionOrder: number | null;
   pauseType: PauseType;
+  /**
+   * Clip Zoom. Only a persisted clip carries one — it is an editorial choice
+   * about the shot, made after the take, not something a recording produces.
+   */
+  zoomType: ClipZoomType;
   diagramSnapshotId: string | null;
   diagramName: string | null;
   /**
@@ -279,6 +285,10 @@ export type ClipReducerAction =
       clipId: FrontendId;
     }
   | {
+      type: "toggle-zoom-for-clip";
+      clipId: FrontendId;
+    }
+  | {
       type: "move-clip";
       clipId: FrontendId;
       direction: "up" | "down";
@@ -391,6 +401,11 @@ export type ClipReducerEffect =
       type: "update-pause";
       clipId: DatabaseId;
       pauseType: PauseType;
+    }
+  | {
+      type: "update-zoom";
+      clipId: DatabaseId;
+      zoomType: ClipZoomType;
     }
   | {
       type: "reorder-clip";

--- a/app/features/video-editor/components/clip-item.tsx
+++ b/app/features/video-editor/components/clip-item.tsx
@@ -25,6 +25,7 @@ import {
   Trash2Icon,
   Workflow,
   XIcon,
+  ZoomInIcon,
 } from "lucide-react";
 import type { Clip } from "../clip-state-reducer";
 import { VideoEditorContext } from "../video-editor-context";
@@ -41,6 +42,7 @@ import {
 } from "@/features/diagrams/use-diagram-snapshot-scene";
 import { resolveForClip } from "@/lib/diagram-action-resolver";
 import { getWebLinkLabel } from "@/lib/clip-web-link";
+import { canZoomClip } from "@/features/videos/clip-zoom";
 import {
   openPlayground,
   openPlaygroundWithDiagram,
@@ -108,6 +110,10 @@ export const ClipItem = (props: ClipItemProps) => {
   const onTogglePauseForClip = useContextSelector(
     VideoEditorContext,
     (ctx) => ctx.onTogglePauseForClip
+  );
+  const onToggleZoomForClip = useContextSelector(
+    VideoEditorContext,
+    (ctx) => ctx.onToggleZoomForClip
   );
   const selectedClipsSet = useContextSelector(
     VideoEditorContext,
@@ -237,6 +243,16 @@ export const ClipItem = (props: ClipItemProps) => {
                 </span>
               )}
             </div>
+
+            {/* Clip Zoom badge — only ever present on a camera scene */}
+            {clip.type === "on-database" && clip.zoomType !== "none" && (
+              <div className="z-10 relative mt-2 flex">
+                <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                  <ZoomInIcon className="w-3 h-3 shrink-0" />
+                  Zoomed
+                </span>
+              </div>
+            )}
 
             {/* Diagram pin indicator */}
             {clip.type === "on-database" && clip.diagramSnapshotId && (
@@ -368,6 +384,21 @@ export const ClipItem = (props: ClipItemProps) => {
           <PauseIcon />
           {clip.pauseType === "long" ? "Remove Pause" : "Add Pause"}
         </ContextMenuItem>
+        {/*
+          Offered only where it applies. Roughly nine clips in ten are a Code
+          scene, so a greyed-out entry on every one of them would be noise
+          teaching a rule you already know.
+        */}
+        {clip.type === "on-database" && canZoomClip(clip.scene) && (
+          <ContextMenuItem
+            onSelect={() => {
+              onToggleZoomForClip(clip.frontendId);
+            }}
+          >
+            <ZoomInIcon />
+            {clip.zoomType === "none" ? "Add Zoom" : "Remove Zoom"}
+          </ContextMenuItem>
+        )}
         <ContextMenuItem
           disabled={clip.type !== "on-database"}
           onSelect={() => {

--- a/app/features/video-editor/components/video-player-panel.tsx
+++ b/app/features/video-editor/components/video-player-panel.tsx
@@ -419,7 +419,10 @@ export const VideoPlayerPanel = () => {
               )}
               <div
                 className={cn(
-                  "w-full aspect-[16/9]",
+                  // overflow-hidden is what makes a Clip Zoom read as a
+                  // crop rather than as an oversized video: the zoomed
+                  // <video> is scaled past its box and clipped back to frame.
+                  "w-full aspect-[16/9] overflow-hidden",
                   !showVideoPlayer && "hidden"
                 )}
               >

--- a/app/features/video-editor/edit-effect-handlers.ts
+++ b/app/features/video-editor/edit-effect-handlers.ts
@@ -126,6 +126,16 @@ export function createEditEffectHandlers(
         });
       });
     },
+    "update-zoom": (_state, effect, dispatch) => {
+      clipService.updateZoom(effect.clipId, effect.zoomType).catch((error) => {
+        dispatch({
+          type: "effect-failed",
+          effectType: "update-zoom",
+          message:
+            error instanceof Error ? error.message : "Failed to update zoom",
+        });
+      });
+    },
     "update-pause": (_state, effect, dispatch) => {
       clipService
         .updatePause(effect.clipId, effect.pauseType)

--- a/app/features/video-editor/hooks/use-video-editor.ts
+++ b/app/features/video-editor/hooks/use-video-editor.ts
@@ -17,6 +17,7 @@ export const useVideoEditor = (props: {
   onClipsRemoved: (clipIds: FrontendId[]) => void;
   onClipsRetranscribe: (clipIds: FrontendId[]) => void;
   onTogglePauseForClip: (clipId: FrontendId) => void;
+  onToggleZoomForClip: (clipId: FrontendId) => void;
   onMoveClip: (clipId: FrontendId, direction: "up" | "down") => void;
   onAddChapter: (name: string) => void;
   onUpdateChapter: (chapterId: FrontendId, name: string) => void;
@@ -59,6 +60,9 @@ export const useVideoEditor = (props: {
       },
       "toggle-pause-for-clip": (_state, effect, _dispatch) => {
         props.onTogglePauseForClip(effect.clipId);
+      },
+      "toggle-zoom-for-clip": (_state, effect, _dispatch) => {
+        props.onToggleZoomForClip(effect.clipId);
       },
       "move-clip": (_state, effect, _dispatch) => {
         props.onMoveClip(effect.clipId, effect.direction);

--- a/app/features/video-editor/preloadable-clip.tsx
+++ b/app/features/video-editor/preloadable-clip.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { ClipOnDatabase, FrontendId } from "./clip-state-reducer";
 import { cn } from "@/lib/utils";
+import { clipZoomCssStyle } from "@/features/videos/clip-zoom";
 import {
   BEAT_DURATION,
   FINAL_VIDEO_PADDING,
@@ -140,6 +141,10 @@ export const PreloadableClip = (props: {
         props.hidden && "hidden",
         props.profile === "TikTok" && "w-92 aspect-[9/16]"
       )}
+      // The preview half of the Clip Zoom contract. These two properties are
+      // formatted from the same rect the export's ffmpeg crop is built from
+      // (see features/videos/clip-zoom), so what plays here is what ships.
+      style={clipZoomCssStyle(props.clip.zoomType) ?? undefined}
       ref={ref}
     />
   );

--- a/app/features/video-editor/video-editor-context.tsx
+++ b/app/features/video-editor/video-editor-context.tsx
@@ -100,6 +100,7 @@ export type VideoEditorContextType = {
   onSetInsertionPoint: (mode: "after" | "before", clipId: FrontendId) => void;
   onMoveClip: (clipId: FrontendId, direction: "up" | "down") => void;
   onTogglePauseForClip: (clipId: FrontendId) => void;
+  onToggleZoomForClip: (clipId: FrontendId) => void;
   onAddChapter: (name: string) => void;
   onUpdateChapter: (chapterId: FrontendId, name: string) => void;
   onAddChapterAt: (

--- a/app/features/video-editor/video-editor-selectors-capture.test.ts
+++ b/app/features/video-editor/video-editor-selectors-capture.test.ts
@@ -31,6 +31,7 @@ const makeClipOnDatabase = (
   profile: null,
   insertionOrder: null,
   pauseType: "none",
+  zoomType: "none",
   diagramSnapshotId: null,
   diagramName: null,
   webLinks: [],

--- a/app/features/video-editor/video-editor-selectors-chapters.test.ts
+++ b/app/features/video-editor/video-editor-selectors-chapters.test.ts
@@ -21,6 +21,7 @@ const makeClip = (
   profile: null,
   insertionOrder: null,
   pauseType: "none",
+  zoomType: "none",
   diagramSnapshotId: null,
   diagramName: null,
   webLinks: [],

--- a/app/features/video-editor/video-editor-selectors-clips.test.ts
+++ b/app/features/video-editor/video-editor-selectors-clips.test.ts
@@ -44,6 +44,7 @@ const makeClipOnDatabase = (
   profile: null,
   insertionOrder: null,
   pauseType: "none",
+  zoomType: "none",
   diagramSnapshotId: null,
   diagramName: null,
   webLinks: [],

--- a/app/features/video-editor/video-editor-selectors-danger-metadata.test.ts
+++ b/app/features/video-editor/video-editor-selectors-danger-metadata.test.ts
@@ -45,6 +45,7 @@ const makeClipOnDatabase = (
   profile: null,
   insertionOrder: null,
   pauseType: "none",
+  zoomType: "none",
   diagramSnapshotId: null,
   diagramName: null,
   webLinks: [],

--- a/app/features/video-editor/video-editor-selectors-timeline.test.ts
+++ b/app/features/video-editor/video-editor-selectors-timeline.test.ts
@@ -32,6 +32,7 @@ const makeClipOnDatabase = (
   profile: null,
   insertionOrder: null,
   pauseType: "none",
+  zoomType: "none",
   diagramSnapshotId: null,
   diagramName: null,
   webLinks: [],

--- a/app/features/video-editor/video-editor.tsx
+++ b/app/features/video-editor/video-editor.tsx
@@ -126,6 +126,7 @@ export const VideoEditor = (props: {
   onDeleteLatestInsertedClip: () => void;
   onTogglePause: () => void;
   onTogglePauseForClip: (clipId: FrontendId) => void;
+  onToggleZoomForClip: (clipId: FrontendId) => void;
   onMoveClip: (clipId: FrontendId, direction: "up" | "down") => void;
   onAddChapter: (name: string) => void;
   onUpdateChapter: (chapterId: FrontendId, name: string) => void;
@@ -181,6 +182,7 @@ export const VideoEditor = (props: {
     onClipsRemoved: props.onClipsRemoved,
     onClipsRetranscribe: props.onClipsRetranscribe,
     onTogglePauseForClip: props.onTogglePauseForClip,
+    onToggleZoomForClip: props.onToggleZoomForClip,
     onMoveClip: props.onMoveClip,
     onAddChapter: props.onAddChapter,
     onUpdateChapter: props.onUpdateChapter,
@@ -449,6 +451,7 @@ export const VideoEditor = (props: {
       onSetInsertionPoint: props.onSetInsertionPoint,
       onMoveClip: props.onMoveClip,
       onTogglePauseForClip: props.onTogglePauseForClip,
+      onToggleZoomForClip: props.onToggleZoomForClip,
       onAddChapter: props.onAddChapter,
       onUpdateChapter: props.onUpdateChapter,
       onAddChapterAt: props.onAddChapterAt,
@@ -541,6 +544,7 @@ export const VideoEditor = (props: {
       props.onSetInsertionPoint,
       props.onMoveClip,
       props.onTogglePauseForClip,
+      props.onToggleZoomForClip,
       props.onAddChapter,
       props.onUpdateChapter,
       props.onAddChapterAt,

--- a/app/features/video-editor/video-state-reducer.ts
+++ b/app/features/video-editor/video-state-reducer.ts
@@ -36,6 +36,10 @@ export namespace videoStateReducer {
         clipId: FrontendId;
       }
     | {
+        type: "toggle-zoom-for-clip";
+        clipId: FrontendId;
+      }
+    | {
         type: "move-clip";
         clipId: FrontendId;
         direction: "up" | "down";

--- a/app/features/videos/clip-zoom.test.ts
+++ b/app/features/videos/clip-zoom.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLIP_ZOOM_TYPES,
+  canZoomClip,
+  checkClipZoomEligibility,
+  clipZoomCropFilter,
+  clipZoomCssStyle,
+  clipZoomIneligibilityMessage,
+  clipZoomRect,
+  resolveClipZoomType,
+  ZOOMABLE_SCENES,
+} from "./clip-zoom";
+
+/**
+ * Resolve what an ffmpeg `crop=w:h:x:y` expression actually evaluates to for a
+ * given source size. Mirrors ffmpeg's own arithmetic on `iw`/`ih` so the test
+ * can compare the export's crop against the preview's transform in pixels
+ * rather than by reading two strings and hoping.
+ */
+const evaluateCropFilter = (
+  filter: string,
+  iw: number,
+  ih: number
+): { x: number; y: number; width: number; height: number } => {
+  const [, expressions] = filter.split("=");
+  const [w, h, x, y] = expressions!.split(":").map((expression) =>
+    // Every term is arithmetic over the two source dimensions.
+    Function("iw", "ih", `return ${expression};`)(iw, ih)
+  );
+  return { x: x!, y: y!, width: w!, height: h! };
+};
+
+/**
+ * The source region a CSS `transform: scale(s)` with `transform-origin`
+ * (ox, oy) leaves visible inside the element's own box. A point p maps to
+ * `origin + s * (p - origin)`, so the region surviving into [0, w] starts at
+ * `ox * w * (1 - 1/s)` and is `w / s` wide.
+ */
+const evaluateCssStyle = (
+  style: { transform: string; transformOrigin: string },
+  width: number,
+  height: number
+): { x: number; y: number; width: number; height: number } => {
+  const scale = Number(/scale\(([-\d.]+)\)/.exec(style.transform)![1]);
+  const [originX, originY] = style.transformOrigin
+    .split(" ")
+    .map((part) => Number(part.replace("%", "")) / 100);
+
+  return {
+    x: originX! * width * (1 - 1 / scale),
+    y: originY! * height * (1 - 1 / scale),
+    width: width / scale,
+    height: height / scale,
+  };
+};
+
+describe("clip zoom", () => {
+  describe("resolveClipZoomType", () => {
+    it("passes through every known level", () => {
+      for (const zoomType of CLIP_ZOOM_TYPES) {
+        expect(resolveClipZoomType(zoomType)).toBe(zoomType);
+      }
+    });
+
+    it("reads null, undefined and junk as no zoom", () => {
+      expect(resolveClipZoomType(null)).toBe("none");
+      expect(resolveClipZoomType(undefined)).toBe("none");
+      expect(resolveClipZoomType("wildly-zoomed")).toBe("none");
+    });
+  });
+
+  describe("the rect", () => {
+    it("is absent for an unzoomed clip, so neither consumer emits anything", () => {
+      expect(clipZoomRect("none")).toBeNull();
+      expect(clipZoomCssStyle("none")).toBeNull();
+      expect(clipZoomCropFilter("none")).toBeNull();
+    });
+
+    it("pins the subtle shot: 115%, centred in x, biased above centre in y", () => {
+      expect(clipZoomRect("subtle")).toEqual({
+        scale: 1.15,
+        originX: 0.5,
+        originY: 0.3,
+      });
+    });
+  });
+
+  /**
+   * The requirement the whole feature hangs on: what the editor previews is
+   * what the Publish ships. Both are formatted from one rect, and this is what
+   * makes that a fact rather than an intention — the two are compared as
+   * resolved pixel rectangles, at several resolutions.
+   */
+  describe("preview and export describe the same shot", () => {
+    const RESOLUTIONS = [
+      { label: "landscape 1080p", width: 1920, height: 1080 },
+      { label: "portrait 1080x1920", width: 1080, height: 1920 },
+      { label: "landscape 1440p", width: 2560, height: 1440 },
+    ];
+
+    for (const zoomType of CLIP_ZOOM_TYPES.filter((t) => t !== "none")) {
+      for (const { label, width, height } of RESOLUTIONS) {
+        it(`agree for "${zoomType}" at ${label}`, () => {
+          const fromExport = evaluateCropFilter(
+            clipZoomCropFilter(zoomType)!,
+            width,
+            height
+          );
+          const fromPreview = evaluateCssStyle(
+            clipZoomCssStyle(zoomType)!,
+            width,
+            height
+          );
+
+          expect(fromPreview.x).toBeCloseTo(fromExport.x, 6);
+          expect(fromPreview.y).toBeCloseTo(fromExport.y, 6);
+          expect(fromPreview.width).toBeCloseTo(fromExport.width, 6);
+          expect(fromPreview.height).toBeCloseTo(fromExport.height, 6);
+        });
+      }
+    }
+
+    it("crops toward the top of frame, not the centre", () => {
+      const { y, height } = evaluateCropFilter(
+        clipZoomCropFilter("subtle")!,
+        1920,
+        1080
+      );
+      const discardedAbove = y;
+      const discardedBelow = 1080 - (y + height);
+
+      expect(discardedAbove).toBeLessThan(discardedBelow);
+    });
+
+    it("keeps the crop inside the source frame", () => {
+      const { x, y, width, height } = evaluateCropFilter(
+        clipZoomCropFilter("subtle")!,
+        1920,
+        1080
+      );
+
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(x + width).toBeLessThanOrEqual(1920);
+      expect(y + height).toBeLessThanOrEqual(1080);
+    });
+  });
+
+  describe("eligibility", () => {
+    it("allows every camera scene", () => {
+      for (const scene of ZOOMABLE_SCENES) {
+        expect(canZoomClip(scene)).toBe(true);
+        expect(checkClipZoomEligibility(scene)).toBeNull();
+      }
+    });
+
+    it("refuses a scene that is not a camera", () => {
+      for (const scene of ["Code", "No Face", "TikTok Code", "white noise"]) {
+        expect(canZoomClip(scene)).toBe(false);
+        expect(checkClipZoomEligibility(scene)).toEqual({
+          reason: "not-a-camera-scene",
+          scene,
+        });
+      }
+    });
+
+    it("refuses a clip with no recorded scene, and says so distinctly", () => {
+      // ~4,500 clips predate scene capture. They are ineligible, but for a
+      // different reason than a Code clip is, and the message has to say which.
+      for (const scene of [null, undefined, ""]) {
+        expect(canZoomClip(scene)).toBe(false);
+        expect(checkClipZoomEligibility(scene)).toEqual({
+          reason: "no-recorded-scene",
+        });
+      }
+
+      expect(
+        clipZoomIneligibilityMessage({ reason: "no-recorded-scene" })
+      ).not.toBe(
+        clipZoomIneligibilityMessage({
+          reason: "not-a-camera-scene",
+          scene: "Code",
+        })
+      );
+    });
+
+    it("names the offending scene in the refusal", () => {
+      expect(
+        clipZoomIneligibilityMessage({
+          reason: "not-a-camera-scene",
+          scene: "Code",
+        })
+      ).toContain("Code");
+    });
+  });
+});

--- a/app/features/videos/clip-zoom.ts
+++ b/app/features/videos/clip-zoom.ts
@@ -1,0 +1,181 @@
+/**
+ * Clip Zoom — the single place the zoomed shot is decided.
+ *
+ * A Clip Zoom renders a Clip larger than frame, cropped in, so that a run of
+ * face-only Camera clips has some visual change across the cuts. It is a
+ * clip-level marker in exactly the sense `pauseType` is: an enum (not a
+ * boolean) so it can gain more levels later, and a property the renderer acts
+ * on — which is why it must reach the Export Hash (see export-hash.ts).
+ *
+ * Two consumers have to agree on the shot, or the editor preview lies about
+ * what the Publish will ship:
+ *
+ *   - the preview, a CSS transform on the clip's <video> element
+ *   - the export, an ffmpeg `crop` in the concat filter chain
+ *
+ * They agree because they are both formatted from {@link clipZoomRect} and
+ * nothing else. The rect is fractional rather than pixel-valued, so it is
+ * resolution-independent: filming at 1440 instead of 1080 needs no change
+ * here. `clip-zoom.test.ts` pins the two formattings against the same
+ * arithmetic, so drift needs someone to edit this file.
+ */
+
+export const CLIP_ZOOM_TYPES = ["none", "subtle"] as const;
+
+export type ClipZoomType = (typeof CLIP_ZOOM_TYPES)[number];
+
+export const DEFAULT_CLIP_ZOOM_TYPE: ClipZoomType = "none";
+
+/**
+ * The OBS scenes a Clip Zoom may be applied to: the ones that are just Matt's
+ * face, where a cut to a slightly tighter shot reads as deliberate. Zooming a
+ * `Code` scene would crop the code, which is the content.
+ *
+ * `TikTok Face` is the portrait profile's camera scene; `Camera` appears under
+ * both profiles.
+ */
+export const ZOOMABLE_SCENES: readonly string[] = ["Camera", "TikTok Face"];
+
+/**
+ * A zoom expressed as fractions of the frame, in the same terms CSS uses:
+ * `scale` is the magnification, and `originX`/`originY` are the fixed point
+ * the magnification happens around (0.5/0.5 being dead centre).
+ *
+ * Both numbers stay fractional deliberately — a rect in source pixels would
+ * need different arithmetic for a 1920x1080 Camera clip and a 1080x1920
+ * TikTok Face clip, and would have to be rewritten the day the camera moves
+ * to 1440.
+ */
+export type ClipZoomRect = {
+  readonly scale: number;
+  readonly originX: number;
+  readonly originY: number;
+};
+
+/**
+ * 115% was picked by rendering candidates against real Camera footage: 108%
+ * is invisible unless you flick between frames, and past ~120% the crop starts
+ * eating the hand gestures that sit low in the shot.
+ *
+ * The vertical origin sits above centre (0.3, so 30% of the discarded height
+ * comes off the top and 70% off the bottom) because the framing already puts
+ * the head high with headroom to spare — a centred crop tightens the headroom
+ * faster than it tightens anything worth keeping.
+ *
+ * Retuning either number is a one-line edit here. It is deliberately NOT
+ * encoded in the enum's value names, which would put today's numbers into
+ * every row and make retuning a migration.
+ */
+const ZOOM_RECTS: Record<ClipZoomType, ClipZoomRect | null> = {
+  none: null,
+  subtle: { scale: 1.15, originX: 0.5, originY: 0.3 },
+};
+
+/**
+ * Coerce a raw `zoom_type` string (e.g. straight off the DB column) into a
+ * known {@link ClipZoomType}. Anything unrecognised is treated as no zoom —
+ * the reading that renders what the footage already looked like.
+ */
+export const resolveClipZoomType = (
+  zoomType: string | null | undefined
+): ClipZoomType =>
+  (CLIP_ZOOM_TYPES as readonly string[]).includes(zoomType ?? "")
+    ? (zoomType as ClipZoomType)
+    : DEFAULT_CLIP_ZOOM_TYPE;
+
+/**
+ * The shot, or `null` for a clip that renders exactly as it was filmed.
+ * Every consumer goes through here.
+ */
+export const clipZoomRect = (
+  zoomType: string | null | undefined
+): ClipZoomRect | null => ZOOM_RECTS[resolveClipZoomType(zoomType)];
+
+/**
+ * The preview half of the contract: CSS properties for the clip's <video>.
+ * `null` when there is no zoom, so the element keeps its untouched styles
+ * rather than carrying an identity transform.
+ *
+ * A `transform-origin` of (ox, oy) under `scale(s)` exposes the source region
+ * starting at `ox * w * (1 - 1/s)` — which is precisely the ffmpeg crop offset
+ * below. That identity is what makes the preview honest, and it is asserted in
+ * the tests rather than left as a comment.
+ */
+export const clipZoomCssStyle = (
+  zoomType: string | null | undefined
+): { transform: string; transformOrigin: string } | null => {
+  const rect = clipZoomRect(zoomType);
+  if (!rect) return null;
+
+  return {
+    transform: `scale(${rect.scale})`,
+    transformOrigin: `${rect.originX * 100}% ${rect.originY * 100}%`,
+  };
+};
+
+/**
+ * The export half: an ffmpeg `crop` filter, or `null` for no zoom.
+ *
+ * Written in ffmpeg's own `iw`/`ih` terms rather than resolved pixels so the
+ * filter is correct for whatever the source happens to be. This crop belongs
+ * BEFORE the normalising `scale` in the chain: cropping first means a 2560x1440
+ * source is cut to 2226x1252 and then scaled DOWN to the 1920x1080 output, so
+ * the zoom costs no sharpness at all. Cropping after the scale would throw the
+ * surplus resolution away and then stretch what was left.
+ */
+export const clipZoomCropFilter = (
+  zoomType: string | null | undefined
+): string | null => {
+  const rect = clipZoomRect(zoomType);
+  if (!rect) return null;
+
+  const { scale, originX, originY } = rect;
+  return [
+    `crop=iw/${scale}`,
+    `ih/${scale}`,
+    `(iw-iw/${scale})*${originX}`,
+    `(ih-ih/${scale})*${originY}`,
+  ].join(":");
+};
+
+/**
+ * Why a Clip cannot be zoomed. `null` means it can.
+ *
+ * The two reasons are kept apart because they are different problems for
+ * whoever hit the wall: a `Code` clip is one you should not be zooming, while
+ * a scene-less clip is one filmed before CVM recorded scenes at all (there are
+ * ~4,500 of them) and no amount of retrying will make it eligible.
+ */
+export type ClipZoomIneligibility =
+  | { readonly reason: "no-recorded-scene" }
+  | { readonly reason: "not-a-camera-scene"; readonly scene: string };
+
+export const checkClipZoomEligibility = (
+  scene: string | null | undefined
+): ClipZoomIneligibility | null => {
+  if (scene === null || scene === undefined || scene === "") {
+    return { reason: "no-recorded-scene" };
+  }
+  if (!ZOOMABLE_SCENES.includes(scene)) {
+    return { reason: "not-a-camera-scene", scene };
+  }
+  return null;
+};
+
+/**
+ * The predicate the UI uses to decide whether to offer the affordance at all.
+ * The service enforces the same rule, so a caller that never touches the UI
+ * (the CLI, or the next one) inherits it rather than reimplementing it.
+ */
+export const canZoomClip = (scene: string | null | undefined): boolean =>
+  checkClipZoomEligibility(scene) === null;
+
+/** Human-facing text for a refusal, shared by every caller that has to say no. */
+export const clipZoomIneligibilityMessage = (
+  ineligibility: ClipZoomIneligibility
+): string =>
+  ineligibility.reason === "no-recorded-scene"
+    ? "clip has no recorded scene, so it cannot be zoomed"
+    : `clip zoom applies only to camera scenes ${JSON.stringify(
+        ZOOMABLE_SCENES
+      )} (this clip is ${JSON.stringify(ineligibility.scene)})`;

--- a/app/packages/course-json/lib/build-course-json.ts
+++ b/app/packages/course-json/lib/build-course-json.ts
@@ -241,6 +241,7 @@ type InputClip = {
   sourceStartTime: number;
   sourceEndTime: number;
   pauseType: string;
+  zoomType: string;
   order: string;
 };
 

--- a/app/packages/course-json/tests/course-json-validation.test.ts
+++ b/app/packages/course-json/tests/course-json-validation.test.ts
@@ -87,6 +87,7 @@ const CLIPS = [
     sourceStartTime: 0,
     sourceEndTime: 10,
     pauseType: "none",
+    zoomType: "none",
     order: "a0",
   },
   {
@@ -94,6 +95,7 @@ const CLIPS = [
     sourceStartTime: 15,
     sourceEndTime: 25,
     pauseType: "none",
+    zoomType: "none",
     order: "a1",
   },
 ];

--- a/app/packages/course-json/tests/course-json.test.ts
+++ b/app/packages/course-json/tests/course-json.test.ts
@@ -86,6 +86,7 @@ const CLIPS = [
     sourceStartTime: 0,
     sourceEndTime: 10,
     pauseType: "none",
+    zoomType: "none",
     order: "a0",
   },
   {
@@ -93,6 +94,7 @@ const CLIPS = [
     sourceStartTime: 15,
     sourceEndTime: 25,
     pauseType: "none",
+    zoomType: "none",
     order: "a1",
   },
 ];
@@ -443,6 +445,7 @@ describe("buildCourseJson", () => {
                       sourceStartTime: 0,
                       sourceEndTime: 20,
                       pauseType: "none",
+                      zoomType: "none",
                       order: "a0",
                     },
                     {
@@ -450,6 +453,7 @@ describe("buildCourseJson", () => {
                       sourceStartTime: 25,
                       sourceEndTime: 45,
                       pauseType: "none",
+                      zoomType: "none",
                       order: "a2",
                     },
                   ],

--- a/app/routes/_app.videos.$videoId.edit.tsx
+++ b/app/routes/_app.videos.$videoId.edit.tsx
@@ -13,6 +13,7 @@ import {
   createFrontendId,
 } from "@/features/video-editor/clip-state-reducer";
 import type { PauseType } from "@/services/video-processing-service";
+import { resolveClipZoomType } from "@/features/videos/clip-zoom";
 import { useOBSConnector } from "@/features/video-editor/obs-connector";
 import { targetProfileForFormat } from "@/features/video-editor/ensure-obs-profile";
 import { useSilenceLength } from "@/features/video-editor/use-silence-length";
@@ -230,6 +231,7 @@ export const ComponentInner = (props: Route.ComponentProps) => {
           databaseId: clip.id as DatabaseId,
           insertionOrder: null,
           pauseType: clip.pauseType as PauseType,
+          zoomType: resolveClipZoomType(clip.zoomType),
           diagramSnapshotId: clip.diagramSnapshotId ?? null,
           diagramName: clip.diagramSnapshot?.diagram?.name ?? null,
           webLinks: (clip.webLinks ?? []) as ClipOnDatabase["webLinks"],
@@ -409,6 +411,9 @@ export const ComponentInner = (props: Route.ComponentProps) => {
       }}
       onTogglePauseForClip={(clipId) => {
         dispatch({ type: "toggle-pause-for-clip", clipId });
+      }}
+      onToggleZoomForClip={(clipId) => {
+        dispatch({ type: "toggle-zoom-for-clip", clipId });
       }}
       onMoveClip={(clipId, direction) => {
         dispatch({ type: "move-clip", clipId, direction });

--- a/app/services/batch-export.server.ts
+++ b/app/services/batch-export.server.ts
@@ -38,6 +38,7 @@ export const batchExportProgram = (
         sourceStartTime: number;
         sourceEndTime: number;
         pauseType: string;
+        zoomType: string;
       }>;
     }> = [];
 
@@ -96,6 +97,7 @@ export const batchExportProgram = (
                   clip.sourceStartTime +
                   (isFinalClip ? FINAL_VIDEO_PADDING : 0),
                 pauseType: clip.pauseType as PauseType,
+                zoomType: clip.zoomType,
               };
             }),
             onStageChange: (stage) => {

--- a/app/services/clip-service-handler.ts
+++ b/app/services/clip-service-handler.ts
@@ -13,6 +13,10 @@ import { eq } from "drizzle-orm";
 import { Effect } from "effect";
 import { generateNKeysBetween } from "fractional-indexing";
 import {
+  checkClipZoomEligibility,
+  clipZoomIneligibilityMessage,
+} from "@/features/videos/clip-zoom";
+import {
   createClipService,
   type ClipService,
   type ClipServiceEvent,
@@ -254,6 +258,41 @@ const dispatchClipServiceEvent = Effect.fn("dispatchClipServiceEvent")(
             pauseType: event.pauseType,
           });
         }
+        return;
+      }
+
+      case "update-zoom": {
+        // The eligibility rule is enforced here, not only at the call sites,
+        // so every caller inherits it. The editor hides the affordance on an
+        // ineligible clip and the CLI pre-checks to report a clean typed
+        // error, but neither of those is what makes the rule hold.
+        const clip = yield* Effect.promise(() =>
+          db.query.clips.findFirst({
+            where: eq(clips.id, event.clipId),
+          })
+        );
+        if (!clip) {
+          throw new Error(`Clip not found: ${event.clipId}`);
+        }
+
+        const ineligibility = checkClipZoomEligibility(clip.scene);
+        if (ineligibility) {
+          throw new Error(clipZoomIneligibilityMessage(ineligibility));
+        }
+
+        yield* Effect.promise(() =>
+          db
+            .update(clips)
+            .set({ zoomType: event.zoomType })
+            .where(eq(clips.id, event.clipId))
+        );
+
+        yield* touchVideoUpdatedAt(db, clip.videoId);
+        logger.log(clip.videoId, {
+          type: "zoom-updated",
+          clipId: event.clipId,
+          zoomType: event.zoomType,
+        });
         return;
       }
 

--- a/app/services/clip-service.schemas.ts
+++ b/app/services/clip-service.schemas.ts
@@ -150,6 +150,11 @@ export const ClipServiceEventSchema = Schema.Union(
     pauseType: Schema.String,
   }),
   Schema.Struct({
+    type: Schema.Literal("update-zoom"),
+    clipId: Schema.String,
+    zoomType: Schema.String,
+  }),
+  Schema.Struct({
     type: Schema.Literal("reorder-clip"),
     clipId: Schema.String,
     direction: ReorderDirectionSchema,

--- a/app/services/clip-service.ts
+++ b/app/services/clip-service.ts
@@ -346,6 +346,11 @@ export interface ClipService {
   unarchiveClips(clipIds: string[]): Promise<void>;
   updateClips(clips: UpdateClipInput[]): Promise<void>;
   updatePause(clipId: string, pauseType: string): Promise<void>;
+  /**
+   * Set a Clip's Clip Zoom. Rejects any clip whose recorded scene is not a
+   * camera scene — see canZoomClip in features/videos/clip-zoom.
+   */
+  updateZoom(clipId: string, zoomType: string): Promise<void>;
   reorderClip(clipId: string, direction: ReorderDirection): Promise<void>;
 
   // Chapter operations
@@ -392,6 +397,7 @@ export type ClipServiceEvent =
   | { type: "unarchive-clips"; clipIds: readonly string[] }
   | { type: "update-clips"; clips: readonly UpdateClipInput[] }
   | { type: "update-pause"; clipId: string; pauseType: string }
+  | { type: "update-zoom"; clipId: string; zoomType: string }
   | { type: "reorder-clip"; clipId: string; direction: ReorderDirection }
   | {
       type: "create-chapter-at-insertion-point";
@@ -492,6 +498,10 @@ export function createClipService(send: ClipServiceTransport): ClipService {
 
     async updatePause(clipId, pauseType) {
       await send({ type: "update-pause", clipId, pauseType });
+    },
+
+    async updateZoom(clipId, zoomType) {
+      await send({ type: "update-zoom", clipId, zoomType });
     },
 
     async reorderClip(clipId, direction) {

--- a/app/services/course-publish-dropbox-upload.test.ts
+++ b/app/services/course-publish-dropbox-upload.test.ts
@@ -183,6 +183,7 @@ const setupUploads = async (opts?: {
       sourceStartTime: clip.sourceStartTime,
       sourceEndTime: clip.sourceEndTime,
       pauseType: "none",
+      zoomType: "none",
     }));
     const exportHash = computeExportHash(clips, "landscape")!;
     const exportPath = resolveExportPath(

--- a/app/services/course-publish-service-batch-export.test.ts
+++ b/app/services/course-publish-service-batch-export.test.ts
@@ -134,6 +134,7 @@ const setup = async () => {
       order: "a0",
       text: "Hello world",
       pauseType: "none",
+      zoomType: "none",
     },
     {
       videoId: video.id,
@@ -143,6 +144,7 @@ const setup = async () => {
       order: "a1",
       text: "Welcome to the course",
       pauseType: "none",
+      zoomType: "none",
     },
   ]);
 
@@ -152,12 +154,14 @@ const setup = async () => {
       sourceStartTime: 0,
       sourceEndTime: 10,
       pauseType: "none",
+      zoomType: "none",
     },
     {
       videoFilename: "recording.mp4",
       sourceStartTime: 15,
       sourceEndTime: 25,
       pauseType: "none",
+      zoomType: "none",
     },
   ];
   const exportHash = computeExportHash(clips, "landscape")!;
@@ -209,6 +213,7 @@ const addVideo = async (
         order: `a${index}`,
         text: title,
         pauseType: "none",
+        zoomType: "none",
       };
       // Leave a gap, so the spans read as distinct takes from one recording.
       sourceStartTime += duration + 1;

--- a/app/services/course-publish-service-sync.test.ts
+++ b/app/services/course-publish-service-sync.test.ts
@@ -182,6 +182,7 @@ const setupSync = async () => {
     sourceStartTime: c.sourceStartTime,
     sourceEndTime: c.sourceEndTime,
     pauseType: "none",
+    zoomType: "none",
     order: c.order,
   }));
   const exportHash = computeExportHash(clips, "landscape")!;

--- a/app/services/course-publish-service-test-setup.ts
+++ b/app/services/course-publish-service-test-setup.ts
@@ -127,12 +127,14 @@ export const setupPublishableCourse = async (opts?: {
       sourceStartTime: 0,
       sourceEndTime: 10 + index,
       pauseType: "none",
+      zoomType: "none",
     },
     {
       videoFilename: "recording.mp4",
       sourceStartTime: 15,
       sourceEndTime: 25 + index,
       pauseType: "none",
+      zoomType: "none",
     },
   ];
 

--- a/app/services/course-publish-service.test.ts
+++ b/app/services/course-publish-service.test.ts
@@ -130,6 +130,7 @@ const setup = async () => {
       order: "a0",
       text: "Hello world",
       pauseType: "none",
+      zoomType: "none",
     },
     {
       videoId: video.id,
@@ -139,6 +140,7 @@ const setup = async () => {
       order: "a1",
       text: "Welcome to the course",
       pauseType: "none",
+      zoomType: "none",
     },
   ]);
 
@@ -148,12 +150,14 @@ const setup = async () => {
       sourceStartTime: 0,
       sourceEndTime: 10,
       pauseType: "none",
+      zoomType: "none",
     },
     {
       videoFilename: "recording.mp4",
       sourceStartTime: 15,
       sourceEndTime: 25,
       pauseType: "none",
+      zoomType: "none",
     },
   ];
   const exportHash = computeExportHash(clips, "landscape")!;

--- a/app/services/course-publish-service.ts
+++ b/app/services/course-publish-service.ts
@@ -49,6 +49,7 @@ export type VideoForExport = {
     sourceStartTime: number;
     sourceEndTime: number;
     pauseType: string;
+    zoomType: string;
     order: string;
   }>;
 };
@@ -183,6 +184,7 @@ export class CoursePublishService extends Effect.Service<CoursePublishService>()
                 clip.sourceStartTime +
                 (isFinalClip ? FINAL_VIDEO_PADDING : 0),
               pauseType: (clip.pauseType as PauseType) || "none",
+              zoomType: clip.zoomType,
             };
           }),
           onStageChange: onStage,

--- a/app/services/db-clip-operations.server.ts
+++ b/app/services/db-clip-operations.server.ts
@@ -18,6 +18,11 @@ import {
 } from "./draft-guard.server";
 import { transactionalizeWrites } from "./with-db-transaction.server";
 import { compareOrderStrings } from "@/lib/sort-by-order";
+import {
+  checkClipZoomEligibility,
+  clipZoomIneligibilityMessage,
+} from "@/features/videos/clip-zoom";
+import { ClipNotZoomableError } from "@/services/db-service-errors";
 
 const makeDbCall = <T>(fn: () => Promise<T>) => {
   return Effect.tryPromise({
@@ -72,6 +77,37 @@ const createClipOperationsUnwrapped = (db: Database) => {
     );
 
     return clip!;
+  });
+
+  /**
+   * Set a Clip's Clip Zoom.
+   *
+   * A dedicated operation rather than another optional field on `updateClip`,
+   * because the write carries a rule `updateClip` has no business knowing:
+   * a zoom is legal only on a camera scene. Enforcing it here means the CLI
+   * and any future caller inherit the rule instead of reimplementing it.
+   */
+  const setClipZoom = Effect.fn("setClipZoom")(function* (
+    clipId: string,
+    zoomType: string
+  ) {
+    const clip = yield* getClipById(clipId);
+
+    const ineligibility = checkClipZoomEligibility(clip.scene);
+    if (ineligibility) {
+      return yield* new ClipNotZoomableError({
+        clipId,
+        scene: clip.scene ?? null,
+        message: clipZoomIneligibilityMessage(ineligibility),
+      });
+    }
+
+    yield* requireDraftVersionForClip(db, clipId);
+    const [updated] = yield* makeDbCall(() =>
+      db.update(clips).set({ zoomType }).where(eq(clips.id, clipId)).returning()
+    );
+
+    return updated!;
   });
 
   const archiveClip = Effect.fn("archiveClip")(function* (clipId: string) {
@@ -718,6 +754,7 @@ const createClipOperationsUnwrapped = (db: Database) => {
     getClipById,
     getClipsByIds,
     updateClip,
+    setClipZoom,
     archiveClip,
     reorderClip,
     createChapter,
@@ -737,6 +774,7 @@ const createClipOperationsUnwrapped = (db: Database) => {
 export const createClipOperations = (db: Database) =>
   transactionalizeWrites(db, createClipOperationsUnwrapped, [
     "updateClip",
+    "setClipZoom",
     "archiveClip",
     "reorderClip",
     "createChapter",

--- a/app/services/db-course-duplicate.server.ts
+++ b/app/services/db-course-duplicate.server.ts
@@ -206,6 +206,7 @@ export const makeDuplicateCourse = (db: Database) =>
                   scene: clip.scene,
                   profile: clip.profile,
                   pauseType: clip.pauseType,
+                  zoomType: clip.zoomType,
                   diagramSnapshotId: clip.diagramSnapshotId,
                 }))
               )

--- a/app/services/db-course-operations.server.ts
+++ b/app/services/db-course-operations.server.ts
@@ -261,6 +261,7 @@ export const createCourseOperations = (db: Database) => {
                                 sourceEndTime: true,
                                 // Part of the export address — see export-hash.
                                 pauseType: true,
+                                zoomType: true,
                                 order: true,
                                 archived: true,
                               },

--- a/app/services/db-duplicate-course-drift.test.ts
+++ b/app/services/db-duplicate-course-drift.test.ts
@@ -94,6 +94,9 @@ describe("duplicateCourse — schema-drift guard", () => {
         "scene",
         "profile",
         "pauseType",
+        // A Clip Zoom is a property of that clip's shot, so a copied clip
+        // should look the same as the one it came from.
+        "zoomType",
         "diagramSnapshotId",
       ],
       notCopied: ["id", "videoId", "archived", "createdAt"],

--- a/app/services/db-service-errors.ts
+++ b/app/services/db-service-errors.ts
@@ -103,3 +103,17 @@ export class VideoTitleTakenError extends Data.TaggedError(
   title: string;
   message: string;
 }> {}
+
+/**
+ * A Clip Zoom was asked for on a Clip that cannot carry one — its recorded
+ * scene is not a camera scene, or it has no recorded scene at all (clips
+ * filmed before CVM captured scenes). Carries the human-facing reason built
+ * by clipZoomIneligibilityMessage so every caller reports the same wall.
+ */
+export class ClipNotZoomableError extends Data.TaggedError(
+  "ClipNotZoomableError"
+)<{
+  clipId: string;
+  scene: string | null;
+  message: string;
+}> {}

--- a/app/services/db-video-operations.copy.server.ts
+++ b/app/services/db-video-operations.copy.server.ts
@@ -66,8 +66,14 @@ export const copyVideoImpl = (
   }
 ): Effect.Effect<string, NotFoundError | UnknownDBServiceError> =>
   Effect.gen(function* () {
-    const { sourceVideoId, newTitle, copyClips, copyBeats, copyScript, renameOld } =
-      opts;
+    const {
+      sourceVideoId,
+      newTitle,
+      copyClips,
+      copyBeats,
+      copyScript,
+      renameOld,
+    } = opts;
 
     // Load source video outside the transaction so we can surface NotFoundError
     // before opening a transaction.
@@ -167,6 +173,7 @@ export const copyVideoImpl = (
                 scene: clip.scene,
                 profile: clip.profile,
                 pauseType: clip.pauseType,
+                zoomType: clip.zoomType,
                 diagramSnapshotId: clip.diagramSnapshotId,
               }))
             );

--- a/app/services/draft-guard.server.ts
+++ b/app/services/draft-guard.server.ts
@@ -271,6 +271,7 @@ export const requireDraftForClipServiceEvent = Effect.fn(
         event.clips.map((c) => c.id)
       );
     case "update-pause":
+    case "update-zoom":
     case "reorder-clip":
       return yield* requireDraftVersionForClip(db, event.clipId);
     case "update-chapter":

--- a/app/services/export-hash.test.ts
+++ b/app/services/export-hash.test.ts
@@ -17,6 +17,7 @@ const makeClip = (
     Pick<ExportClip, "videoFilename" | "sourceStartTime" | "sourceEndTime">
 ): ExportClip => ({
   pauseType: "none",
+  zoomType: "none",
   ...overrides,
 });
 
@@ -203,11 +204,50 @@ describe("export-hash", () => {
               sourceStartTime: 0,
               sourceEndTime: 10,
               pauseType: "none",
+              zoomType: "none",
             }),
           ],
           "landscape"
         )
       ).toBe("ae5332862e6c002c82e975dceadd3cab");
+    });
+
+    it("changing a clip's Clip Zoom changes the address", () => {
+      // The renderer crops a zoomed clip, so it ships different bytes. A zoom
+      // that did not reach the address would leave the un-zoomed export
+      // addressable and the Publish would ship it.
+      const at = (zoomType: string) =>
+        computeExportHash(
+          [
+            makeClip({
+              videoFilename: "rec.mp4",
+              sourceStartTime: 0,
+              sourceEndTime: 10,
+              zoomType,
+            }),
+          ],
+          "landscape"
+        );
+
+      expect(at("subtle")).not.toBe(at("none"));
+    });
+
+    it("treats an unrecognised zoom as no zoom", () => {
+      const at = (zoomType: string) =>
+        computeExportHash(
+          [
+            makeClip({
+              videoFilename: "rec.mp4",
+              sourceStartTime: 0,
+              sourceEndTime: 10,
+              zoomType,
+            }),
+          ],
+          "landscape"
+        );
+
+      expect(at("wildly-zoomed")).toBe(at("none"));
+      expect(at("")).toBe(at("none"));
     });
 
     it("changing EXPORT_VERSION would change hashes", () => {

--- a/app/services/export-hash.ts
+++ b/app/services/export-hash.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import { Effect } from "effect";
 import { FileSystem } from "@effect/platform";
 import { resolveVideoFormat } from "@/features/videos/video-format";
+import {
+  DEFAULT_CLIP_ZOOM_TYPE,
+  resolveClipZoomType,
+} from "@/features/videos/clip-zoom";
 
 /**
  * Bump this constant to force re-export of all videos (e.g., after changing
@@ -15,6 +19,7 @@ export type ExportClip = {
   sourceStartTime: number;
   sourceEndTime: number;
   pauseType: string;
+  zoomType: string;
 };
 
 /**
@@ -37,6 +42,7 @@ export const toExportClips = (
     sourceStartTime: number;
     sourceEndTime: number;
     pauseType: string;
+    zoomType: string;
   }>
 ): ExportClip[] =>
   clips.map((c) => ({
@@ -44,6 +50,7 @@ export const toExportClips = (
     sourceStartTime: c.sourceStartTime,
     sourceEndTime: c.sourceEndTime,
     pauseType: c.pauseType,
+    zoomType: c.zoomType,
   }));
 
 /**
@@ -62,6 +69,13 @@ export const toExportClips = (
  * flipping a video's format must invalidate its existing export. The raw column
  * is normalised via {@link resolveVideoFormat} so callers can pass it straight
  * from the DB.
+ *
+ * A clip's Clip Zoom (`zoomType`) is part of the address for the same reason
+ * `pauseType` is: the renderer crops a zoomed clip, so it changes the exported
+ * bytes. It is emitted only when it is not "none", so every export made before
+ * Clip Zoom existed keeps the address it already had and nothing re-renders —
+ * the same reasoning that let `pauseType` be added without bumping
+ * EXPORT_VERSION.
  *
  * A clip's `pauseType` is part of the address too, because a long pause makes
  * the renderer hold the clip longer and so changes the exported bytes. It is
@@ -84,6 +98,9 @@ export const computeExportHash = (
       s: c.sourceStartTime,
       e: c.sourceEndTime,
       ...(c.pauseType === LONG_PAUSE ? { p: LONG_PAUSE } : {}),
+      ...(resolveClipZoomType(c.zoomType) === DEFAULT_CLIP_ZOOM_TYPE
+        ? {}
+        : { z: resolveClipZoomType(c.zoomType) }),
     })),
   };
 

--- a/app/services/ffmpeg-commands.ts
+++ b/app/services/ffmpeg-commands.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { tmpdir } from "os";
 import { registerFfmpegChild } from "./ffmpeg-child-registry";
 import { createFfmpegProgressParser } from "./ffmpeg-progress";
+import { clipZoomCropFilter } from "@/features/videos/clip-zoom";
 
 const GPU_PERMITS = 6;
 const CPU_PERMITS = 12;
@@ -198,6 +199,7 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
           startTime: number;
           duration: number;
           pauseType: "none" | "long";
+          zoomType?: string;
         }[],
         dimensions: { width: number; height: number },
         onProgress?: (percent: number) => void
@@ -242,11 +244,21 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
         // video's format: portrait 1080x1920 for shorts (whose 9:16 subtitle
         // overlay must line up), landscape 1920x1080 otherwise. Passing the
         // wrong dimensions here is what previously forced every export portrait.
+        //
+        // A Clip Zoom's crop goes BEFORE that scale, so a source larger than
+        // the output frame is cropped and then scaled DOWN — the zoom spends
+        // surplus resolution rather than upscaling. Cropping after the scale
+        // would discard those pixels first and stretch what remained. The crop
+        // string comes from clipZoomCropFilter, the same rect the editor
+        // preview's CSS transform is formatted from.
         const filterParts: string[] = [];
         const concatInputs: string[] = [];
         for (let i = 0; i < clips.length; i++) {
+          const cropFilter = clipZoomCropFilter(clips[i]!.zoomType);
           filterParts.push(
-            `[${i}:v]setpts=PTS-STARTPTS,scale=${dimensions.width}:${dimensions.height},setsar=1[v${i}]`,
+            `[${i}:v]setpts=PTS-STARTPTS,${
+              cropFilter ? `${cropFilter},` : ""
+            }scale=${dimensions.width}:${dimensions.height},setsar=1[v${i}]`,
             `[${i}:a]asetpts=PTS-STARTPTS,aformat=channel_layouts=stereo[a${i}]`
           );
           concatInputs.push(`[v${i}][a${i}]`);

--- a/app/services/render-vertical-video-service.ts
+++ b/app/services/render-vertical-video-service.ts
@@ -56,6 +56,7 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
                 startTime: clip.sourceStartTime,
                 duration: clip.sourceEndTime - clip.sourceStartTime,
                 pauseType: clip.pauseType as "none" | "long",
+                zoomType: clip.zoomType,
               })),
               // The vertical renderer always produces a 9:16 short — the Remotion
               // subtitle/CTA overlay below is rendered at 1080x1920 to match.

--- a/app/services/video-concatenation-service.ts
+++ b/app/services/video-concatenation-service.ts
@@ -97,6 +97,7 @@ export const concatenateVideos = Effect.fn("concatenateVideos")(
                 scene: clip.scene,
                 profile: clip.profile,
                 pauseType: clip.pauseType,
+                zoomType: clip.zoomType,
               })
             );
           } else {

--- a/app/services/video-editor-logger-service.ts
+++ b/app/services/video-editor-logger-service.ts
@@ -45,6 +45,11 @@ export type LogEvent =
       pauseType: string;
     }
   | {
+      type: "zoom-updated";
+      clipId: string;
+      zoomType: string;
+    }
+  | {
       type: "clip-reordered";
       clipId: string;
       direction: "up" | "down";

--- a/app/services/video-processing-service.ts
+++ b/app/services/video-processing-service.ts
@@ -137,6 +137,7 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
           startTime: number;
           duration: number;
           pauseType: PauseType;
+          zoomType: string;
         }[];
         shortsDirectoryOutputName: string | undefined;
         onStageChange?: (


### PR DESCRIPTION
Adds a clip-level marker (`zoom_type`: `none` | `subtle`) that renders a **Clip** at 115% of frame — cropped centrally in x, biased above centre in y — so a run of face-only camera clips has some visual change across its cuts.

Designed in a grilling session before any code was written; every decision below was made deliberately rather than fallen into.

## The shot is decided in one place

`app/features/videos/clip-zoom.ts` returns a rect as fractions of the frame (`scale`, `originX`, `originY`). Both consumers are formatted from it and nothing else:

- the editor preview, as a CSS transform on the clip's `<video>`
- the export, as an ffmpeg `crop` in the existing concat pass

That is what makes the preview honest about what the **Publish** will ship, and it is asserted rather than intended — `clip-zoom.test.ts` resolves both to pixel rectangles and compares them at 1080p, 1080x1920 and 1440p. Drift needs someone to edit that module.

## Choices worth knowing

- **Static, not an animated push-in.** A fixed crop rectangle is the only version where preview and export can be made provably identical.
- **The crop goes before the normalising `scale`.** A source larger than the output frame is cropped and *then* scaled down, so the zoom spends surplus resolution rather than upscaling. Filming at 1440 would make it free.
- **Fractional, not pixel-valued**, so no arithmetic differs between a 1920x1080 `Camera` clip and a 1080x1920 `TikTok Face` clip, and 1440 needs no change.
- **115% and the 0.3 bias were chosen against real footage**, not guessed: 108% is invisible unless you flick between frames.
- **Camera scenes only** — `Camera` and `TikTok Face`. A clip with no recorded scene (~4,500 predate scene capture) is refused too, with a distinct message. The predicate lives in the service, so the CLI and any future caller inherit the rule.
- **An enum, not a boolean**, following the `pauseType` precedent. 115% is a constant in one file rather than encoded in the value names, so retuning the shot is not a migration.

## No existing export re-renders

`zoomType` enters the **Export Hash** only when it is not `none`, exactly as `pauseType` did. Every export already on disk keeps its address. The **Export Version Key** is untouched, and the existing golden-hash regression guard proves it.

## Shorts get it free

The vertical renderer calls the same concat step, and the Remotion subtitle overlay composites *afterwards* — so a **Short** gets zoomed footage with subtitles and CTA at their intended size.

## Authoring

- A magnifier entry in the clip context menu, shown only on eligible clips. Roughly nine clips in ten are a `Code` scene, so greying the rest out would be noise teaching a rule you already know.
- `cvm clip update <id> --zoom <none|subtle>` — the first write verb on `cvm clip`, deliberately accepting nothing else. A clip's text is recorded truth and its timings are the cut.

## Deliberately out of scope

Animated push-in; automatic detection of camera runs; per-clip amounts or anchors; a second zoom level; and the pre-existing squash on the 45 clips whose scene does not match their profile's aspect ratio.

## Verification

- Full suite: **3067 passed**. The 3 failing files (`cli-segment-writes`, `cli-backup-coordination`, `course-publish-service-video-tasks`) fail identically on an untouched checkout — verified by stashing — so they are pre-existing and unrelated.
- `tsgo --noEmit` clean; Prettier clean.
- The generated filter chain was run through real ffmpeg on real footage: it produces a valid 1920x1080 frame, and the resolved crop matches the CSS-derived rect to four decimal places (`x=125.2174 y=42.2609 w=1669.5652 h=939.1304`).

One thing to check by eye before merging: whether 115% is the level you want. It is a one-line change in `clip-zoom.ts` and, because the value is not in the data, retuning it costs nothing but a re-export of whatever you have already zoomed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)