### PR TITLE
fix(export): stop rare ffmpeg progress-drain hangs, and log stderr per video

### DIFF
--- a/apps/local/app/services/ffmpeg-commands.ts
+++ b/apps/local/app/services/ffmpeg-commands.ts
@@ -1,6 +1,6 @@
 import { Command, FileSystem } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
-import { Data, Effect, Stream } from "effect";
+import { Data, Effect, Ref, Stream } from "effect";
 import crypto from "node:crypto";
 import path from "node:path";
 import { tmpdir } from "os";
@@ -91,7 +91,11 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
           args: string[];
           totalDurationSeconds: number;
           onProgress: ((percent: number) => void) | undefined;
-          onLog?: (info: FfmpegLogInfo) => void;
+          // Required, not optional: an omitted onLog silently drops the
+          // per-video log this function exists to feed — see the
+          // "optional parameters" note in .sandcastle/CODING_STANDARDS.md.
+          // A caller with nothing to do about it passes a no-op explicitly.
+          onLog: (info: FfmpegLogInfo) => void;
           errorPrefix: string;
         }) {
           const commandLine = ["ffmpeg", ...opts.args];
@@ -146,29 +150,41 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
               );
 
               // Tee stderr to our own stderr (so a developer watching the
-              // terminal sees what they always have) while folding a bounded
-              // tail for the error message and the per-video log.
+              // terminal sees what they always have) while accumulating a
+              // bounded tail for the error message and the per-video log.
+              // Written into a Ref rather than folded through the stream's
+              // own return value: a Ref keeps whatever was captured so far
+              // even if the stream itself dies partway (a decode error, a
+              // closed fd) — the same per-chunk containment as stdout above,
+              // so one bad chunk can't cost the whole tail.
+              const stderrTailRef = yield* Ref.make("");
               const drainStderr = child.stderr.pipe(
                 Stream.decodeText(),
-                Stream.runFoldEffect("", (tail, chunk) =>
+                Stream.runForEach((chunk) =>
                   Effect.sync(() => {
                     try {
                       process.stderr.write(chunk);
                     } catch {
                       // Best-effort tee only; never let a closed fd stop capture.
                     }
-                    return appendBoundedTail(tail, chunk);
-                  })
+                  }).pipe(
+                    Effect.zipRight(
+                      Ref.update(stderrTailRef, (tail) =>
+                        appendBoundedTail(tail, chunk)
+                      )
+                    ),
+                    Effect.catchAllCause(() => Effect.void)
+                  )
                 ),
-                Effect.orElseSucceed(() => "")
+                Effect.ignore
               );
 
-              const [, stderrTail] = yield* Effect.all(
-                [drainStdout, drainStderr],
-                { concurrency: 2 }
-              );
+              yield* Effect.all([drainStdout, drainStderr], {
+                concurrency: 2,
+              });
+              const stderrTail = yield* Ref.get(stderrTailRef);
 
-              opts.onLog?.({ command: commandLine, stderrTail });
+              opts.onLog({ command: commandLine, stderrTail });
 
               const code = yield* child.exitCode.pipe(
                 Effect.mapError((e) => toError(e, `: ${e.message}`, stderrTail))
@@ -263,8 +279,15 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
           zoomType?: string;
         }[],
         dimensions: { width: number; height: number },
-        onProgress?: (percent: number) => void,
-        onLog?: (info: FfmpegLogInfo) => void
+        // A single required object rather than stacking positional optionals:
+        // onProgress may reasonably be skipped (progress reporting is a UI
+        // nicety), but onLog must not be — an omitted logger silently drops
+        // the per-video log this function exists to feed. See the "optional
+        // parameters" note in .sandcastle/CODING_STANDARDS.md.
+        extras: {
+          onProgress?: (percent: number) => void;
+          onLog: (info: FfmpegLogInfo) => void;
+        }
       ) {
         const LONG_PAUSE_DURATION = 0.18;
 
@@ -377,8 +400,8 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
           runFfmpegWithProgress({
             args,
             totalDurationSeconds: expectedOutputDuration,
-            onProgress,
-            onLog,
+            onProgress: extras.onProgress,
+            onLog: extras.onLog,
             errorPrefix: "Failed to create concatenated video",
           })
         );
@@ -388,8 +411,10 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
 
       const normalizeAudio = Effect.fn("normalizeAudio")(function* (
         inputVideo: string,
-        onProgress?: (percent: number) => void,
-        onLog?: (info: FfmpegLogInfo) => void
+        extras: {
+          onProgress?: (percent: number) => void;
+          onLog: (info: FfmpegLogInfo) => void;
+        }
       ) {
         const outputDir = path.join(tmpdir(), "video-processing");
         yield* fs.makeDirectory(outputDir, { recursive: true });
@@ -456,8 +481,8 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
             args,
             // Video is stream-copied, so the output duration is the input's.
             totalDurationSeconds: videoDuration,
-            onProgress,
-            onLog,
+            onProgress: extras.onProgress,
+            onLog: extras.onLog,
             errorPrefix: "Failed to normalize audio",
           })
         );
