### PR TITLE
alternate-clip-zoom — bulk Clip Zoom authoring pass over a Course

### DIFF
--- a/app/cli/commands/clip.ts
+++ b/app/cli/commands/clip.ts
@@ -55,7 +55,7 @@ import {
  * VERBS:
  *   clip list --video <videoId>   every active clip on a Video, timeline order
  *   clip get <id...>              one or more clips by id (variadic)
- *   clip update <id> --zoom <t>   set the Clip Zoom (the ONLY writable field)
+ *   clip update --zoom <t> <id>   set the Clip Zoom (the ONLY writable field)
  *
  * `update` is deliberately the narrowest possible write. A Clip's text is
  * recorded truth (the Transcript is derived from it) and its timings are the
@@ -91,7 +91,7 @@ scoping and archived clips are always hidden (no --archived flag).
 Verbs:
   clip list --video <videoId>   every active clip on a Video, in timeline order (NDJSON)
   clip get <id...>              fetch one or more clips by id (variadic)
-  clip update <id> --zoom <t>   set the Clip Zoom ("none" | "subtle")
+  clip update --zoom <t> <id>   set the Clip Zoom ("none" | "subtle")
 
 'update' accepts --zoom and nothing else: a clip's text is recorded truth and its timings are the
 cut, neither of which the CLI rewrites. There is no 'clip tree' (clips are leaves) — use
@@ -107,14 +107,19 @@ clip filmed before CVM recorded scenes and so having none) is refused with exit 
 which of the two it was. The zoom reaches the Export Hash, so setting it marks the Video for
 re-export, and it shows in the editor preview exactly as it will export.
 
+NOTE ON FLAG ORDER
+  --zoom must come BEFORE the positional id ('update --zoom subtle <id>', NOT
+  'update <id> --zoom subtle') — a flag placed after the id is rejected with a MissingValue
+  ParseError (exit 3). This is how every verb on every noun parses.
+
 Examples:
-  cvm clip update clip_abc --zoom subtle
-  cvm clip update clip_abc --zoom none
+  cvm clip update --zoom subtle clip_abc
+  cvm clip update --zoom none clip_abc
 
   # Zoom every camera clip on a video:
   cvm clip list --video vid_123 \
     | jq -r 'select(.scene == "Camera") | .id' \
