### PR TITLE
prompts: ask the quiz question in the reader's world

### DIFF
--- a/app/prompts/quiz-instructions.ts
+++ b/app/prompts/quiz-instructions.ts
@@ -30,6 +30,8 @@ A question tests one of two things, and nothing else:
 
 An article holding no decision and no load-bearing recall gets no quiz. Report that gap for a human to judge.
 
+Ask in the reader's world, so the question points at the work: "Your session just passed 150,000 tokens and the work is not finished. What now?" A question pointed at the article — "What does this lesson say about 150,000 tokens?" — tests only whether they read the page, and the same tic in the \`answer\` field turns the explanation into a book report. The answer still comes from the body; the wording never says so.
+
 Write the choices like this:
 
 - Every wrong choice is something a real reader would actually do. A choice nobody would pick makes the question free.


### PR DESCRIPTION
Follow-up to #1529. That PR merged before its second commit landed, so `main` has the friction gate ("spend it on what the reader paid you to teach") but not the rule that goes with it. This restores the missing commit — nothing else.

This is the live twin of https://github.com/mattpocock/personal-wiki/pull/288, which carries the same rule into the wiki's quiz-authoring doctrine.

## Why

Reviewing the first 11 quizzes authored under this doctrine, 8 of 29 questions opened with "What does this lesson say…". A question pointed at the article tests whether the reader read the page, not whether they can act. All 8 were rewritten, and the rule went into the brief for the remaining 26 explainers.

## Verification

- `npm run typecheck` — clean
- `npx vitest run app/prompts app/features/article-writer` — 277 tests, 23 files, all passing
- `npx prettier --check app/prompts/quiz-instructions.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