@@ -469,7 +494,8 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
         videoPath: string,
         overlayPath: string,
         outputPath: string,
-        onLog?: (info: FfmpegLogInfo) => void
+        // Required, not optional — see the note on runFfmpegWithProgress.
+        onLog: (info: FfmpegLogInfo) => void
       ) {
         const args = [
           "-y",
@@ -502,10 +528,10 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
         // Scoped (so an interrupted fiber kills the child) and registered
         // with the parent-death backstop (so a dev-server restart mid-render
         // doesn't orphan it) — this was previously the one ffmpeg call in the
-        // service missing both, despite being the final, often longest step
-        // of a Short's render (libx264 "slow"). Only stderr is piped: stdout
-        // carries no progress data here, so inheriting it is exempt from the
-        // drain-or-block hazard documented on runFfmpegWithProgress.
+        // export path missing both, despite being the final, often longest
+        // step of a Short's render (libx264 "slow"). Only stderr is piped:
+        // stdout carries no progress data here, so inheriting it is exempt
+        // from the drain-or-block hazard documented on runFfmpegWithProgress.
         yield* gpuSemaphore.withPermits(1)(
           Effect.scoped(
             Effect.gen(function* () {
@@ -526,22 +552,34 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
                 (unregister) => Effect.sync(unregister)
               );
 
-              const stderrTail = yield* child.stderr.pipe(
+              // Same Ref-backed, per-chunk-contained capture as
+              // runFfmpegWithProgress's stderr drain — see its comment for
+              // why a Ref (not the stream's own fold result) is what
+              // survives a mid-stream failure.
+              const stderrTailRef = yield* Ref.make("");
+              yield* child.stderr.pipe(
                 Stream.decodeText(),
-                Stream.runFoldEffect("", (tail, chunk) =>
+                Stream.runForEach((chunk) =>
                   Effect.sync(() => {
                     try {
                       process.stderr.write(chunk);
                     } catch {
                       // Best-effort tee only; never let a closed fd stop capture.
                     }
-                    return appendBoundedTail(tail, chunk);
-                  })
+                  }).pipe(
+                    Effect.zipRight(
+                      Ref.update(stderrTailRef, (tail) =>
+                        appendBoundedTail(tail, chunk)
+                      )
+                    ),
+                    Effect.catchAllCause(() => Effect.void)
+                  )
                 ),
-                Effect.orElseSucceed(() => "")
+                Effect.ignore
               );
+              const stderrTail = yield* Ref.get(stderrTailRef);
 
-              onLog?.({ command: commandLine, stderrTail });
+              onLog({ command: commandLine, stderrTail });
 
               const code = yield* child.exitCode.pipe(
                 Effect.mapError(

--- a/apps/local/app/services/ffmpeg-commands.ts
+++ b/apps/local/app/services/ffmpeg-commands.ts
@@ -6,7 +6,13 @@ import path from "node:path";
 import { tmpdir } from "os";
 import { registerFfmpegChild } from "./ffmpeg-child-registry";
 import { createFfmpegProgressParser } from "./ffmpeg-progress";
+import { appendBoundedTail, withStderrTail } from "./ffmpeg-log-capture";
 import { clipZoomCropFilter } from "@/features/videos/clip-zoom";
+
+/** Emitted once a command has run (success or failure) so a caller that
+ * knows the domain object (a videoId) can tee it into a durable, agent- and
+ * human-readable log — see VideoEditorLoggerService's "cli-output" event. */
+export type FfmpegLogInfo = { command: string[]; stderrTail: string };
 
 const GPU_PERMITS = 6;
 const CPU_PERMITS = 12;
@@ -63,18 +69,43 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
        * publish) kills the child; the PID is also registered with the
        * parent-death backstop (see ffmpeg-child-registry) for the case where
        * the dev server itself dies without interrupting any fiber.
+       *
+       * Both stdout (progress) and stderr (diagnostics) are piped rather than
+       * inherited, and BOTH are drained concurrently via a single
+       * `Effect.all`. That concurrency is load-bearing, not incidental: a
+       * piped OS stream that nobody reads fills its buffer (~64KB) and blocks
+       * the writer, so draining stdout to completion before even starting to
+       * drain stderr would recreate, on stderr, the exact hang this function
+       * exists to prevent on stdout.
+       *
+       * Each drained chunk is handled in isolation — a throw anywhere
+       * downstream of `onProgress` (most plausibly an SSE controller whose
+       * client has gone away) must never stop that stream's loop. If it did,
+       * nobody would read that pipe again, ffmpeg's next write to it would
+       * block on a full buffer, and the encode would hang forever — a hang
+       * invisible to `Effect.retry`, since a process that never exits never
+       * resolves to a failure to retry.
        */
       const runFfmpegWithProgress = Effect.fn("runFfmpegWithProgress")(
         function* (opts: {
           args: string[];
           totalDurationSeconds: number;
           onProgress: ((percent: number) => void) | undefined;
+          onLog?: (info: FfmpegLogInfo) => void;
           errorPrefix: string;
         }) {
-          const toError = (cause: unknown, detail: string) =>
+          const commandLine = ["ffmpeg", ...opts.args];
+          const toError = (
+            cause: unknown,
+            detail: string,
+            stderrTail: string
+          ) =>
             new FFmpegError({
               cause,
-              message: `${opts.errorPrefix}${detail}`,
+              message: withStderrTail(
+                `${opts.errorPrefix}${detail}`,
+                stderrTail
+              ),
             });
 
           yield* Effect.scoped(
@@ -86,8 +117,8 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
                   "-progress",
                   "pipe:1",
                   ...opts.args
-                ).pipe(Command.stderr("inherit"))
-              ).pipe(Effect.mapError((e) => toError(e, `: ${e.message}`)));
+                )
+              ).pipe(Effect.mapError((e) => toError(e, `: ${e.message}`, "")));
 
               yield* Effect.acquireRelease(
                 Effect.sync(() => registerFfmpegChild(child.pid)),
@@ -100,20 +131,50 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
               });
 
               // Drain stdout even when nobody listens — an unread pipe would
-              // eventually block ffmpeg. The stream ends when the process does.
-              yield* child.stdout.pipe(
+              // eventually block ffmpeg. The stream ends when the process
+              // does. A failing chunk (see the function doc) is contained
+              // right here, per chunk, so the loop keeps running instead of
+              // Effect.ignore below only stopping it after the fact.
+              const drainStdout = child.stdout.pipe(
                 Stream.decodeText(),
                 Stream.runForEach((chunk) =>
-                  Effect.sync(() => parser.push(chunk))
+                  Effect.sync(() => parser.push(chunk)).pipe(
+                    Effect.catchAllCause(() => Effect.void)
+                  )
                 ),
                 Effect.ignore
               );
 
+              // Tee stderr to our own stderr (so a developer watching the
+              // terminal sees what they always have) while folding a bounded
+              // tail for the error message and the per-video log.
+              const drainStderr = child.stderr.pipe(
+                Stream.decodeText(),
+                Stream.runFoldEffect("", (tail, chunk) =>
+                  Effect.sync(() => {
+                    try {
+                      process.stderr.write(chunk);
+                    } catch {
+                      // Best-effort tee only; never let a closed fd stop capture.
+                    }
+                    return appendBoundedTail(tail, chunk);
+                  })
+                ),
+                Effect.orElseSucceed(() => "")
+              );
+
+              const [, stderrTail] = yield* Effect.all(
+                [drainStdout, drainStderr],
+                { concurrency: 2 }
+              );
+
+              opts.onLog?.({ command: commandLine, stderrTail });
+
               const code = yield* child.exitCode.pipe(
-                Effect.mapError((e) => toError(e, `: ${e.message}`))
+                Effect.mapError((e) => toError(e, `: ${e.message}`, stderrTail))
               );
               if (code !== 0) {
-                yield* toError(null, `, exit code: ${code}`);
+                yield* toError(null, `, exit code: ${code}`, stderrTail);
               }
             })
           );
@@ -202,7 +263,8 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
           zoomType?: string;
         }[],
         dimensions: { width: number; height: number },
-        onProgress?: (percent: number) => void
+        onProgress?: (percent: number) => void,
+        onLog?: (info: FfmpegLogInfo) => void
       ) {
         const LONG_PAUSE_DURATION = 0.18;
 
@@ -316,6 +378,7 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
             args,
             totalDurationSeconds: expectedOutputDuration,
             onProgress,
+            onLog,
             errorPrefix: "Failed to create concatenated video",
           })
         );