-    | xargs -n1 -I{} cvm clip update {} --zoom subtle`;
+    | xargs -n1 cvm clip update --zoom subtle`;
 
 const LIST_HELP = `List every active (non-archived) Clip on a Video, in timeline order.
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:baseline": "tsx scripts/baseline-migrations.ts",
     "db:backfill-search-text": "tsx scripts/backfill-search-text.ts",
+    "zoom:alternate": "tsx scripts/alternate-clip-zoom.ts",
     "gen:lucide-icons": "tsx scripts/generate-lucide-icons.ts",
     "db:studio": "drizzle-kit studio",
     "db:clone-local": "./scripts/clone-db-to-local.sh",

--- a/scripts/alternate-clip-zoom.plan.test.ts
+++ b/scripts/alternate-clip-zoom.plan.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+  planZoomAlternation,
+  type PlannedClip,
+  type ZoomChange,
+} from "./alternate-clip-zoom.plan";
+
+/** A Clip in whatever scene, carrying whatever zoom, with a readable id. */
+const clip = (
+  id: string,
+  scene: string | null,
+  zoomType = "none"
+): PlannedClip => ({ id, scene, zoomType });
+
+const camera = (id: string, zoomType = "none") => clip(id, "Camera", zoomType);
+const code = (id: string) => clip(id, "Code");
+
+/**
+ * Apply a plan to the Clips it was built from, so a test can assert the
+ * RESULTING timeline rather than a list of diffs. Reading "none, subtle, none"
+ * is how the rule is actually judged.
+ */
+const applyPlan = (
+  clips: readonly PlannedClip[],
+  changes: readonly ZoomChange[]
+): string[] => {
+  const byId = new Map(changes.map((c) => [c.clipId, c.to]));
+  return clips.map((c) => byId.get(c.id) ?? c.zoomType);
+};
+
+const zoomsAfterPlanning = (clips: readonly PlannedClip[]): string[] =>
+  applyPlan(clips, planZoomAlternation(clips));
+
+describe("planZoomAlternation", () => {
+  describe("runs of two or more camera clips", () => {
+    it("alternates along a run, starting as filmed", () => {
+      const clips = [camera("a"), camera("b"), camera("c"), camera("d")];
+
+      expect(zoomsAfterPlanning(clips)).toEqual([
+        "none",
+        "subtle",
+        "none",
+        "subtle",
+      ]);
+    });
+
+    it("treats a pair as a run — the smallest case the rule covers", () => {
+      const clips = [camera("a"), camera("b")];
+
+      expect(zoomsAfterPlanning(clips)).toEqual(["none", "subtle"]);
+    });
+
+    it("restarts the alternation after another scene cuts in", () => {
+      // Camera Camera | Code | Camera Camera. Each run is judged on its own, so
+      // both start as filmed rather than carrying phase across the Code clip.
+      const clips = [
+        camera("a"),
+        camera("b"),
+        code("c"),
+        camera("d"),
+        camera("e"),
+      ];
+
+      expect(zoomsAfterPlanning(clips)).toEqual([
+        "none",
+        "subtle",
+        "none",
+        "none",
+        "subtle",
+      ]);
+    });
+
+    it("runs across the portrait camera scene too", () => {
+      const clips = [
+        clip("a", "TikTok Face"),
+        clip("b", "TikTok Face"),
+        clip("c", "TikTok Face"),
+      ];
+
+      expect(zoomsAfterPlanning(clips)).toEqual(["none", "subtle", "none"]);
+    });
+  });
+
+  describe("what it leaves alone", () => {
+    it("never touches a lone camera clip, even one already zoomed", () => {
+      // The zoom exists to make a CUT interesting. A single camera clip
+      // surrounded by code has no adjacent camera cut to play against, so a
+      // hand-made choice there is the author's and survives the pass.
+      const clips = [code("a"), camera("b", "subtle"), code("c")];
+
+      expect(planZoomAlternation(clips)).toEqual([]);
+    });
+
+    it("never touches a clip that cannot be zoomed", () => {
+      const clips = [
+        code("a"),
+        clip("b", "No Face"),
+        clip("c", null),
+        clip("d", ""),
+      ];
+
+      expect(planZoomAlternation(clips)).toEqual([]);
+    });
+
+    it("does not let a scene-less clip join a run", () => {
+      // ~4,500 clips predate scene capture. One sitting between two camera
+      // clips breaks the run rather than silently extending it, so neither
+      // neighbour is left alternating against a clip that cannot be zoomed.
+      const clips = [camera("a"), clip("b", null), camera("c")];
+
+      expect(planZoomAlternation(clips)).toEqual([]);
+    });
+  });
+
+  describe("the diff it reports", () => {
+    it("proposes nothing when the timeline already obeys the rule", () => {
+      const clips = [camera("a"), camera("b", "subtle"), camera("c")];
+
+      expect(planZoomAlternation(clips)).toEqual([]);
+    });
+
+    it("is idempotent — a second pass over the result is empty", () => {
+      const clips = [
+        camera("a", "subtle"),
+        camera("b"),
+        camera("c", "subtle"),
+        code("d"),
+        camera("e"),
+        camera("f"),
+      ];
+
+      const settled = zoomsAfterPlanning(clips).map((zoomType, i) =>
+        clip(clips[i]!.id, clips[i]!.scene, zoomType)
+      );
+
+      expect(planZoomAlternation(settled)).toEqual([]);
+    });
+
+    it("clears a zoom that the alternation puts on an even position", () => {
+      const clips = [camera("a", "subtle"), camera("b", "subtle")];
+
+      expect(planZoomAlternation(clips)).toEqual([
+        {
+          clipId: "a",
+          from: "subtle",
+          to: "none",
+          runLength: 2,
+          indexInRun: 0,
+        },
+      ]);
+    });
+
+    it("reports the run each change belongs to, for the printed plan", () => {
+      const changes = planZoomAlternation([
+        camera("a"),
+        camera("b"),
+        camera("c"),
+      ]);
+
+      expect(changes).toEqual([
+        {
+          clipId: "b",
+          from: "none",
+          to: "subtle",
+          runLength: 3,
+          indexInRun: 1,
+        },
+      ]);
+    });
+
+    it("reads an unknown zoom value as no zoom", () => {
+      const clips = [camera("a", "wildly-zoomed"), camera("b")];
+
+      // "a" already renders as filmed, so only "b" needs changing.
+      expect(planZoomAlternation(clips).map((c) => c.clipId)).toEqual(["b"]);
+    });
+  });
+
+  it("has nothing to say about an empty video", () => {
+    expect(planZoomAlternation([])).toEqual([]);
+  });
+});

--- a/scripts/alternate-clip-zoom.plan.ts
+++ b/scripts/alternate-clip-zoom.plan.ts
@@ -1,0 +1,118 @@
+/**
+ * The rule this script exists to apply, kept pure and away from all I/O.
+ *
+ * A Clip Zoom is a manual, editorial choice — the product never applies one by
+ * itself, and nothing here changes that. This is a one-shot authoring pass:
+ * given a Video's Clips in timeline order, it says which Clip Zooms it WOULD
+ * set. The runner (`alternate-clip-zoom.ts`) is what turns that into
+ * `cvm clip update` calls, and only when asked to.
+ *
+ * THE RULE
+ *   Find each maximal RUN of consecutive zoomable Clips — a stretch of camera
+ *   scenes with no other scene cutting in. Where a run holds two or more Clips,
+ *   alternate the Clip Zoom along it: none, subtle, none, subtle… so that every
+ *   cut inside the run changes the shot. A single camera Clip standing alone
+ *   has no neighbouring cut to play against, so it is never touched.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO
+ *   - It does not touch a Clip outside a run of two or more. A lone camera Clip
+ *     you zoomed by hand keeps its zoom.
+ *   - It does not touch a non-camera Clip. Those cannot be zoomed at all, and
+ *     eligibility is read from `clip-zoom.ts` rather than restated here, so the
+ *     scene list has exactly one home.
+ *   - It knows nothing of Chapters. A Chapter is a marker on the timeline, not
+ *     a cut in the footage, so a run reads straight through one.
+ *
+ * Inside a run, alternation starts at "none". The first Clip of a run therefore
+ * renders as filmed, and the zoom reads as the departure it is.
+ */
+
+import {
+  DEFAULT_CLIP_ZOOM_TYPE,
+  canZoomClip,
+  resolveClipZoomType,
+  type ClipZoomType,
+} from "../app/features/videos/clip-zoom";
+
+/** The zoom a Clip alternates TO. Kept next to the rule that chooses it. */
+const ALTERNATE_CLIP_ZOOM_TYPE: ClipZoomType = "subtle";
+
+/** The fields of a Clip this pass reads. A subset of `cvm clip list` output. */
+export type PlannedClip = {
+  readonly id: string;
+  readonly scene: string | null;
+  readonly zoomType: string;
+};
+
+/** One Clip whose Clip Zoom the pass wants to change. */
+export type ZoomChange = {
+  readonly clipId: string;
+  readonly from: ClipZoomType;
+  readonly to: ClipZoomType;
+  /** How many Clips are in the run this one belongs to (always >= 2). */
+  readonly runLength: number;
+  /** This Clip's 0-based position along that run. */
+  readonly indexInRun: number;
+};
+
+/**
+ * Split Clips into maximal stretches of consecutive zoomable ones. Anything
+ * unzoomable ends the current run and starts no new one.
+ */
+const zoomableRuns = (
+  clips: readonly PlannedClip[]
+): ReadonlyArray<readonly PlannedClip[]> => {
+  const runs: PlannedClip[][] = [];
+  let current: PlannedClip[] = [];
+
+  for (const clip of clips) {
+    if (canZoomClip(clip.scene)) {
+      current.push(clip);
+      continue;
+    }
+    if (current.length > 0) runs.push(current);
+    current = [];
+  }
+  if (current.length > 0) runs.push(current);
+
+  return runs;
+};
+
+/**
+ * The Clip Zoom a Clip should carry, by its position along a run of two or
+ * more: even positions as filmed, odd positions zoomed.
+ */
+const zoomForPositionInRun = (indexInRun: number): ClipZoomType =>
+  indexInRun % 2 === 0 ? DEFAULT_CLIP_ZOOM_TYPE : ALTERNATE_CLIP_ZOOM_TYPE;
+
+/**
+ * The changes this pass wants to make to one Video's Clips, which must be given
+ * in timeline order. Clips already carrying the zoom the rule wants produce no
+ * change, so the pass is idempotent: run it twice and the second run is empty.
+ */
+export const planZoomAlternation = (
+  clips: readonly PlannedClip[]
+): ZoomChange[] => {
+  const changes: ZoomChange[] = [];
+
+  for (const run of zoomableRuns(clips)) {
+    // A lone camera Clip has no adjacent cut to alternate against.
+    if (run.length < 2) continue;
+
+    run.forEach((clip, indexInRun) => {
+      const from = resolveClipZoomType(clip.zoomType);
+      const to = zoomForPositionInRun(indexInRun);
+      if (from === to) return;
+
+      changes.push({
+        clipId: clip.id,
+        from,
+        to,
+        runLength: run.length,
+        indexInRun,
+      });
+    });
+  }
+
+  return changes;
+};

--- a/scripts/alternate-clip-zoom.ts
+++ b/scripts/alternate-clip-zoom.ts
@@ -1,0 +1,224 @@
+/**
+ * alternate-clip-zoom — a one-shot authoring pass over a Course's Clip Zooms.
+ *
+ * Where two or more camera Clips run back to back, this alternates their Clip
+ * Zoom (none, subtle, none…) so every cut inside the run changes the shot. The
+ * rule itself lives in `alternate-clip-zoom.plan.ts` and is tested there; this
+ * file is only the I/O around it.
+ *
+ * It is a WRAPPER OVER THE cvm CLI, not a second way into the database. Every
+ * read is `cvm course tree` / `cvm clip list` and every write is
+ * `cvm clip update --zoom`, so this pass inherits the CLI's rules rather than
+ * restating them: the camera-scene check, the Draft-Version write guard and the
+ * Export Hash all behave exactly as they do when you set a zoom by hand.
+ *
+ * It is also deliberately NOT part of the product. Nothing in the editor or the
+ * export applies a Clip Zoom on its own — a Clip Zoom is an editorial choice.
+ * This is a tool you point at a Course when you want that choice made in bulk.
+ *
+ * USAGE
+ *   tsx scripts/alternate-clip-zoom.ts --course <courseId> [--apply]
+ *   tsx scripts/alternate-clip-zoom.ts --video <videoId> [--video <id>…] [--apply]
+ *
+ *   Without --apply it only prints the plan. Nothing is written until you ask.
+ *
+ * EXIT CODES
+ *   0  the plan printed, or every write succeeded
+ *   1  --apply was given and at least one write failed
+ *   2  bad arguments
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  planZoomAlternation,
+  type PlannedClip,
+  type ZoomChange,
+} from "./alternate-clip-zoom.plan";
+
+const USAGE = `alternate-clip-zoom — alternate the Clip Zoom along runs of camera clips.
+
+Where two or more camera clips run back to back, set their Clip Zoom to
+none, subtle, none… so every cut inside the run changes the shot. A lone camera
+clip is never touched, and neither is any clip that cannot be zoomed.
+
+USAGE
+  tsx scripts/alternate-clip-zoom.ts --course <courseId> [--apply]
+  tsx scripts/alternate-clip-zoom.ts --video <videoId> [--video <videoId>…] [--apply]
+
+OPTIONS
+  --course <id>   every Video in this Course's Draft Version
+  --video <id>    one Video; repeat the flag for several
+  --apply         actually write the changes (without it, only the plan prints)
+  --help          this text
+
+This wraps the cvm CLI, so the camera-scene rule, the Draft-Version write guard
+and the Export Hash all behave as they do for 'cvm clip update' by hand.`;
+
+/**
+ * Run a cvm verb and hand back its stdout. Throws with stderr on a failure.
+ *
+ * stdout goes to a FILE rather than down a pipe, and that is not a style
+ * choice. `cvm`'s bin edge calls process.exit as soon as the command resolves;
+ * writes to a pipe are asynchronous, so anything still buffered is discarded
+ * and a large read comes back silently truncated at the pipe capacity — a
+ * `course tree --depth all` of this size loses roughly 90% of itself. Writes to
+ * a file are synchronous and survive the exit. Reading a truncated tree would
+ * quietly plan a zoom pass over a fraction of the course, so this is the
+ * difference between a correct pass and a plausible-looking wrong one.
+ */
+const cvm = (...args: string[]): string => {
+  const dir = mkdtempSync(join(tmpdir(), "cvm-zoom-"));
+  const outPath = join(dir, "stdout");
+  const fd = openSync(outPath, "w");
+
+  try {
+    execFileSync("cvm", args, { stdio: ["ignore", fd, "pipe"] });
+    return readFileSync(outPath, "utf8");
+  } finally {
+    closeSync(fd);
+    rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+type TreeNode = {
+  id: string;
+  kind: string;
+  name: string;
+  children?: TreeNode[];
+};
+
+/** Every Video in a Course's Draft Version, in course order. */
+const videosInCourse = (
+  courseId: string
+): Array<{ id: string; name: string }> => {
+  const root = JSON.parse(cvm("course", "tree", "--depth", "all", courseId));
+  const videos: Array<{ id: string; name: string }> = [];
+
+  const walk = (node: TreeNode): void => {
+    if (node.kind === "video") videos.push({ id: node.id, name: node.name });
+    for (const child of node.children ?? []) walk(child);
+  };
+  walk(root);
+
+  return videos;
+};
+
+/** One Video's Clips, in timeline order. `clip list` emits NDJSON. */
+const clipsInVideo = (videoId: string): PlannedClip[] =>
+  cvm("clip", "list", "--video", videoId)
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line) as PlannedClip);
+
+const describeChange = (change: ZoomChange): string =>
+  `    ${change.clipId}  ${change.from} -> ${change.to}` +
+  `   (clip ${change.indexInRun + 1} of a ${change.runLength}-clip run)`;
+
+const parseArgs = (argv: string[]) => {
+  const courseIds: string[] = [];
+  const videoIds: string[] = [];
+  let apply = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--apply") apply = true;
+    else if (arg === "--help" || arg === "-h") return "help" as const;
+    else if (arg === "--course") courseIds.push(argv[++i] ?? "");
+    else if (arg === "--video") videoIds.push(argv[++i] ?? "");
+    else return { error: `unknown argument ${JSON.stringify(arg)}` };
+  }
+
+  if (courseIds.length === 0 && videoIds.length === 0) {
+    return { error: "give --course <id> or --video <id>" };
+  }
+  if (courseIds.some((id) => id === "") || videoIds.some((id) => id === "")) {
+    return { error: "--course and --video each need an id" };
+  }
+
+  return { courseIds, videoIds, apply };
+};
+
+const main = (): number => {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args === "help") {
+    console.log(USAGE);
+    return 0;
+  }
+  if ("error" in args) {
+    console.error(`${args.error}\n\n${USAGE}`);
+    return 2;
+  }
+
+  const videos = [
+    ...args.courseIds.flatMap(videosInCourse),
+    ...args.videoIds.map((id) => ({ id, name: id })),
+  ];
+
+  console.log(
+    `${args.apply ? "Applying" : "Planning"} zoom alternation over ${
+      videos.length
+    } video(s).\n`
+  );
+
+  let planned = 0;
+  let applied = 0;
+  let failed = 0;
+
+  for (const video of videos) {
+    const changes = planZoomAlternation(clipsInVideo(video.id));
+    if (changes.length === 0) continue;
+
+    planned += changes.length;
+    console.log(`  ${video.name}`);
+    for (const change of changes) console.log(describeChange(change));
+
+    if (!args.apply) {
+      console.log("");
+      continue;
+    }
+
+    for (const change of changes) {
+      try {
+        // Options BEFORE the positional id — @effect/cli rejects a flag that
+        // follows one (exit 3, "MissingValue"), as it does across every verb.
+        cvm("clip", "update", "--zoom", change.to, change.clipId);
+        applied++;
+      } catch (error) {
+        failed++;
+        // stderr carries the CLI's own message — a refused scene, or a Video
+        // whose Course Version is no longer a Draft.
+        const stderr =
+          error instanceof Error && "stderr" in error
+            ? String(error.stderr).trim()
+            : String(error);
+        console.error(`    FAILED ${change.clipId}: ${stderr}`);
+      }
+    }
+    console.log("");
+  }
+
+  if (planned === 0) {
+    console.log("Every run already alternates. Nothing to do.");
+    return 0;
+  }
+
+  console.log(
+    args.apply
+      ? `${applied} clip(s) updated, ${failed} failed.`
+      : `${planned} clip(s) would change. Re-run with --apply to write them.`
+  );
+
+  return failed > 0 ? 1 : 0;
+};
+
+process.exit(main());


### PR DESCRIPTION
Where two or more camera Clips run back to back, alternate their Clip Zoom along the run — `none`, `subtle`, `none`… — so every cut inside the run changes the shot. A stretch of face-only Camera clips cut together currently has no visual change at its cuts; this puts one there.

## A wrapper, not product logic

Nothing in the editor or the export applies a Clip Zoom on its own, and this does not change that. A Clip Zoom stays an editorial choice — this is a one-shot pass you point at a Course when you want that choice made in bulk.

It wraps the `cvm` CLI rather than opening a second path into the database. Every read is `cvm course tree` / `cvm clip list`, every write is `cvm clip update --zoom`. So it inherits the camera-scene rule, the Draft-Version write guard and the Export Hash instead of restating any of them, and `cvm clip update` stays the narrowest possible write verb.

```
pnpm zoom:alternate --course <courseId>            # print the plan, write nothing
pnpm zoom:alternate --course <courseId> --apply    # write it
pnpm zoom:alternate --video <videoId> [--video …]  # narrow to some videos
```

## The rule

Runs are maximal stretches of consecutive zoomable Clips. Anything else — a `Code` clip, or one of the ~4,500 clips filmed before CVM recorded scenes — **ends** a run rather than silently extending it. Alternation starts at `none`, so the first Clip of a run renders as filmed and the zoom reads as the departure it is. A lone camera Clip has no adjacent cut to play against and is **never touched**, which is what lets a hand-made zoom survive the pass.

The rule is pure, lives in `alternate-clip-zoom.plan.ts` and has 13 tests. The runner is only the I/O around it. The pass is idempotent, and that is asserted rather than assumed.

Chapters are invisible to it on purpose: a Chapter is a marker on the timeline, not a cut in the footage, so a run reads straight through one.

## Two bugs this turned up

**1. `cvm clip update <id> --zoom <t>` does not work.** `@effect/cli` rejects a flag that follows a positional arg, so the help text I shipped with Clip Zoom documented an ordering that fails with a `MissingValue` ParseError. Corrected here to `update --zoom <t> <id>`, and the verb now carries the same `NOTE ON FLAG ORDER` that `course tree` already carries. Found by running it, not by reading it.

**2. `cvm` truncates stdout when piped — worth a look independently of this PR.** `app/cli/bin.mjs` calls `process.exit` as soon as the command resolves; writes to a pipe are asynchronous, so whatever is still buffered is discarded.

```
cvm course tree --depth all <accc>  > file   # 599,192 bytes
cvm course tree --depth all <accc> | wc -c   #  65,536 bytes
```

About 90% lost, silently. That breaks the piped `| jq` workflow the help text recommends across every noun. This script sidesteps it by capturing stdout to a file and says why. **I did not fix the bin edge here** — flushing before exit deserves its own change and its own testing, since `process.exit` is presumably there to stop the DB connection holding the loop open. Happy to take it next.

## Verification

- Full suite: **3107 passed**. The 3 failing files (`cli-segment-writes`, `cli-backup-coordination`, `course-publish-service-video-tasks`) are the same pre-existing failures baselined on the untouched tree.
- `tsgo --noEmit` clean, Prettier clean.
- Ran against the real AI Coding Crash Course (70 videos, 2,387 clips): planned 28 changes. An independent count of odd positions in runs agreed — 31, minus the 3 clips already zoomed by hand. Applied, then re-ran: nothing left to do. The course now carries 31 zoomed clips.

**This has already been applied to the AI Coding Crash Course**, so 17 videos are marked for re-export.