### PR TITLE
clip: add update --start/--end, move, delete

### DIFF
--- a/app/cli/cli-clip-writes.test.ts
+++ b/app/cli/cli-clip-writes.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { Effect } from "effect";
+import {
+  createTestDb,
+  truncateAllTables,
+  type TestDb,
+} from "@/test-utils/pglite";
+import { ClipOperationsService } from "@/services/db-clip-operations.server";
+import {
+  buildWriteLayer,
+  makeRun,
+  ndjson,
+  one,
+  seedWrite,
+  type RunResult,
+  type WriteSeed,
+} from "./cli-write-test-harness";
+
+// ===========================================================================
+// cvm clip writes: update / move / delete
+// (Split out like cli-beat-writes.test.ts. Clip has no `add` verb — the only
+// creators are OBS-capture append and "create video from selection", neither
+// CLI-facing — so fixtures here are seeded directly through
+// ClipOperationsService.appendClips rather than through the CLI.)
+//
+// NOTE on argv shape: like every other write-verb suite, flags go BEFORE the
+// trailing positional <id> (`--start 3 <id>`, not `<id> --start 3`).
+// ===========================================================================
+
+let testDb: TestDb;
+let layer: ReturnType<typeof buildWriteLayer>;
+let run: (argv: ReadonlyArray<string>) => Promise<RunResult>;
+
+beforeAll(async () => {
+  const result = await createTestDb();
+  testDb = result.testDb;
+  layer = buildWriteLayer(testDb);
+  run = makeRun(layer);
+});
+
+let s: WriteSeed;
+beforeEach(async () => {
+  await truncateAllTables(testDb);
+  s = await seedWrite(testDb);
+});
+
+interface ClipRow {
+  id: string;
+  videoId: string;
+  sourceStartTime: number;
+  sourceEndTime: number;
+  order: string;
+  archived: boolean;
+  zoomType: string;
+  scene: string | null;
+  text: string;
+  transcribedAt: string | null;
+}
+
+const list = async (videoId: string): Promise<ClipRow[]> =>
+  ndjson((await run(["clip", "list", "--video", videoId])).stdout) as ClipRow[];
+
+/**
+ * Seed a clip directly through the service — clip has no CLI `add` verb.
+ * Pass `after` (a previously-seeded clip's id) to append it to the END of
+ * the timeline instead of the start, so a chain of `seedClip` calls builds
+ * clips in the order they're called rather than each landing at the front.
+ */
+const seedClip = (
+  videoId: string,
+  opts: { start: number; end: number; scene?: string; after?: string }
+): Promise<ClipRow> =>
+  Effect.gen(function* () {
+    const clipOps = yield* ClipOperationsService;
+    const [clip] = yield* clipOps.appendClips({
+      videoId,
+      insertionPoint:
+        opts.after === undefined
+          ? { type: "start" }
+          : { type: "after-clip", databaseClipId: opts.after },
+      clips: [
+        { inputVideo: "test.mp4", startTime: opts.start, endTime: opts.end },
+      ],
+    });
+    if (opts.scene !== undefined) {
+      return (yield* clipOps.updateClip(clip!.id, {
+        scene: opts.scene,
+      })) as unknown as ClipRow;
+    }
+    return clip as unknown as ClipRow;
+  }).pipe(Effect.provide(layer), Effect.runPromise);
+
+describe("clip writes (update / move / delete)", () => {
+  describe("update --start / --end", () => {
+    it("retimes both ends, leaving text/transcribedAt untouched", async () => {
+      const clip = await seedClip(s.standaloneActiveId, { start: 0, end: 10 });
+      const updated = one<ClipRow>(
+        (await run(["clip", "update", "--start", "2.5", "--end", "8", clip.id]))
+          .stdout
+      );
+      expect(updated.sourceStartTime).toBe(2.5);
+      expect(updated.sourceEndTime).toBe(8);
+      expect(updated.text).toBe(clip.text);
+      expect(updated.transcribedAt).toBe(clip.transcribedAt);
+    });
+
+    it("--start alone keeps the existing end", async () => {
+      const clip = await seedClip(s.standaloneActiveId, { start: 0, end: 10 });
+      const updated = one<ClipRow>(
+        (await run(["clip", "update", "--start", "3", clip.id])).stdout
+      );
+      expect(updated.sourceStartTime).toBe(3);
+      expect(updated.sourceEndTime).toBe(clip.sourceEndTime);
+    });
+
+    it("--end alone keeps the existing start", async () => {
+      const clip = await seedClip(s.standaloneActiveId, { start: 0, end: 10 });
+      const updated = one<ClipRow>(
+        (await run(["clip", "update", "--end", "9", clip.id])).stdout
+      );
+      expect(updated.sourceEndTime).toBe(9);
+      expect(updated.sourceStartTime).toBe(clip.sourceStartTime);
+    });
+
+    it("resulting start >= end => invalid input, exit 3", async () => {
+      const clip = await seedClip(s.standaloneActiveId, { start: 0, end: 10 });
+      const { stdout, stderr, exitCode } = await run([
+        "clip",
+        "update",
+        "--start",
+        "9",
+        "--end",
+        "9",
+        clip.id,
+      ]);
+      expect(exitCode).toBe(3);
+      expect(stdout).toBe("");
+      expect((JSON.parse(stderr.trim()) as { _tag: string })._tag).toBe(
+        "ParseError"
+      );
+    });
+
+    it("resulting duration below the minimum clip length => invalid input, exit 3", async () => {
+      const clip = await seedClip(s.standaloneActiveId, { start: 0, end: 10 });
+      const { exitCode } = await run([
+        "clip",
+        "update",
+        "--start",
+        "5",
+        "--end",
+        "5.5",
+        clip.id,
+      ]);
+      expect(exitCode).toBe(3);
+    });
+
+    it("combines with --zoom in one call", async () => {
+      const clip = await seedClip(s.standaloneActiveId, {
+        start: 0,
+        end: 10,
+        scene: "Camera",
+      });
+      const updated = one<ClipRow>(
+        (
+          await run([
+            "clip",
+            "update",
+            "--start",
+            "1",
+            "--zoom",
+            "subtle",
+            clip.id,
+          ])
+        ).stdout
+      );
+      expect(updated.sourceStartTime).toBe(1);
+      expect(updated.zoomType).toBe("subtle");
+    });
+  });
+
+  it("update with no flags => invalid input, exit 3", async () => {
+    const clip = await seedClip(s.standaloneActiveId, { start: 0, end: 10 });
+    const { stdout, stderr, exitCode } = await run(["clip", "update", clip.id]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+    expect((JSON.parse(stderr.trim()) as { _tag: string })._tag).toBe(
+      "ParseError"
+    );
+  });
+
+  it("update an unknown id => NotFoundError, exit 2", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "clip",
+      "update",
+      "--start",
+      "1",
+      "clip_missing",
+    ]);
+    expect(exitCode).toBe(2);
+    expect(stdout).toBe("");
+    const err = JSON.parse(stderr.trim()) as { _tag: string; entity: string };
+    expect(err._tag).toBe("NotFoundError");
+    expect(err.entity).toBe("clip");
+  });
+
+  describe("delete", () => {
+    it("archives the clip, echoes archived:true, hides it from list, no restore", async () => {
+      const clip = await seedClip(s.standaloneActiveId, { start: 0, end: 10 });
+      const del = one<ClipRow>((await run(["clip", "delete", clip.id])).stdout);
+      expect(del.id).toBe(clip.id);
+      expect(del.archived).toBe(true);
+      expect((await list(s.standaloneActiveId)).map((r) => r.id)).not.toContain(
+        clip.id
+      );
+    });
+
+    it("an unknown id => NotFoundError, exit 2", async () => {
+      const { stdout, stderr, exitCode } = await run([
+        "clip",
+        "delete",
+        "clip_missing",
+      ]);
+      expect(exitCode).toBe(2);
+      expect(stdout).toBe("");
+      expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+        "clip"
+      );
+    });
+
+    it("any write on an already-deleted clip => NotFoundError, exit 2", async () => {
+      const clip = await seedClip(s.standaloneActiveId, { start: 0, end: 10 });
+      await run(["clip", "delete", clip.id]);
+      expect(
+        (await run(["clip", "update", "--start", "1", clip.id])).exitCode
+      ).toBe(2);
+      expect((await run(["clip", "delete", clip.id])).exitCode).toBe(2);
+      expect(
+        (await run(["clip", "move", "--after", clip.id, clip.id])).exitCode
+      ).toBe(2);
+    });
+  });
+
+  describe("move", () => {
+    it("--before jumps to an arbitrary earlier position", async () => {
+      const a = await seedClip(s.standaloneActiveId, { start: 0, end: 1 });
+      const b = await seedClip(s.standaloneActiveId, {
+        start: 1,
+        end: 2,
+        after: a.id,
+      });
+      const c = await seedClip(s.standaloneActiveId, {
+        start: 2,
+        end: 3,
+        after: b.id,
+      });
+      expect((await list(s.standaloneActiveId)).map((r) => r.id)).toEqual([
+        a.id,
+        b.id,
+        c.id,
+      ]);
+      const moved = one<ClipRow>(
+        (await run(["clip", "move", "--before", a.id, c.id])).stdout
+      );
+      expect(moved.id).toBe(c.id);
+      expect((await list(s.standaloneActiveId)).map((r) => r.id)).toEqual([
+        c.id,
+        a.id,
+        b.id,
+      ]);
+    });
+
+    it("--after positions immediately after the target", async () => {
+      const a = await seedClip(s.standaloneActiveId, { start: 0, end: 1 });
+      // No `after` here: both land via {type: "start"}, so b lands ahead of a
+      // ([b, a]) — the move to "--after a" is what re-establishes [a, b],
+      // meaningfully exercising the positioning rather than a no-op.
+      const b = await seedClip(s.standaloneActiveId, { start: 1, end: 2 });
+      const moved = one<ClipRow>(
+        (await run(["clip", "move", "--after", a.id, b.id])).stdout
+      );
+      expect(moved.id).toBe(b.id);
+      expect((await list(s.standaloneActiveId)).map((r) => r.id)).toEqual([
+        a.id,
+        b.id,
+      ]);
+    });
+
+    it("with both --before and --after => invalid input, exit 3", async () => {
+      const a = await seedClip(s.standaloneActiveId, { start: 0, end: 1 });
+      const b = await seedClip(s.standaloneActiveId, { start: 1, end: 2 });
+      const { stdout, stderr, exitCode } = await run([
+        "clip",
+        "move",
+        "--before",
+        a.id,
+        "--after",
+        a.id,
+        b.id,
+      ]);
+      expect(exitCode).toBe(3);
+      expect(stdout).toBe("");
+      expect((JSON.parse(stderr.trim()) as { _tag: string })._tag).toBe(
+        "ParseError"
+      );
+    });
+
+    it("with neither --before nor --after => invalid input, exit 3", async () => {
+      const a = await seedClip(s.standaloneActiveId, { start: 0, end: 1 });
+      const { exitCode } = await run(["clip", "move", a.id]);
+      expect(exitCode).toBe(3);
+    });
+
+    it("--before an unknown clip id => NotFoundError, exit 2", async () => {
+      const a = await seedClip(s.standaloneActiveId, { start: 0, end: 1 });
+      const { stdout, stderr, exitCode } = await run([
+        "clip",
+        "move",
+        "--before",
+        "clip_missing",
+        a.id,
+      ]);
+      expect(exitCode).toBe(2);
+      expect(stdout).toBe("");
+      expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+        "clip"
+      );
+    });
+
+    it("--before a clip on a different video => NotFoundError, exit 2 (no cross-video move)", async () => {
+      const a = await seedClip(s.standaloneActiveId, { start: 0, end: 1 });
+      const other = await seedClip(s.lessonVideoId, { start: 0, end: 1 });
+      const { exitCode } = await run([
+        "clip",
+        "move",
+        "--before",
+        other.id,
+        a.id,
+      ]);
+      expect(exitCode).toBe(2);
+    });
+  });
+});