@@ -325,7 +388,8 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
 
       const normalizeAudio = Effect.fn("normalizeAudio")(function* (
         inputVideo: string,
-        onProgress?: (percent: number) => void
+        onProgress?: (percent: number) => void,
+        onLog?: (info: FfmpegLogInfo) => void
       ) {
         const outputDir = path.join(tmpdir(), "video-processing");
         yield* fs.makeDirectory(outputDir, { recursive: true });
@@ -393,6 +457,7 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
             // Video is stream-copied, so the output duration is the input's.
             totalDurationSeconds: videoDuration,
             onProgress,
+            onLog,
             errorPrefix: "Failed to normalize audio",
           })
         );
@@ -403,7 +468,8 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
       const compositeOverlay = Effect.fn("compositeOverlay")(function* (
         videoPath: string,
         overlayPath: string,
-        outputPath: string
+        outputPath: string,
+        onLog?: (info: FfmpegLogInfo) => void
       ) {
         const args = [
           "-y",
@@ -431,30 +497,75 @@ export class FFmpegCommandsService extends Effect.Service<FFmpegCommandsService>
           ...BITEXACT_ARGS,
           outputPath,
         ];
+        const commandLine = ["ffmpeg", ...args];
 
+        // Scoped (so an interrupted fiber kills the child) and registered
+        // with the parent-death backstop (so a dev-server restart mid-render
+        // doesn't orphan it) — this was previously the one ffmpeg call in the
+        // service missing both, despite being the final, often longest step
+        // of a Short's render (libx264 "slow"). Only stderr is piped: stdout
+        // carries no progress data here, so inheriting it is exempt from the
+        // drain-or-block hazard documented on runFfmpegWithProgress.
         yield* gpuSemaphore.withPermits(1)(
-          Effect.gen(function* () {
-            const code = yield* Command.exitCode(
-              Command.make("ffmpeg", ...args).pipe(
-                Command.stdout("inherit"),
-                Command.stderr("inherit")
-              )
-            ).pipe(
-              Effect.mapError(
-                (e) =>
-                  new FFmpegError({
-                    cause: e,
-                    message: `Failed to composite overlay: ${e.message}`,
+          Effect.scoped(
+            Effect.gen(function* () {
+              const child = yield* Command.start(
+                Command.make("ffmpeg", ...args).pipe(Command.stdout("inherit"))
+              ).pipe(
+                Effect.mapError(
+                  (e) =>
+                    new FFmpegError({
+                      cause: e,
+                      message: `Failed to composite overlay: ${e.message}`,
+                    })
+                )
+              );
+
+              yield* Effect.acquireRelease(
+                Effect.sync(() => registerFfmpegChild(child.pid)),
+                (unregister) => Effect.sync(unregister)
+              );
+
+              const stderrTail = yield* child.stderr.pipe(
+                Stream.decodeText(),
+                Stream.runFoldEffect("", (tail, chunk) =>
+                  Effect.sync(() => {
+                    try {
+                      process.stderr.write(chunk);
+                    } catch {
+                      // Best-effort tee only; never let a closed fd stop capture.
+                    }
+                    return appendBoundedTail(tail, chunk);
                   })
-              )
-            );
-            if (code !== 0) {
-              yield* new FFmpegError({
-                cause: null,
-                message: `ffmpeg composite exited with code ${code}`,
-              });
-            }
-          })
+                ),
+                Effect.orElseSucceed(() => "")
+              );
+
+              onLog?.({ command: commandLine, stderrTail });
+
+              const code = yield* child.exitCode.pipe(
+                Effect.mapError(
+                  (e) =>
+                    new FFmpegError({
+                      cause: e,
+                      message: withStderrTail(
+                        `Failed to composite overlay: ${e.message}`,
+                        stderrTail
+                      ),
+                    })
+                )
+              );
+              if (code !== 0) {
+                yield* new FFmpegError({
+                  cause: null,
+                  message: withStderrTail(
+                    `ffmpeg composite exited with code ${code}`,
+                    stderrTail
+                  ),
+                });
+              }
+            })
+          )
         );
 
         return outputPath;

--- a/apps/local/app/services/ffmpeg-log-capture.test.ts
+++ b/apps/local/app/services/ffmpeg-log-capture.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { appendBoundedTail, withStderrTail } from "./ffmpeg-log-capture";
+
+describe("appendBoundedTail", () => {
+  it("concatenates chunks while under the limit", () => {
+    const tail = appendBoundedTail(
+      appendBoundedTail("", "frame=1 fps=30\n", 100),
+      "frame=2 fps=30\n",
+      100
+    );
+    expect(tail).toBe("frame=1 fps=30\nframe=2 fps=30\n");
+  });
+
+  it("keeps only the last maxChars once the combined text overflows", () => {
+    const tail = appendBoundedTail("a".repeat(10), "b".repeat(10), 15);
+    expect(tail).toBe("a".repeat(5) + "b".repeat(10));
+    expect(tail.length).toBe(15);
+  });
+
+  it("truncates a single oversized chunk to its own tail", () => {
+    const tail = appendBoundedTail("", "x".repeat(50), 10);
+    expect(tail).toBe("x".repeat(10));
+  });
+
+  it("defaults to MAX_STDERR_TAIL_CHARS when no limit is given", () => {
+    const tail = appendBoundedTail("", "y".repeat(10_000));
+    expect(tail.length).toBe(8_000);
+  });
+});
+
+describe("withStderrTail", () => {
+  it("returns the message unchanged when there is no captured output", () => {
+    expect(withStderrTail("Failed to export", "")).toBe("Failed to export");
+  });
+
+  it("appends the tail under a labelled separator when present", () => {
+    expect(
+      withStderrTail("Failed to export", "Unknown encoder 'h264_nvenc'")
+    ).toBe(
+      "Failed to export\n--- ffmpeg stderr (tail) ---\nUnknown encoder 'h264_nvenc'"
+    );
+  });
+});

--- a/apps/local/app/services/ffmpeg-log-capture.ts
+++ b/apps/local/app/services/ffmpeg-log-capture.ts
@@ -1,0 +1,34 @@
+/**
+ * Bounded accumulation of ffmpeg/ffprobe stderr text, and the formatting that
+ * turns it into a useful error message.
+ *
+ * ffmpeg writes its diagnostic output — codec errors, encoder session
+ * failures, filter graph problems — to stderr for as long as the process
+ * runs, which for an export can be minutes. Capturing it verbatim risks
+ * unbounded memory; keeping only the tail is enough for diagnosis, since the
+ * bytes that matter on failure are almost always the last ones written
+ * before the process died. The same bound keeps the per-video log line (see
+ * VideoEditorLoggerService's "cli-output" event) from growing without limit
+ * across a long-running encode.
+ */
+export const MAX_STDERR_TAIL_CHARS = 8_000;
+
+export const appendBoundedTail = (
+  previousTail: string,
+  chunk: string,
+  maxChars: number = MAX_STDERR_TAIL_CHARS
+): string => {
+  const combined = previousTail + chunk;
+  return combined.length > maxChars
+    ? combined.slice(combined.length - maxChars)
+    : combined;
+};
+
+/**
+ * Appends a captured stderr tail to an error message, or returns the message
+ * unchanged when nothing was captured (e.g. the process never started).
+ */
+export const withStderrTail = (message: string, stderrTail: string): string =>
+  stderrTail
+    ? `${message}\n--- ffmpeg stderr (tail) ---\n${stderrTail}`
+    : message;

--- a/apps/local/app/services/ffmpeg-video-logger.test.ts
+++ b/apps/local/app/services/ffmpeg-video-logger.test.ts
@@ -1,0 +1,52 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { makeFfmpegLogger } from "./ffmpeg-video-logger";
+
+describe("makeFfmpegLogger", () => {
+  it("logs a cli-output event stage-prefixed with the joined command", () => {
+    const calls: { videoId: string; event: unknown }[] = [];
+    const fakeLogger = {
+      log: (videoId: string, event: unknown) =>
+        Effect.sync(() => {
+          calls.push({ videoId, event });
+        }),
+    };
+
+    const onLog = makeFfmpegLogger(fakeLogger, "video-1", "export:concat");
+    onLog({ command: ["ffmpeg", "-y", "-i", "in.mp4"], stderrTail: "warn" });
+
+    expect(calls).toEqual([
+      {
+        videoId: "video-1",
+        event: {
+          type: "cli-output",
+          command: "[export:concat] ffmpeg -y -i in.mp4",
+          stderr: "warn",
+        },
+      },
+    ]);
+  });
+
+  it("never throws when the underlying logger fails", () => {
+    const fakeLogger = {
+      log: () => Effect.fail(new Error("disk full")),
+    };
+
+    const onLog = makeFfmpegLogger(fakeLogger as any, "video-1", "stage");
+
+    expect(() => onLog({ command: ["ffmpeg"], stderrTail: "" })).not.toThrow();
+  });
+
+  it("never throws when the underlying logger itself throws synchronously", () => {
+    const fakeLogger = {
+      log: () =>
+        Effect.sync(() => {
+          throw new Error("boom");
+        }),
+    };
+
+    const onLog = makeFfmpegLogger(fakeLogger as any, "video-1", "stage");
+
+    expect(() => onLog({ command: ["ffmpeg"], stderrTail: "" })).not.toThrow();
+  });
+});

--- a/apps/local/app/services/ffmpeg-video-logger.ts
+++ b/apps/local/app/services/ffmpeg-video-logger.ts
@@ -1,0 +1,35 @@
+import { Effect } from "effect";
+import type { FfmpegLogInfo } from "./ffmpeg-commands";
+import type { VideoEditorLoggerService } from "./video-editor-logger-service";
+
+/**
+ * Bridges FFmpegCommandsService's `onLog` callback (a plain sync function —
+ * ffmpeg-commands.ts has no Effect Context of its own to run inside, and no
+ * notion of a videoId) to VideoEditorLoggerService's per-video "cli-output"
+ * event. The one place both exportVideoClips and renderVerticalVideo build
+ * their ffmpeg loggers from, so the two don't drift.
+ *
+ * VideoEditorLoggerService.log is a synchronous fs write (appendFileSync),
+ * so Effect.runSync is exact here — no detached fiber, no lost writes if the
+ * process exits right after export completes. Logging is best-effort: a
+ * disk hiccup must never fail the export it exists to help explain.
+ */
+export const makeFfmpegLogger =
+  (
+    logger: Pick<VideoEditorLoggerService, "log">,
+    videoId: string,
+    stage: string
+  ) =>
+  (info: FfmpegLogInfo): void => {
+    try {
+      Effect.runSync(
+        logger.log(videoId, {
+          type: "cli-output",
+          command: `[${stage}] ${info.command.join(" ")}`,
+          stderr: info.stderrTail,
+        })
+      );
+    } catch {
+      // Best-effort only — never let a logging failure fail the export.
+    }
+  };

--- a/apps/local/app/services/render-vertical-video-service.ts
+++ b/apps/local/app/services/render-vertical-video-service.ts
@@ -7,6 +7,7 @@ import crypto from "node:crypto";
 import { VideoOperationsService } from "@/services/db-video-operations.server";
 import { VideoProcessingService } from "./video-processing-service";
 import { FFmpegCommandsService } from "./ffmpeg-commands";
+import { VideoEditorLoggerService } from "./video-editor-logger-service";
 import { VIDEO_FORMAT_DIMENSIONS } from "@/features/videos/video-format";
 
 export type RenderVerticalStage =
@@ -27,6 +28,7 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
       const videoProcessing = yield* VideoProcessingService;
       const ffmpegCommands = yield* FFmpegCommandsService;
       const effectFs = yield* FileSystem.FileSystem;
+      const videoEditorLogger = yield* VideoEditorLoggerService;
 
       const renderVerticalVideo = Effect.fn("renderVerticalVideo")(
         function* (opts: {
@@ -46,6 +48,26 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
             });
           }
 
+          // Every ffmpeg invocation for this render is teed into
+          // `.data/logs/{videoId}.log` (the "cli-output" event, on both
+          // success and failure) — see the matching comment in
+          // video-processing-service.ts's exportVideoClips.
+          const logCliOutput =
+            (stage: "concat" | "normalize-audio" | "composite-overlay") =>
+            (info: { command: string[]; stderrTail: string }) => {
+              try {
+                Effect.runSync(
+                  videoEditorLogger.log(opts.videoId, {
+                    type: "cli-output",
+                    command: `[short:${stage}] ${info.command.join(" ")}`,
+                    stderr: info.stderrTail,
+                  })
+                );
+              } catch {
+                // Logging is best-effort — never let it fail the render.
+              }
+            };
+
           // Step 1: Concatenate clips → temp file (not the final output path,
           // since the composite step will write the final .mp4)
           opts.onStageChange?.("concatenating-clips");
@@ -60,10 +82,15 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
               })),
               // The vertical renderer always produces a 9:16 short — the Remotion
               // subtitle/CTA overlay below is rendered at 1080x1920 to match.
-              VIDEO_FORMAT_DIMENSIONS.short
+              VIDEO_FORMAT_DIMENSIONS.short,
+              undefined,
+              logCliOutput("concat")
             );
-          const concatenatedPath =
-            yield* ffmpegCommands.normalizeAudio(rawConcatenatedPath);
+          const concatenatedPath = yield* ffmpegCommands.normalizeAudio(
+            rawConcatenatedPath,
+            undefined,
+            logCliOutput("normalize-audio")
+          );
 
           // Clean up raw concatenated file
           yield* effectFs
@@ -139,7 +166,8 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
           yield* ffmpegCommands.compositeOverlay(
             concatenatedPath,
             overlayPath,
-            outputPath
+            outputPath,
+            logCliOutput("composite-overlay")
           );
 
           // Clean up intermediate files
@@ -160,6 +188,7 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
       NodeContext.layer,
       VideoProcessingService.Default,
       FFmpegCommandsService.Default,
+      VideoEditorLoggerService.Default,
     ],
   }
 ) {}

--- a/apps/local/app/services/render-vertical-video-service.ts
+++ b/apps/local/app/services/render-vertical-video-service.ts
@@ -8,6 +8,7 @@ import { VideoOperationsService } from "@/services/db-video-operations.server";
 import { VideoProcessingService } from "./video-processing-service";
 import { FFmpegCommandsService } from "./ffmpeg-commands";
 import { VideoEditorLoggerService } from "./video-editor-logger-service";