--- a/app/cli/commands/clip.ts
+++ b/app/cli/commands/clip.ts
@@ -1,5 +1,5 @@
 import { Args, Command, Options } from "@effect/cli";
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
 import { ClipOperationsService } from "@/services/db-clip-operations.server";
 import { VideoOperationsService } from "@/services/db-video-operations.server";
 import {
@@ -9,12 +9,14 @@ import {
   notFound,
   notFoundMany,
   parseError,
+  rejectBothFlags,
 } from "@/cli/helpers";
 import { withBackupCoordination } from "@/cli/backup-coordinator";
 import {
   CLIP_ZOOM_TYPES,
   type ClipZoomType,
 } from "@/features/videos/clip-zoom";
+import { MINIMUM_CLIP_LENGTH_SECONDS } from "@/silence-detection-constants";
 
 /**
  * clip — a timestamped slice of source footage inside a Video.
@@ -34,7 +36,8 @@ import {
  *   Clips are CHILDREN of a Video, addressed only by id. There is no version
  *   scoping here — clips belong to the live recorded timeline of one Video.
  *   Archived clips are treated as deleted: they are ALWAYS filtered out and
- *   never surfaced (no --archived flag on this noun).
+ *   never surfaced (no --archived flag on this noun, and no restore verb —
+ *   same one-way convention as `beat delete`).
  *
  * OUTPUT FIELDS:
  *   id               clip id (use with `clip get`)
@@ -53,17 +56,25 @@ import {
  *   createdAt        row creation timestamp
  *
  * VERBS:
- *   clip list --video <videoId>   every active clip on a Video, timeline order
- *   clip get <id...>              one or more clips by id (variadic)
- *   clip update <id> --zoom <t>   set the Clip Zoom (the ONLY writable field)
+ *   clip list --video <videoId>          every active clip on a Video, timeline order
+ *   clip get <id...>                     one or more clips by id (variadic)
+ *   clip update <id> [flags]             set --zoom and/or retime --start/--end
+ *   clip move <id> --before/--after <id> reposition within the Video's timeline
+ *   clip delete <id>                     archive (soft delete; no restore)
  *
- * `update` is deliberately the narrowest possible write. A Clip's text is
- * recorded truth (the Transcript is derived from it) and its timings are the
- * cut — none of that is the CLI's to rewrite. Only the Clip Zoom, an editorial
- * choice about the shot, is writable here, and only on a camera scene.
+ * `update`'s --start/--end retime the cut WITHOUT touching `text`/`transcribedAt` — there is no
+ * re-transcription step, so a retimed clip's text can drift out of sync with its new audio range
+ * until something re-transcribes it. This was a deliberate v1 tradeoff, not an oversight: there
+ * is no "what changed" signal to retranscribe from yet (see issue #1532, audio introspection).
  *
- * Clips are leaf timeline rows — there is no `clip tree`. To explore a Video's
- * structure use `video tree`, then resolve ids with `clip get`.
+ * All writes here are IMMEDIATE — no confirmation, no dry-run (this is an agent-facing tool, same
+ * convention as `beat`/`file`). The real safety net is version scoping: every write requires the
+ * owning CourseVersion to be a draft, so published content can't be clobbered from here.
+ *
+ * Clips are leaf timeline rows — there is no `clip tree`. To explore a Video's structure use
+ * `video tree`, then resolve ids with `clip get`. There is no `clip add`: every existing creator
+ * (OBS capture append, "create video from selection") needs a real footage file + time range on
+ * disk, so manual single-clip creation doesn't have anywhere to hang off yet.
  *
  * EXAMPLES:
  *   # All clips on a video, in timeline order (NDJSON):
@@ -86,35 +97,76 @@ A Clip is one captured segment of source footage, defined by a source filename a
 window into it (sourceStartTime/sourceEndTime, seconds). Clips and Chapters share one fractional
 'order' space; interleaving them in order is what forms the Video's Transcript. A clip's 'text' is
 its spoken transcription. Clips are children of a Video, addressed by id only; there is no version
-scoping and archived clips are always hidden (no --archived flag).
+scoping and archived clips are always hidden (no --archived flag, no restore verb).
 
 Verbs:
-  clip list --video <videoId>   every active clip on a Video, in timeline order (NDJSON)
-  clip get <id...>              fetch one or more clips by id (variadic)
-  clip update <id> --zoom <t>   set the Clip Zoom ("none" | "subtle")
+  clip list --video <videoId>          every active clip on a Video, in timeline order (NDJSON)
+  clip get <id...>                     fetch one or more clips by id (variadic)
+  clip update <id> [flags]             set --zoom and/or retime --start/--end
+  clip move <id> --before/--after <id> reposition within the timeline
+  clip delete <id>                     archive the clip (soft delete; irreversible from the CLI)
 
-'update' accepts --zoom and nothing else: a clip's text is recorded truth and its timings are the
-cut, neither of which the CLI rewrites. There is no 'clip tree' (clips are leaves) — use
-'video tree' then 'clip get'.`;
+All writes are immediate — no confirmation, no dry-run (agent-facing tool). There is no 'clip tree'
+(clips are leaves) — use 'video tree' then 'clip get'. There is no 'clip add': creating a clip needs
+a real footage file + time range, which no CLI-facing creator exists for yet.`;
 
-const UPDATE_HELP = `Set a Clip's Clip Zoom.
+const UPDATE_HELP = `Update a Clip: set its Clip Zoom and/or retime its cut.
 
-A Clip Zoom renders the clip slightly tighter than frame, so a run of face-only camera clips has
-some visual change across its cuts. Levels: "none" (as filmed) and "subtle".
+At least one of --zoom / --start / --end is required.
 
-Only camera scenes can be zoomed — 'Camera' and 'TikTok Face'. Anything else (a 'Code' clip, or a
-clip filmed before CVM recorded scenes and so having none) is refused with exit 3; the message says
-which of the two it was. The zoom reaches the Export Hash, so setting it marks the Video for
-re-export, and it shows in the editor preview exactly as it will export.
+--zoom <t>: "none" (as filmed) or "subtle", rendering the clip slightly tighter so a run of
+face-only camera clips has some visual change across its cuts. Only camera scenes can be zoomed —
+'Camera' and 'TikTok Face'. Anything else (a 'Code' clip, or a clip filmed before CVM recorded
+scenes) is refused with exit 3. Reaches the Export Hash, so setting it marks the Video for
+re-export.
+
+--start / --end <seconds>: move the in/out point into the source file. Either can be passed alone
+(the other keeps its current value) or both together. Rejected with exit 3 if the resulting range
+has start >= end, or is shorter than the ${MINIMUM_CLIP_LENGTH_SECONDS}s minimum clip length.
+
+IMPORTANT: retiming does NOT touch 'text' or 'transcribedAt' — the transcript is not
+re-generated for the new range. A retimed clip's text can be stale until something re-transcribes
+it; there is currently no CLI signal for "this text no longer matches this range" (only the
+pre-existing "never transcribed" signal, transcribedAt == null).
 
 Examples:
   cvm clip update clip_abc --zoom subtle
-  cvm clip update clip_abc --zoom none
+  cvm clip update clip_abc --start 12.4 --end 18.9
+  cvm clip update clip_abc --end 18.9 --zoom none
 
   # Zoom every camera clip on a video:
   cvm clip list --video vid_123 \
     | jq -r 'select(.scene == "Camera") | .id' \
     | xargs -n1 -I{} cvm clip update {} --zoom subtle`;
+
+const MOVE_HELP = `Reposition a Clip within its Video's timeline.
+
+Requires exactly one of --before / --after <id>, where <id> is another active clip on the SAME
+video (a clip cannot move across videos via this command). Clips and Chapters share one fractional
+order space, so the new position is computed against both — landing a clip "after" the last clip
+before a Chapter is well-defined even though the anchor id is a clip.
+
+This jumps straight to an arbitrary position in one call, unlike a step-by-step up/down nudge.
+
+Immediate — there is no confirmation prompt (this is an agent-facing tool).
+
+Examples:
+  cvm clip move clip_abc --before clip_def   # clip_abc lands immediately before clip_def
+  cvm clip move clip_abc --after clip_def    # clip_abc lands immediately after clip_def`;
+
+const DELETE_HELP = `Archive (soft-delete) a Clip.
+
+Sets 'archived: true'. Archived clips are ALWAYS filtered out everywhere (no --archived flag, no
+'clip get' access, no restore verb) — same one-way convention as 'beat delete'. The row still
+exists in the database (unlike 'file delete', which is a real unlink), but nothing in this CLI can
+bring it back.
+
+Immediately, no confirmation prompt (this is an agent-facing tool). Only its ClipWebLinks cascade
+on delete at the database level; nothing else references a Clip by foreign key, so deleting one
+does not orphan any Beat, Script, or Deliverable.
+
+Examples:
+  cvm clip delete clip_abc`;
 
 const LIST_HELP = `List every active (non-archived) Clip on a Video, in timeline order.
 
@@ -196,44 +248,212 @@ const getCmd = Command.make("get", { ids }, ({ ids }) =>
 const zoomOpt = Options.choice("zoom", CLIP_ZOOM_TYPES).pipe(
   Options.withDescription(
     `Clip Zoom to set: ${CLIP_ZOOM_TYPES.join(" | ")}. Camera scenes only.`
-  )
+  ),
+  Options.optional
+);
+
+const startOpt = Options.float("start").pipe(
+  Options.withDescription(
+    "New sourceStartTime, in seconds (in-point into the source file)."
+  ),
+  Options.optional
+);
+
+const endOpt = Options.float("end").pipe(
+  Options.withDescription(
+    "New sourceEndTime, in seconds (out-point into the source file)."
+  ),
+  Options.optional
+);
+
+const beforeOpt = Options.text("before").pipe(
+  Options.withDescription(
+    "Place immediately before this clip id (mutually exclusive with --after)."
+  ),
+  Options.optional
+);
+
+const afterOpt = Options.text("after").pipe(
+  Options.withDescription(
+    "Place immediately after this clip id (mutually exclusive with --before)."
+  ),
+  Options.optional
 );
 
 const idArg = Args.text({ name: "id" });
 
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve + gate a clip for a write: a bad id is a clean not-found (exit 2)
+ * rather than arriving as a service failure, and archived clips are deleted
+ * as far as this noun is concerned, so they are not-found too.
+ */
+const requireActiveClip = (id: string) =>
+  Effect.gen(function* () {
+    const clipOps = yield* ClipOperationsService;
+    const [existing] = yield* clipOps.getClipsByIds([id]);
+    if (!existing || existing.archived) {
+      return yield* notFound("clip", id);
+    }
+    return existing;
+  });
+
+/**
+ * Resolve `clip move`'s --before/--after into the single "anchor id" the
+ * service positions against (mirrors `beat move`'s resolveBeforeBeatId, but
+ * over the merged clip+chapter order space since clips and chapters share
+ * one fractional order key). --after X resolves to whatever item currently
+ * follows X — which may legitimately be a Chapter id, since the service's
+ * `moveClipToPosition` positions against either.
+ */
+const resolveBeforeItemId = (params: {
+  readonly videoId: string;
+  readonly before: Option.Option<string>;
+  readonly after: Option.Option<string>;
+  readonly excludeId: string;
+}) =>
+  Effect.gen(function* () {
+    const before = Option.getOrUndefined(params.before);
+    const after = Option.getOrUndefined(params.after);
+
+    yield* rejectBothFlags({
+      a: before,
+      b: after,
+      flags: ["--before", "--after"],
+      entity: "clip",
+    });
+    if (before === undefined && after === undefined) {
+      return yield* parseError("move needs one of --before / --after", "clip");
+    }
+
+    const clipOps = yield* ClipOperationsService;
+    const items = (yield* clipOps.listTimelineOrder(params.videoId)).filter(
+      (item) => item.id !== params.excludeId
+    );
+
+    if (before !== undefined) {
+      if (!items.some((item) => item.type === "clip" && item.id === before)) {
+        return yield* notFound("clip", before);
+      }
+      return before;
+    }
+
+    const idx = items.findIndex(
+      (item) => item.type === "clip" && item.id === after
+    );
+    if (idx === -1) {
+      return yield* notFound("clip", after!);
+    }
+    return items[idx + 1]?.id ?? null;
+  });
+
+// ---------------------------------------------------------------------------
+// Verbs
+// ---------------------------------------------------------------------------
+
 const updateCmd = Command.make(
   "update",
-  { id: idArg, zoom: zoomOpt },
-  ({ id, zoom }) =>
+  { id: idArg, zoom: zoomOpt, start: startOpt, end: endOpt },
+  ({ id, zoom, start, end }) =>
     withBackupCoordination(
       Effect.gen(function* () {
-        const clipOps = yield* ClipOperationsService;
+        const z = Option.getOrUndefined(zoom);
+        const s = Option.getOrUndefined(start);
+        const e = Option.getOrUndefined(end);
 
-        // Resolve first, so a bad id is a clean not-found (exit 2) rather than
-        // arriving as a service failure. Archived clips are deleted as far as
-        // this noun is concerned, so they are not-found too.
-        const [existing] = yield* clipOps.getClipsByIds([id]);
-        if (!existing || existing.archived) {
-          return yield* notFound("clip", id);
+        if (z === undefined && s === undefined && e === undefined) {
+          return yield* parseError(
+            "update needs at least one of --zoom / --start / --end",
+            "clip"
+          );
+        }
+
+        const clipOps = yield* ClipOperationsService;
+        let row = yield* requireActiveClip(id);
+
+        if (s !== undefined || e !== undefined) {
+          const newStart = s ?? row.sourceStartTime;
+          const newEnd = e ?? row.sourceEndTime;
+          if (newStart >= newEnd) {
+            return yield* parseError(
+              `--start (${newStart}) must be before --end (${newEnd})`,
+              "clip"
+            );
+          }
+          if (newEnd - newStart < MINIMUM_CLIP_LENGTH_SECONDS) {
+            return yield* parseError(
+              `clip would be ${(newEnd - newStart).toFixed(3)}s, below the ` +
+                `${MINIMUM_CLIP_LENGTH_SECONDS}s minimum clip length`,
+              "clip"
+            );
+          }
+          row = yield* clipOps.updateClip(id, {
+            sourceStartTime: newStart,
+            sourceEndTime: newEnd,
+          });
         }
 
         // setClipZoom re-checks eligibility — it is the service that owns the
         // rule. Translating its failure here is only about the exit code: an
         // ineligible clip is bad input (exit 3), not an internal fault.
-        const updated = yield* clipOps
-          .setClipZoom(id, zoom satisfies ClipZoomType)
-          .pipe(
-            Effect.catchTag("ClipNotZoomableError", (e) =>
-              parseError(e.message, "clip")
-            )
-          );
+        if (z !== undefined) {
+          row = yield* clipOps
+            .setClipZoom(id, z satisfies ClipZoomType)
+            .pipe(
+              Effect.catchTag("ClipNotZoomableError", (e) =>
+                parseError(e.message, "clip")
+              )
+            );
+        }
 
-        yield* emitObject(updated);
+        yield* emitObject(row);
       })
     )
 ).pipe(Command.withDescription(detail(UPDATE_HELP)));
 
+const moveCmd = Command.make(
+  "move",
+  { id: idArg, before: beforeOpt, after: afterOpt },
+  ({ id, before, after }) =>
+    withBackupCoordination(
+      Effect.gen(function* () {
+        const existing = yield* requireActiveClip(id);
+        const beforeItemId = yield* resolveBeforeItemId({
+          videoId: existing.videoId,
+          before,
+          after,
+          excludeId: id,
+        });
+
+        const clipOps = yield* ClipOperationsService;
+        const moved = yield* clipOps
+          .moveClipToPosition(id, beforeItemId)
+          .pipe(
+            Effect.catchTag("NotFoundError", (e) =>
+              notFound("clip", (e.params as { clipId?: string }).clipId ?? id)
+            )
+          );
+        yield* emitObject(moved);
+      })
+    )
+).pipe(Command.withDescription(detail(MOVE_HELP)));
+
+const deleteCmd = Command.make("delete", { id: idArg }, ({ id }) =>
+  withBackupCoordination(
+    Effect.gen(function* () {
+      yield* requireActiveClip(id);
+      const clipOps = yield* ClipOperationsService;
+      yield* clipOps.archiveClip(id);
+      const [archived] = yield* clipOps.getClipsByIds([id]);
+      yield* emitObject(archived);
+    })
+  )
+).pipe(Command.withDescription(detail(DELETE_HELP)));
+
 export const clipCommand = Command.make("clip").pipe(
   Command.withDescription(detail(CLIP_HELP)),
-  Command.withSubcommands([listCmd, getCmd, updateCmd])
+  Command.withSubcommands([listCmd, getCmd, updateCmd, moveCmd, deleteCmd])
 );

--- a/app/services/db-chapter-operations.server.ts
+++ b/app/services/db-chapter-operations.server.ts
@@ -1,0 +1,425 @@
+import type { Database } from "@/services/drizzle-service.server";
+import { clips, chapters } from "@/db/schema";
+import {
+  NotFoundError,
+  UnknownDBServiceError,
+} from "@/services/db-service-errors";
+import { and, asc, eq } from "drizzle-orm";
+import { Effect } from "effect";
+import { generateNKeysBetween } from "fractional-indexing";
+import {
+  requireDraftVersionForChapter,
+  requireDraftVersionForVideo,
+} from "./draft-guard.server";
+import { compareOrderStrings } from "@/lib/sort-by-order";
+
+const makeDbCall = <T>(fn: () => Promise<T>) => {
+  return Effect.tryPromise({
+    try: fn,
+    catch: (e) => new UnknownDBServiceError({ cause: e }),
+  });
+};
+
+/**
+ * Chapter write/read operations. Split out of db-clip-operations.server.ts
+ * purely to stay under the repo's per-file token budget: Chapters and Clips
+ * share one fractional order space (see `app/cli/commands/clip.ts`
+ * docstring), so every positioning op here still reads both tables to
+ * compute a merged timeline view, but none of these functions call INTO the
+ * Clip-specific ops, so the split has no behavioral seam. Merged back into
+ * `ClipOperationsService`'s single surface by db-clip-operations.server.ts —
+ * every existing caller keeps going through that one service.
+ */
+export const createChapterOperationsUnwrapped = (db: Database) => {
+  const createChapter = Effect.fn("createChapter")(function* (
+    videoId: string,
+    name: string,
+    order: string
+  ) {
+    yield* requireDraftVersionForVideo(db, videoId);
+    const [chapter] = yield* makeDbCall(() =>
+      db
+        .insert(chapters)
+        .values({
+          videoId,
+          name,
+          order,
+          archived: false,
+        })
+        .returning()
+    );
+
+    if (!chapter) {
+      return yield* new UnknownDBServiceError({
+        cause: "No chapter was returned from the database",
+      });
+    }
+
+    return chapter;
+  });
+
+  const createChapterAtInsertionPoint = Effect.fn(
+    "createChapterAtInsertionPoint"
+  )(function* (
+    videoId: string,
+    name: string,
+    insertionPoint:
+      | { type: "start" }
+      | { type: "after-clip"; databaseClipId: string }
+      | { type: "after-chapter"; chapterId: string }
+  ) {
+    yield* requireDraftVersionForVideo(db, videoId);
+    // Get all non-archived clips and chapters for this video, ordered
+    const allClips = yield* makeDbCall(() =>
+      db.query.clips.findMany({
+        where: and(eq(clips.videoId, videoId), eq(clips.archived, false)),
+        orderBy: asc(clips.order),
+      })
+    );
+
+    const allChapters = yield* makeDbCall(() =>
+      db.query.chapters.findMany({
+        where: and(eq(chapters.videoId, videoId), eq(chapters.archived, false)),
+        orderBy: asc(chapters.order),
+      })
+    );
+
+    // Combine and sort by order
+    const allItems = [
+      ...allClips.map((c) => ({ type: "clip" as const, ...c })),
+      ...allChapters.map((cs) => ({
+        type: "chapter" as const,
+        ...cs,
+      })),
+    ].sort((a, b) => compareOrderStrings(a.order, b.order));
+
+    // Calculate order based on insertion point
+    let prevOrder: string | null = null;
+    let nextOrder: string | null = null;
+
+    if (insertionPoint.type === "start") {
+      // Insert before all items
+      const firstItem = allItems[0];
+      nextOrder = firstItem?.order ?? null;
+    } else if (insertionPoint.type === "after-clip") {
+      // Insert after specific clip
+      const insertAfterClipIndex = allItems.findIndex(
+        (item) =>
+          item.type === "clip" && item.id === insertionPoint.databaseClipId
+      );
+
+      if (insertAfterClipIndex === -1) {
+        return yield* new NotFoundError({
+          type: "createChapterAtInsertionPoint",
+          params: { videoId, insertionPoint },
+          message: `Could not find a clip to insert after`,
+        });
+      }
+
+      const insertAfterItem = allItems[insertAfterClipIndex];
+      prevOrder = insertAfterItem?.order ?? null;
+
+      const nextItem = allItems[insertAfterClipIndex + 1];
+      nextOrder = nextItem?.order ?? null;
+    } else if (insertionPoint.type === "after-chapter") {
+      // Insert after specific chapter
+      const insertAfterSectionIndex = allItems.findIndex(
+        (item) =>
+          item.type === "chapter" && item.id === insertionPoint.chapterId
+      );
+
+      if (insertAfterSectionIndex === -1) {
+        return yield* new NotFoundError({
+          type: "createChapterAtInsertionPoint",
+          params: { videoId, insertionPoint },
+          message: `Could not find a chapter to insert after`,
+        });
+      }
+
+      const insertAfterItem = allItems[insertAfterSectionIndex];
+      prevOrder = insertAfterItem?.order ?? null;
+
+      const nextItem = allItems[insertAfterSectionIndex + 1];
+      nextOrder = nextItem?.order ?? null;
+    }
+
+    const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
+
+    const [chapter] = yield* makeDbCall(() =>
+      db
+        .insert(chapters)
+        .values({
+          videoId,
+          name,
+          order: order!,
+          archived: false,
+        })
+        .returning()
+    );
+
+    if (!chapter) {
+      return yield* new UnknownDBServiceError({
+        cause: "No chapter was returned from the database",
+      });
+    }
+
+    return chapter;
+  });
+
+  const createChapterAtPosition = Effect.fn("createChapterAtPosition")(
+    function* (
+      videoId: string,
+      name: string,
+      position: "before" | "after",
+      targetItemId: string,
+      targetItemType: "clip" | "chapter"
+    ) {
+      yield* requireDraftVersionForVideo(db, videoId);
+      // Get all non-archived clips and chapters for this video, ordered
+      const allClips = yield* makeDbCall(() =>
+        db.query.clips.findMany({
+          where: and(eq(clips.videoId, videoId), eq(clips.archived, false)),
+          orderBy: asc(clips.order),
+        })
+      );
+
+      const allChapters = yield* makeDbCall(() =>
+        db.query.chapters.findMany({
+          where: and(
+            eq(chapters.videoId, videoId),
+            eq(chapters.archived, false)
+          ),
+          orderBy: asc(chapters.order),
+        })
+      );
+
+      // Combine and sort by order
+      const allItems = [
+        ...allClips.map((c) => ({ type: "clip" as const, ...c })),
+        ...allChapters.map((cs) => ({
+          type: "chapter" as const,
+          ...cs,
+        })),
+      ].sort((a, b) => compareOrderStrings(a.order, b.order));
+
+      // Find the target item
+      const targetIndex = allItems.findIndex(
+        (item) => item.type === targetItemType && item.id === targetItemId
+      );
+
+      if (targetIndex === -1) {
+        return yield* new NotFoundError({
+          type: "createChapterAtPosition",
+          params: { videoId, targetItemId, targetItemType },
+          message: `Could not find the target ${targetItemType} to position relative to`,
+        });
+      }
+
+      // Calculate order based on position
+      let prevOrder: string | null = null;
+      let nextOrder: string | null = null;
+
+      if (position === "before") {
+        // Insert before target item
+        nextOrder = allItems[targetIndex]?.order ?? null;
+        const prevItem = allItems[targetIndex - 1];
+        prevOrder = prevItem?.order ?? null;
+      } else {
+        // Insert after target item
+        prevOrder = allItems[targetIndex]?.order ?? null;
+        const nextItem = allItems[targetIndex + 1];
+        nextOrder = nextItem?.order ?? null;
+      }
+
+      const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
+
+      const [chapter] = yield* makeDbCall(() =>
+        db
+          .insert(chapters)
+          .values({
+            videoId,
+            name,
+            order: order!,
+            archived: false,
+          })
+          .returning()
+      );
+
+      if (!chapter) {
+        return yield* new UnknownDBServiceError({
+          cause: "No chapter was returned from the database",
+        });
+      }
+
+      return chapter;
+    }
+  );
+
+  const getChapterById = Effect.fn("getChapterById")(function* (
+    chapterId: string
+  ) {
+    const chapter = yield* makeDbCall(() =>
+      db.query.chapters.findFirst({
+        where: eq(chapters.id, chapterId),
+      })
+    );
+
+    if (!chapter) {
+      return yield* new NotFoundError({
+        type: "getChapterById",
+        params: { chapterId },
+      });
+    }
+
+    return chapter;
+  });
+
+  const updateChapter = Effect.fn("updateChapter")(function* (
+    chapterId: string,
+    updates: {
+      name?: string;
+    }
+  ) {
+    yield* requireDraftVersionForChapter(db, chapterId);
+    const [chapter] = yield* makeDbCall(() =>
+      db
+        .update(chapters)
+        .set(updates)
+        .where(eq(chapters.id, chapterId))
+        .returning()
+    );
+
+    if (!chapter) {
+      return yield* new NotFoundError({
+        type: "updateChapter",
+        params: { chapterId },
+      });
+    }
+
+    return chapter;
+  });
+
+  const archiveChapter = Effect.fn("archiveChapter")(function* (
+    chapterId: string
+  ) {
+    yield* requireDraftVersionForChapter(db, chapterId);
+    const chapterExists = yield* makeDbCall(() =>
+      db.query.chapters.findFirst({
+        where: eq(chapters.id, chapterId),
+      })
+    );
+
+    if (!chapterExists) {
+      return yield* new NotFoundError({
+        type: "archiveChapter",
+        params: { chapterId },
+      });
+    }
+
+    yield* makeDbCall(() =>
+      db
+        .update(chapters)
+        .set({ archived: true })
+        .where(eq(chapters.id, chapterId))
+    );
+
+    return { success: true };
+  });
+
+  const reorderChapter = Effect.fn("reorderChapter")(function* (
+    chapterId: string,
+    direction: "up" | "down"
+  ) {
+    yield* requireDraftVersionForChapter(db, chapterId);
+    // Get the chapter to know what video we're working with
+    const chapter = yield* makeDbCall(() =>
+      db.query.chapters.findFirst({
+        where: eq(chapters.id, chapterId),
+      })
+    );
+
+    if (!chapter) {
+      return yield* new NotFoundError({
+        type: "reorderChapter",
+        params: { chapterId },
+      });
+    }
+
+    // Get all non-archived clips and chapters for this video, ordered
+    const allClips = yield* makeDbCall(() =>
+      db.query.clips.findMany({
+        where: and(
+          eq(clips.videoId, chapter.videoId),
+          eq(clips.archived, false)
+        ),
+        orderBy: asc(clips.order),
+      })
+    );
+
+    const allChapters = yield* makeDbCall(() =>
+      db.query.chapters.findMany({
+        where: and(
+          eq(chapters.videoId, chapter.videoId),
+          eq(chapters.archived, false)
+        ),
+        orderBy: asc(chapters.order),
+      })
+    );
+
+    // Combine and sort by order
+    const allItems = [
+      ...allClips.map((c) => ({ type: "clip" as const, ...c })),
+      ...allChapters.map((cs) => ({
+        type: "chapter" as const,
+        ...cs,
+      })),
+    ].sort((a, b) => compareOrderStrings(a.order, b.order));
+
+    const itemIndex = allItems.findIndex(
+      (item) => item.type === "chapter" && item.id === chapterId
+    );
+    const targetIndex = direction === "up" ? itemIndex - 1 : itemIndex + 1;
+
+    // Check boundaries
+    if (targetIndex < 0 || targetIndex >= allItems.length) {
+      return { success: false, reason: "boundary" };
+    }
+
+    // Calculate new order
+    let newOrder: string;
+    if (direction === "up") {
+      const prevItem = allItems[targetIndex - 1];
+      const nextItem = allItems[targetIndex];
+      const prevOrder = prevItem?.order ?? null;
+      const nextOrder = nextItem!.order;
+      const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
+      newOrder = order!;
+    } else {
+      const prevItem = allItems[targetIndex];
+      const nextItem = allItems[targetIndex + 1];
+      const prevOrder = prevItem!.order;
+      const nextOrder = nextItem?.order ?? null;
+      const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
+      newOrder = order!;
+    }
+
+    yield* makeDbCall(() =>
+      db
+        .update(chapters)
+        .set({ order: newOrder })
+        .where(eq(chapters.id, chapterId))
+    );
+
+    return { success: true };
+  });
+
+  return {
+    createChapter,
+    createChapterAtInsertionPoint,
+    createChapterAtPosition,
+    getChapterById,
+    updateChapter,
+    archiveChapter,
+    reorderChapter,
+  };
+};

--- a/app/services/db-clip-operations.server.ts
+++ b/app/services/db-clip-operations.server.ts
@@ -11,7 +11,6 @@ import { and, asc, eq, inArray } from "drizzle-orm";
 import { Effect } from "effect";
 import { generateNKeysBetween } from "fractional-indexing";
 import {
-  requireDraftVersionForChapter,
   requireDraftVersionForClip,
   requireDraftVersionForClipWebLink,
   requireDraftVersionForVideo,
@@ -23,6 +22,7 @@ import {
   clipZoomIneligibilityMessage,
 } from "@/features/videos/clip-zoom";
 import { ClipNotZoomableError } from "@/services/db-service-errors";
+import { createChapterOperationsUnwrapped } from "./db-chapter-operations.server";
 
 const makeDbCall = <T>(fn: () => Promise<T>) => {
   return Effect.tryPromise({
@@ -69,6 +69,8 @@ const createClipOperationsUnwrapped = (db: Database) => {
       profile?: string;
       transcribedAt?: Date;
       pauseType?: string;
+      sourceStartTime?: number;
+      sourceEndTime?: number;
     }
   ) {
     yield* requireDraftVersionForClip(db, clipId);
@@ -214,45 +216,16 @@ const createClipOperationsUnwrapped = (db: Database) => {
     return { success: true };
   });
 
-  const createChapter = Effect.fn("createChapter")(function* (
-    videoId: string,
-    name: string,
-    order: string
+  /**
+   * Non-archived clips and chapters of a Video, merged and sorted by the
+   * shared fractional `order` key. Clips and Chapters share one ordering
+   * space (see `app/cli/commands/clip.ts` docstring), so any positioning
+   * logic — reordering a clip, inserting a chapter — has to reason about
+   * both together; this is the one place that assembles the merged view.
+   */
+  const listTimelineOrder = Effect.fn("listTimelineOrder")(function* (
+    videoId: string
   ) {
-    yield* requireDraftVersionForVideo(db, videoId);
-    const [chapter] = yield* makeDbCall(() =>
-      db
-        .insert(chapters)
-        .values({
-          videoId,
-          name,
-          order,
-          archived: false,
-        })
-        .returning()
-    );
-
-    if (!chapter) {
-      return yield* new UnknownDBServiceError({
-        cause: "No chapter was returned from the database",
-      });
-    }
-
-    return chapter;
-  });
-
-  const createChapterAtInsertionPoint = Effect.fn(
-    "createChapterAtInsertionPoint"
-  )(function* (
-    videoId: string,
-    name: string,
-    insertionPoint:
-      | { type: "start" }
-      | { type: "after-clip"; databaseClipId: string }
-      | { type: "after-chapter"; chapterId: string }
-  ) {
-    yield* requireDraftVersionForVideo(db, videoId);
-    // Get all non-archived clips and chapters for this video, ordered
     const allClips = yield* makeDbCall(() =>
       db.query.clips.findMany({
         where: and(eq(clips.videoId, videoId), eq(clips.archived, false)),
@@ -267,334 +240,67 @@ const createClipOperationsUnwrapped = (db: Database) => {
       })
     );
 
-    // Combine and sort by order
-    const allItems = [
-      ...allClips.map((c) => ({ type: "clip" as const, ...c })),
-      ...allChapters.map((cs) => ({
+    return [
+      ...allClips.map((c) => ({
+        type: "clip" as const,
+        id: c.id,
+        order: c.order,
+      })),
+      ...allChapters.map((c) => ({
         type: "chapter" as const,
-        ...cs,
+        id: c.id,
+        order: c.order,
       })),
     ].sort((a, b) => compareOrderStrings(a.order, b.order));
+  });
 
-    // Calculate order based on insertion point
-    let prevOrder: string | null = null;
-    let nextOrder: string | null = null;
+  /**
+   * Reposition a Clip to an explicit point in its Video's timeline order,
+   * anchored immediately before `beforeItemId` (a Clip OR Chapter id, since
+   * they share one order space) — `null` appends to the end.
+   *
+   * Unlike `reorderClip` (nudge one slot up/down), this jumps straight to an
+   * arbitrary position. The CLI's `clip move --before/--after` resolves its
+   * target id against `listTimelineOrder` and hands the result here.
+   */
+  const moveClipToPosition = Effect.fn("moveClipToPosition")(function* (
+    clipId: string,
+    beforeItemId: string | null
+  ) {
+    yield* requireDraftVersionForClip(db, clipId);
+    const clip = yield* getClipById(clipId);
 
-    if (insertionPoint.type === "start") {
-      // Insert before all items
-      const firstItem = allItems[0];
-      nextOrder = firstItem?.order ?? null;
-    } else if (insertionPoint.type === "after-clip") {
-      // Insert after specific clip
-      const insertAfterClipIndex = allItems.findIndex(
-        (item) =>
-          item.type === "clip" && item.id === insertionPoint.databaseClipId
-      );
+    const items = (yield* listTimelineOrder(clip.videoId)).filter(
+      (item) => item.id !== clipId
+    );
 
-      if (insertAfterClipIndex === -1) {
+    let prevOrder: string | null;
+    let nextOrder: string | null;
+    if (beforeItemId === null) {
+      prevOrder = items.at(-1)?.order ?? null;
+      nextOrder = null;
+    } else {
+      const idx = items.findIndex((item) => item.id === beforeItemId);
+      if (idx === -1) {
         return yield* new NotFoundError({
-          type: "createChapterAtInsertionPoint",
-          params: { videoId, insertionPoint },
-          message: `Could not find a clip to insert after`,
+          type: "moveClipToPosition",
+          params: { clipId: beforeItemId },
         });
       }
-
-      const insertAfterItem = allItems[insertAfterClipIndex];
-      prevOrder = insertAfterItem?.order ?? null;
-
-      const nextItem = allItems[insertAfterClipIndex + 1];
-      nextOrder = nextItem?.order ?? null;
-    } else if (insertionPoint.type === "after-chapter") {
-      // Insert after specific chapter
-      const insertAfterSectionIndex = allItems.findIndex(
-        (item) =>
-          item.type === "chapter" && item.id === insertionPoint.chapterId
-      );
-
-      if (insertAfterSectionIndex === -1) {
-        return yield* new NotFoundError({
-          type: "createChapterAtInsertionPoint",
-          params: { videoId, insertionPoint },
-          message: `Could not find a chapter to insert after`,
-        });
-      }
-
-      const insertAfterItem = allItems[insertAfterSectionIndex];
-      prevOrder = insertAfterItem?.order ?? null;
-
-      const nextItem = allItems[insertAfterSectionIndex + 1];
-      nextOrder = nextItem?.order ?? null;
+      prevOrder = items[idx - 1]?.order ?? null;
+      nextOrder = items[idx]!.order;
     }
 
     const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
 
-    const [chapter] = yield* makeDbCall(() =>
-      db
-        .insert(chapters)
-        .values({
-          videoId,
-          name,
-          order: order!,
-          archived: false,
-        })
-        .returning()
-    );
-
-    if (!chapter) {
-      return yield* new UnknownDBServiceError({
-        cause: "No chapter was returned from the database",
-      });
-    }
-
-    return chapter;
-  });
-
-  const createChapterAtPosition = Effect.fn("createChapterAtPosition")(
-    function* (
-      videoId: string,
-      name: string,
-      position: "before" | "after",
-      targetItemId: string,
-      targetItemType: "clip" | "chapter"
-    ) {
-      yield* requireDraftVersionForVideo(db, videoId);
-      // Get all non-archived clips and chapters for this video, ordered
-      const allClips = yield* makeDbCall(() =>
-        db.query.clips.findMany({
-          where: and(eq(clips.videoId, videoId), eq(clips.archived, false)),
-          orderBy: asc(clips.order),
-        })
-      );
-
-      const allChapters = yield* makeDbCall(() =>
-        db.query.chapters.findMany({
-          where: and(
-            eq(chapters.videoId, videoId),
-            eq(chapters.archived, false)
-          ),
-          orderBy: asc(chapters.order),
-        })
-      );
-
-      // Combine and sort by order
-      const allItems = [
-        ...allClips.map((c) => ({ type: "clip" as const, ...c })),
-        ...allChapters.map((cs) => ({
-          type: "chapter" as const,
-          ...cs,
-        })),
-      ].sort((a, b) => compareOrderStrings(a.order, b.order));
-
-      // Find the target item
-      const targetIndex = allItems.findIndex(
-        (item) => item.type === targetItemType && item.id === targetItemId
-      );
-
-      if (targetIndex === -1) {
-        return yield* new NotFoundError({
-          type: "createChapterAtPosition",
-          params: { videoId, targetItemId, targetItemType },
-          message: `Could not find the target ${targetItemType} to position relative to`,
-        });
-      }
-
-      // Calculate order based on position
-      let prevOrder: string | null = null;
-      let nextOrder: string | null = null;
-
-      if (position === "before") {
-        // Insert before target item
-        nextOrder = allItems[targetIndex]?.order ?? null;
-        const prevItem = allItems[targetIndex - 1];
-        prevOrder = prevItem?.order ?? null;
-      } else {
-        // Insert after target item
-        prevOrder = allItems[targetIndex]?.order ?? null;
-        const nextItem = allItems[targetIndex + 1];
-        nextOrder = nextItem?.order ?? null;
-      }
-
-      const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
-
-      const [chapter] = yield* makeDbCall(() =>
-        db
-          .insert(chapters)
-          .values({
-            videoId,
-            name,
-            order: order!,
-            archived: false,
-          })
-          .returning()
-      );
-
-      if (!chapter) {
-        return yield* new UnknownDBServiceError({
-          cause: "No chapter was returned from the database",
-        });
-      }
-
-      return chapter;
-    }
-  );
-
-  const getChapterById = Effect.fn("getChapterById")(function* (
-    chapterId: string
-  ) {
-    const chapter = yield* makeDbCall(() =>
-      db.query.chapters.findFirst({
-        where: eq(chapters.id, chapterId),
-      })
-    );
-
-    if (!chapter) {
-      return yield* new NotFoundError({
-        type: "getChapterById",
-        params: { chapterId },
-      });
-    }
-
-    return chapter;
-  });
-
-  const updateChapter = Effect.fn("updateChapter")(function* (
-    chapterId: string,
-    updates: {
-      name?: string;
-    }
-  ) {
-    yield* requireDraftVersionForChapter(db, chapterId);
-    const [chapter] = yield* makeDbCall(() =>
-      db
-        .update(chapters)
-        .set(updates)
-        .where(eq(chapters.id, chapterId))
-        .returning()
-    );
-
-    if (!chapter) {
-      return yield* new NotFoundError({
-        type: "updateChapter",
-        params: { chapterId },
-      });
-    }
-
-    return chapter;
-  });
-
-  const archiveChapter = Effect.fn("archiveChapter")(function* (
-    chapterId: string
-  ) {
-    yield* requireDraftVersionForChapter(db, chapterId);
-    const chapterExists = yield* makeDbCall(() =>
-      db.query.chapters.findFirst({
-        where: eq(chapters.id, chapterId),
-      })
-    );
-
-    if (!chapterExists) {
-      return yield* new NotFoundError({
-        type: "archiveChapter",
-        params: { chapterId },
-      });
-    }
-
     yield* makeDbCall(() =>
-      db
-        .update(chapters)
-        .set({ archived: true })
-        .where(eq(chapters.id, chapterId))
+      db.update(clips).set({ order: order! }).where(eq(clips.id, clipId))
     );
 
-    return { success: true };
+    return yield* getClipById(clipId);
   });
 
-  const reorderChapter = Effect.fn("reorderChapter")(function* (
-    chapterId: string,
-    direction: "up" | "down"
-  ) {
-    yield* requireDraftVersionForChapter(db, chapterId);
-    // Get the chapter to know what video we're working with
-    const chapter = yield* makeDbCall(() =>
-      db.query.chapters.findFirst({
-        where: eq(chapters.id, chapterId),
-      })
-    );
-
-    if (!chapter) {
-      return yield* new NotFoundError({
-        type: "reorderChapter",
-        params: { chapterId },
-      });
-    }
-
-    // Get all non-archived clips and chapters for this video, ordered
-    const allClips = yield* makeDbCall(() =>
-      db.query.clips.findMany({
-        where: and(
-          eq(clips.videoId, chapter.videoId),
-          eq(clips.archived, false)
-        ),
-        orderBy: asc(clips.order),
-      })
-    );
-
-    const allChapters = yield* makeDbCall(() =>
-      db.query.chapters.findMany({
-        where: and(
-          eq(chapters.videoId, chapter.videoId),
-          eq(chapters.archived, false)
-        ),
-        orderBy: asc(chapters.order),
-      })
-    );
-
-    // Combine and sort by order
-    const allItems = [
-      ...allClips.map((c) => ({ type: "clip" as const, ...c })),
-      ...allChapters.map((cs) => ({
-        type: "chapter" as const,
-        ...cs,
-      })),
-    ].sort((a, b) => compareOrderStrings(a.order, b.order));
-
-    const itemIndex = allItems.findIndex(
-      (item) => item.type === "chapter" && item.id === chapterId
-    );
-    const targetIndex = direction === "up" ? itemIndex - 1 : itemIndex + 1;
-
-    // Check boundaries
-    if (targetIndex < 0 || targetIndex >= allItems.length) {
-      return { success: false, reason: "boundary" };
-    }
-
-    // Calculate new order
-    let newOrder: string;
-    if (direction === "up") {
-      const prevItem = allItems[targetIndex - 1];
-      const nextItem = allItems[targetIndex];
-      const prevOrder = prevItem?.order ?? null;
-      const nextOrder = nextItem!.order;
-      const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
-      newOrder = order!;
-    } else {
-      const prevItem = allItems[targetIndex];
-      const nextItem = allItems[targetIndex + 1];
-      const prevOrder = prevItem!.order;
-      const nextOrder = nextItem?.order ?? null;
-      const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
-      newOrder = order!;
-    }
-
-    yield* makeDbCall(() =>
-      db
-        .update(chapters)
-        .set({ order: newOrder })
-        .where(eq(chapters.id, chapterId))
-    );
-
-    return { success: true };
-  });
+  const chapterOps = createChapterOperationsUnwrapped(db);
 
   const appendClips = Effect.fn("addClips")(function* (opts: {
     videoId: string;
@@ -757,13 +463,9 @@ const createClipOperationsUnwrapped = (db: Database) => {
     setClipZoom,
     archiveClip,
     reorderClip,
-    createChapter,
-    createChapterAtInsertionPoint,
-    createChapterAtPosition,
-    getChapterById,
-    updateChapter,
-    archiveChapter,
-    reorderChapter,
+    listTimelineOrder,
+    moveClipToPosition,
+    ...chapterOps,
     appendClips,
     createClipWebLinks,
     deleteClipWebLink,
@@ -777,6 +479,7 @@ export const createClipOperations = (db: Database) =>
     "setClipZoom",
     "archiveClip",
     "reorderClip",
+    "moveClipToPosition",
     "createChapter",
     "createChapterAtInsertionPoint",
     "createChapterAtPosition",

--- a/app/services/db-service-clip-ordering.test.ts
+++ b/app/services/db-service-clip-ordering.test.ts
@@ -453,3 +453,143 @@ describe("createChapterAtPosition", () => {
       }).pipe(Effect.provide(testLayer))
   );
 });
+
+describe("moveClipToPosition", () => {
+  let videoId: string;
+  let clipCounter = 0;
+
+  const appendClips = (insertionPoint: InsertionPoint, clipCount = 1) =>
+    Effect.gen(function* () {
+      const clipOps = yield* ClipOperationsService;
+      const offset = clipCounter;
+      clipCounter += clipCount;
+      return yield* clipOps.appendClips({
+        videoId,
+        insertionPoint,
+        clips: Array.from({ length: clipCount }, (_, i) => ({
+          inputVideo: "test.mp4",
+          startTime: (offset + i) * 10,
+          endTime: (offset + i + 1) * 10,
+        })),
+      });
+    });
+
+  const createSection = (name: string, insertionPoint: InsertionPoint) =>
+    Effect.gen(function* () {
+      const clipOps = yield* ClipOperationsService;
+      return yield* clipOps.createChapterAtInsertionPoint(
+        videoId,
+        name,
+        insertionPoint
+      );
+    });
+
+  const moveClip = (clipId: string, beforeItemId: string | null) =>
+    Effect.gen(function* () {
+      const clipOps = yield* ClipOperationsService;
+      return yield* clipOps.moveClipToPosition(clipId, beforeItemId);
+    });
+
+  const getAllItemsSorted = () =>
+    Effect.gen(function* () {
+      const videoOps = yield* VideoOperationsService;
+      const video = yield* videoOps.getVideoWithClipsById(videoId);
+      return sortByOrder([
+        ...video.clips.map((c: any) => ({
+          type: "clip" as const,
+          id: c.id,
+          order: c.order,
+        })),
+        ...video.chapters.map((s: any) => ({
+          type: "chapter" as const,
+          id: s.id,
+          order: s.order,
+        })),
+      ]);
+    });
+
+  beforeEach(async () => {
+    clipCounter = 0;
+    await truncateAllTables(testDb);
+
+    const video = await Effect.gen(function* () {
+      const videoOps = yield* VideoOperationsService;
+      return yield* videoOps.createStandaloneVideo({ title: "test-video.mp4" });
+    }).pipe(Effect.provide(testLayer), Effect.runPromise);
+    videoId = video.id;
+  });
+
+  it.effect("jumps a clip to before a non-adjacent clip", () =>
+    Effect.gen(function* () {
+      // Build: [Clip A, Clip B, Clip C]
+      const clipA = (yield* appendClips({ type: "start" }))[0]!;
+      const clipB = (yield* appendClips({
+        type: "after-clip",
+        databaseClipId: clipA.id,
+      }))[0]!;
+      const clipC = (yield* appendClips({
+        type: "after-clip",
+        databaseClipId: clipB.id,
+      }))[0]!;
+
+      // Move C to before A in one jump (not an adjacent swap)
+      yield* moveClip(clipC.id, clipA.id);
+
+      const items = yield* getAllItemsSorted();
+      expect(items.map((i) => i.id)).toEqual([clipC.id, clipA.id, clipB.id]);
+    }).pipe(Effect.provide(testLayer))
+  );
+
+  it.effect("positions a clip immediately after a chapter", () =>
+    Effect.gen(function* () {
+      // Build: [Clip A, Section, Clip B]
+      const clipA = (yield* appendClips({ type: "start" }))[0]!;
+      const section = yield* createSection("Section 1", {
+        type: "after-clip",
+        databaseClipId: clipA.id,
+      });
+      const clipB = (yield* appendClips({
+        type: "after-chapter",
+        chapterId: section.id,
+      }))[0]!;
+
+      // Move Clip B to before Clip A — should land ahead of the section too,
+      // since clips and chapters share one order space.
+      yield* moveClip(clipB.id, clipA.id);
+
+      const items = yield* getAllItemsSorted();
+      expect(items.map((i) => ({ type: i.type, id: i.id }))).toEqual([
+        { type: "clip", id: clipB.id },
+        { type: "clip", id: clipA.id },
+        { type: "chapter", id: section.id },
+      ]);
+    }).pipe(Effect.provide(testLayer))
+  );
+
+  it.effect("null beforeItemId appends to the end", () =>
+    Effect.gen(function* () {
+      // Build: [Clip A, Clip B]
+      const clipA = (yield* appendClips({ type: "start" }))[0]!;
+      const clipB = (yield* appendClips({
+        type: "after-clip",
+        databaseClipId: clipA.id,
+      }))[0]!;
+
+      yield* moveClip(clipA.id, null);
+
+      const items = yield* getAllItemsSorted();
+      expect(items.map((i) => i.id)).toEqual([clipB.id, clipA.id]);
+    }).pipe(Effect.provide(testLayer))
+  );
+
+  it.effect("unknown beforeItemId => NotFoundError", () =>
+    Effect.gen(function* () {
+      const clipA = (yield* appendClips({ type: "start" }))[0]!;
+
+      const result = yield* moveClip(clipA.id, "nonexistent-id").pipe(
+        Effect.flip
+      );
+      expect(result._tag).toBe("NotFoundError");
+    }).pipe(Effect.provide(testLayer))
+  );
+});


### PR DESCRIPTION
## Summary

Grew the `cvm clip` CLI beyond its zoom-only `update` per the plan worked out in `/grill-me`:

- **`clip update --start/--end <seconds>`** — retime a clip's cut (either flag alone, or both). Rejects `start >= end` and anything under the existing `MINIMUM_CLIP_LENGTH_SECONDS` (1s) floor. Deliberately does **not** touch `text`/`transcribedAt` — there's no retranscription step to keep them in sync yet, so a retimed clip's text can go stale until something re-transcribes it. That's a known, accepted tradeoff for this pass (see follow-up below), not an oversight.
- **`clip move --before/--after <id>`** — reposition a clip to an arbitrary point in its video's timeline, mirroring `beat move`'s shape. Required new service-layer positioning (`moveClipToPosition` + `listTimelineOrder`), since the only prior clip-positioning primitive (`reorderClip`) only nudges one slot up/down — it can't jump.
- **`clip delete`** — soft-delete via the existing (already-implemented-but-unexposed) `archiveClip`. Same one-way "archived == deleted, no restore verb" convention as `beat delete`.

**No `clip add`.** Every existing clip creator needs a real footage file + an in/out time range on disk (OBS-capture append, "create video from selection") — there's no "create from nothing" path to hang a CLI command on, and it would need filesystem access to source video, which is a materially bigger feature than update/delete/move. Reordering covers the "move clips around" motivation that first justified wanting it.

All writes stay **immediate — no confirmation, no dry-run**, matching the explicit "agent-facing tool" convention already stated in `beat.help.ts`/`file.help.ts`. The safety net is the pre-existing `requireDraftVersionForClip` guard (every clip write already requires the owning course version to be a draft), not new ceremony.

Also splits Chapter operations out of `db-clip-operations.server.ts` into a new `db-chapter-operations.server.ts` (merged back into the same `ClipOperationsService` surface — no external caller changes), since the new clip additions pushed the combined file over the repo's 5500-token-per-file budget.

Filed #1532 separately for post-hoc audio introspection (silence/dead-air detection on existing clips) — a related idea that came up during planning but is a genuinely different problem (audio analysis pipeline), deliberately not part of this PR.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint:boundaries` — clean (run under Node 22; this sandbox's default Node 25 isn't yet supported by dependency-cruiser)
- [x] New tests: `app/services/db-service-clip-ordering.test.ts` (`moveClipToPosition` — jump across non-adjacent items, position after a chapter since clips/chapters share one order space, append via `null`, not-found) and `app/cli/cli-clip-writes.test.ts` (update start/end validation, zoom+retime combined, delete + hides-from-list + already-deleted writes, move before/after + cross-video rejection) — 4 + 17 new tests, all passing
- [x] Existing suites unaffected: `cli-integration`, `cli-beat-writes`, `clip-service-*`, `db-diagram-component-operations` all still green after the Chapter-ops extraction
- [x] Confirmed two pre-existing failures (`cli-segment-writes.test.ts`, `course-publish-service-video-tasks.test.ts`) reproduce identically on `main` — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)