+import { makeFfmpegLogger } from "./ffmpeg-video-logger";
 import { VIDEO_FORMAT_DIMENSIONS } from "@/features/videos/video-format";
 
 export type RenderVerticalStage =
@@ -52,21 +53,9 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
           // `.data/logs/{videoId}.log` (the "cli-output" event, on both
           // success and failure) — see the matching comment in
           // video-processing-service.ts's exportVideoClips.
-          const logCliOutput =
-            (stage: "concat" | "normalize-audio" | "composite-overlay") =>
-            (info: { command: string[]; stderrTail: string }) => {
-              try {
-                Effect.runSync(
-                  videoEditorLogger.log(opts.videoId, {
-                    type: "cli-output",
-                    command: `[short:${stage}] ${info.command.join(" ")}`,
-                    stderr: info.stderrTail,
-                  })
-                );
-              } catch {
-                // Logging is best-effort — never let it fail the render.
-              }
-            };
+          const logCliOutput = (
+            stage: "concat" | "normalize-audio" | "composite-overlay"
+          ) => makeFfmpegLogger(videoEditorLogger, opts.videoId, `short:${stage}`);
 
           // Step 1: Concatenate clips → temp file (not the final output path,
           // since the composite step will write the final .mp4)
@@ -83,13 +72,11 @@ export class RenderVerticalVideoService extends Effect.Service<RenderVerticalVid
               // The vertical renderer always produces a 9:16 short — the Remotion
               // subtitle/CTA overlay below is rendered at 1080x1920 to match.
               VIDEO_FORMAT_DIMENSIONS.short,
-              undefined,
-              logCliOutput("concat")
+              { onLog: logCliOutput("concat") }
             );
           const concatenatedPath = yield* ffmpegCommands.normalizeAudio(
             rawConcatenatedPath,
-            undefined,
-            logCliOutput("normalize-audio")
+            { onLog: logCliOutput("normalize-audio") }
           );
 
           // Clean up raw concatenated file

--- a/apps/local/app/services/video-processing-service.ts
+++ b/apps/local/app/services/video-processing-service.ts
@@ -9,6 +9,7 @@ import OpenAI from "openai";
 import { FFmpegCommandsService } from "./ffmpeg-commands";
 import { findSilenceInVideo } from "./silence-detection";
 import { VideoEditorLoggerService } from "./video-editor-logger-service";
+import { makeFfmpegLogger } from "./ffmpeg-video-logger";
 import type { SilenceLength } from "@/silence-detection-constants";
 import {
   VIDEO_FORMAT_DIMENSIONS,
@@ -164,25 +165,8 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
         // or GET /api/videos/:videoId/log-path) — the "cli-output" event, on
         // both success and failure, so a rare hang or corrupt export has a
         // durable artifact to diagnose from instead of a swallowed exit code.
-        const logCliOutput =
-          (stage: "concat" | "normalize-audio") =>
-          (info: { command: string[]; stderrTail: string }) => {
-            try {
-              // VideoEditorLoggerService.log is a synchronous fs write, so
-              // runSync is exact here — no detached fiber, no lost writes if
-              // the process exits right after export completes. Logging is
-              // best-effort: a disk hiccup here must never fail the export.
-              Effect.runSync(
-                videoEditorLogger.log(opts.videoId, {
-                  type: "cli-output",
-                  command: `[export:${stage}] ${info.command.join(" ")}`,
-                  stderr: info.stderrTail,
-                })
-              );
-            } catch {
-              // Best-effort only.
-            }
-          };
+        const logCliOutput = (stage: "concat" | "normalize-audio") =>
+          makeFfmpegLogger(videoEditorLogger, opts.videoId, `export:${stage}`);
 
         // Create concatenated video using native FFmpeg, in the aspect ratio
         // that matches the video's format (portrait for shorts, landscape
@@ -192,18 +176,22 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
           yield* ffmpegCommands.createAndConcatenateVideoClipsSinglePass(
             opts.clips,
             VIDEO_FORMAT_DIMENSIONS[opts.format],
-            (percent) =>
-              opts.onProgress?.({ stage: "concatenating-clips", percent }),
-            logCliOutput("concat")
+            {
+              onProgress: (percent) =>
+                opts.onProgress?.({ stage: "concatenating-clips", percent }),
+              onLog: logCliOutput("concat"),
+            }
           );
 
         // Normalize audio
         opts.onStageChange?.("normalizing-audio");
         const normalizedPath = yield* ffmpegCommands.normalizeAudio(
           concatenatedPath,
-          (percent) =>
-            opts.onProgress?.({ stage: "normalizing-audio", percent }),
-          logCliOutput("normalize-audio")
+          {
+            onProgress: (percent) =>
+              opts.onProgress?.({ stage: "normalizing-audio", percent }),
+            onLog: logCliOutput("normalize-audio"),
+          }
         );
 
         // Move to final location

--- a/apps/local/app/services/video-processing-service.ts
+++ b/apps/local/app/services/video-processing-service.ts
@@ -8,6 +8,7 @@ import { homedir, tmpdir } from "os";
 import OpenAI from "openai";
 import { FFmpegCommandsService } from "./ffmpeg-commands";
 import { findSilenceInVideo } from "./silence-detection";
+import { VideoEditorLoggerService } from "./video-editor-logger-service";
 import type { SilenceLength } from "@/silence-detection-constants";
 import {
   VIDEO_FORMAT_DIMENSIONS,
@@ -69,6 +70,7 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
     effect: Effect.gen(function* () {
       const effectFs = yield* FileSystem.FileSystem;
       const ffmpegCommands = yield* FFmpegCommandsService;
+      const videoEditorLogger = yield* VideoEditorLoggerService;
       const transcriptionSemaphore = yield* Effect.makeSemaphore(
         TRANSCRIPTION_PERMITS
       );
@@ -157,6 +159,31 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
           "FINISHED_VIDEOS_DIRECTORY"
         );
 
+        // Every ffmpeg invocation for this export is teed into
+        // `.data/logs/{videoId}.log` (fetch its path via VideoEditorLoggerService
+        // or GET /api/videos/:videoId/log-path) — the "cli-output" event, on
+        // both success and failure, so a rare hang or corrupt export has a
+        // durable artifact to diagnose from instead of a swallowed exit code.
+        const logCliOutput =
+          (stage: "concat" | "normalize-audio") =>
+          (info: { command: string[]; stderrTail: string }) => {
+            try {
+              // VideoEditorLoggerService.log is a synchronous fs write, so
+              // runSync is exact here — no detached fiber, no lost writes if
+              // the process exits right after export completes. Logging is
+              // best-effort: a disk hiccup here must never fail the export.
+              Effect.runSync(
+                videoEditorLogger.log(opts.videoId, {
+                  type: "cli-output",
+                  command: `[export:${stage}] ${info.command.join(" ")}`,
+                  stderr: info.stderrTail,
+                })
+              );
+            } catch {
+              // Best-effort only.
+            }
+          };
+
         // Create concatenated video using native FFmpeg, in the aspect ratio
         // that matches the video's format (portrait for shorts, landscape
         // otherwise).
@@ -166,7 +193,8 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
             opts.clips,
             VIDEO_FORMAT_DIMENSIONS[opts.format],
             (percent) =>
-              opts.onProgress?.({ stage: "concatenating-clips", percent })
+              opts.onProgress?.({ stage: "concatenating-clips", percent }),
+            logCliOutput("concat")
           );
 
         // Normalize audio
@@ -174,7 +202,8 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
         const normalizedPath = yield* ffmpegCommands.normalizeAudio(
           concatenatedPath,
           (percent) =>
-            opts.onProgress?.({ stage: "normalizing-audio", percent })
+            opts.onProgress?.({ stage: "normalizing-audio", percent }),
+          logCliOutput("normalize-audio")
         );
 
         // Move to final location
@@ -605,6 +634,10 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
         sendClipsToDavinciResolve,
       };
     }),
-    dependencies: [NodeContext.layer, FFmpegCommandsService.Default],
+    dependencies: [
+      NodeContext.layer,
+      FFmpegCommandsService.Default,
+      VideoEditorLoggerService.Default,
+    ],
   }
 ) {}


### PR DESCRIPTION
## Summary

Follow-up to a deep-dive into the occasional Crash Course export failures Matt noticed (never happened in Cohort 005). Root cause is very likely a hang, not a crash: `#1411` (2026-07-24, "real ffmpeg progress for video exports") switched the concat and normalize-audio ffmpeg calls from inherited stdout to `-progress pipe:1`, which **must** be continuously drained or ffmpeg blocks on `write()` once the OS pipe buffer fills. The drain loop was wrapped in a single outer `Effect.ignore`, so any exception downstream of the caller-supplied `onProgress` (most plausibly an SSE `controller.enqueue` on a client that's gone away) silently killed the drain *while ffmpeg kept running* — leaving it to hang forever on its next progress write. That hang is invisible to `Effect.retry`, since a process that never exits never resolves to a failure to retry. This mechanism didn't exist when Cohort 005 was recorded.

Clip Zoom, the portrait/landscape scale bugs, and the GPU permit counts were all ruled out during the investigation (unused by the Crash Course / fixed before it / unchanged since Feb, respectively).

## Changes

- **Contain each drained chunk individually** (`catchAllCause` per chunk) instead of one outer `Effect.ignore` around the whole loop, so one bad callback can't stop drainage of the rest of the stream.
- **Pipe and drain stderr too** (previously `inherit`, so unobservable in a headless run) — teed to our own stderr for live visibility, folded into a bounded tail (new `ffmpeg-log-capture.ts`) that's now included in the thrown error message. Stdout and stderr are drained **concurrently** via `Effect.all`, not sequentially — that's load-bearing, since draining one to completion before starting the other would recreate the exact hang this fixes, just on the other stream.
- **`compositeOverlay`** (the Shorts pipeline's final step) gets the same stderr capture, plus `Effect.scoped` + the parent-death child registry it was previously the only ffmpeg call missing — a dev-server restart mid-render could orphan it.
- **Every ffmpeg invocation for an export is now teed into `.data/logs/{videoId}.log`** via `VideoEditorLoggerService`'s existing `"cli-output"` event — that event type (with `stdout`/`stderr` fields) was already defined but never wired up anywhere. Findable via `GET /api/videos/:videoId/log-path`, same convention used elsewhere in the codebase (see `docs/log-analysis-a82d8244.md` for a precedent of an agent diagnosing a bug from exactly this kind of log). So the next rare hang or failure leaves a durable, agent-readable artifact instead of a swallowed exit code.

## Test plan

- [x] `pnpm run lint:boundaries` passes
- [x] New `ffmpeg-log-capture.test.ts` (bounded tail truncation/formatting) passes
- [x] Every existing test file importing the three changed services (`render-vertical-video-service.test.ts`, `silence-detection.test.ts`, the `course-publish-service*` family) passes individually
- [x] Touched files typecheck clean in isolation (repo-wide `typecheck` already fails on `main` from 18 pre-existing, unrelated `hast`/`mdast`/`tldraw` errors — same reason the immediately preceding commit on `main` used `--no-verify`)
- [ ] No real ffmpeg binary available in this sandbox, so the actual spawn/drain-concurrency behavior isn't exercised end-to-end — worth a real export smoke test before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
