### PR TITLE
feat(cli): footage transcription, clip add, and chapter noun

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,8 +108,12 @@ A **Video** with `format: "short"`: a vertical, short-form video (the kind poste
 _Avoid_: TikTok (reserved for the actual TikTok platform — the OBS recording profile and Buffer posting destinations — and NOT the canonical name for a Short)
 
 **Clip**:
-A timestamped segment of source footage within a video, defined by start/end times and a source filename.
+A timestamped segment of **Footage** within a video, defined by start/end times and a source filename (`videoFilename`, a bare path with no foreign key). Captured by OBS append or "create video from selection", or cut by hand with `cvm clip add`, which slices the new Clip's `text` from the source Footage's cached transcript.
 _Avoid_: Segment, Cut, Take
+
+**Footage**:
+A raw source video FILE on disk (an OBS capture, a screen recording) before it is cut into **Clips** — the input to editing, not a product of it. UNLIKE EVERY OTHER NOUN IN THE DOMAIN MODEL, Footage has no database row: its identity is its filesystem path, and its whole-file **Transcription** is cached in a sidecar file beside it (`<path>.transcript.json`), keyed by a content hash so replacing/re-recording the file re-transcribes rather than serving stale words — the same "the filesystem **is** the state" convention as a **Video File**. Transcribed whole-file and speaker-agnostic (mono audio, Whisper word + segment timestamps, NO diarization; a file over Whisper's 25MB upload cap is split into chunks cut at detected silence and merged back onto one timeline). Managed with `cvm footage` (list / transcribe / transcript), all LOCAL-ONLY (it lives on the author's disk); `cvm clip add` reads the cached transcript to give a new **Clip** its text. A Clip's `videoFilename` points at the Footage it was cut from.
+_Avoid_: Raw footage (informal prose ok), Source video
 
 **Effect Clip**:
 A special clip for non-speech content (white noise, transitions) manually inserted into the timeline.
@@ -135,7 +139,7 @@ The ordered text projection of a **Video** — its **Clips** and **Chapters** in
 _Avoid_: Clip text (only covers Clips), Joined clips, Caption (reserved for the per-clip transcription product)
 
 **Video File**:
-A plain file on disk attached to a **Video**, under `{VIDEO_FILES_DIR}/{lineageId}/` and addressed relative to it. Not a database row — the directory listing **is** the state; deleting is a real unlink (no `archived`, no restore). Belongs to the Video, never the Lesson; lesson-bound and **Standalone Videos** behave identically. Purpose: **writer context** — the Article Writer reads a Video's **Transcript**, **Script**, **Beats**, and text Video Files. Those sources are ranked by the fidelity ladder (see **Script**): the Transcript alone sets what the article may claim, and text Video Files are supporting material showing what was on screen (code samples, notes, session logs) that the writer draws detail and evidence from, never a source of claims in their own right. Extensions `ts/tsx/js/jsx/json/md/mdx/txt/csv` are ticked by default in the writer's picker; others start unticked; images pass as images. Subdirectories allowed; dotfiles and `node_modules` ignored. Managed from the editor UI or `cvm file`.
+A plain file on disk attached to a **Video**, under `{VIDEO_FILES_DIR}/{lineageId}/` and addressed relative to it. Not a database row — the directory listing **is** the state; deleting is a real unlink (no `archived`, no restore). Shares that filesystem-is-the-state convention with **Footage** (which caches its transcript in a sidecar on disk), though the two are unrelated: a Video File is writer context, Footage is raw recording. Belongs to the Video, never the Lesson; lesson-bound and **Standalone Videos** behave identically. Purpose: **writer context** — the Article Writer reads a Video's **Transcript**, **Script**, **Beats**, and text Video Files. Those sources are ranked by the fidelity ladder (see **Script**): the Transcript alone sets what the article may claim, and text Video Files are supporting material showing what was on screen (code samples, notes, session logs) that the writer draws detail and evidence from, never a source of claims in their own right. Extensions `ts/tsx/js/jsx/json/md/mdx/txt/csv` are ticked by default in the writer's picker; others start unticked; images pass as images. Subdirectories allowed; dotfiles and `node_modules` ignored. Managed from the editor UI or `cvm file`.
 _Avoid_: Attachment, Asset (reserved for exported/published artifacts), Standalone file / Lesson file (the old UI-era split, now one concept)
 
 ### Video planning

--- a/apps/local/app/cli/cli-chapter-writes.test.ts
+++ b/apps/local/app/cli/cli-chapter-writes.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { Effect, Layer } from "effect";
+import {
+  createTestDb,
+  truncateAllTables,
+  type TestDb,
+} from "@/test-utils/pglite";
+import { ClipOperationsService } from "@/services/db-clip-operations.server";
+import { DrizzleService } from "@/services/drizzle-service.server";
+import {
+  buildWriteLayer,
+  makeRun,
+  ndjson,
+  one,
+  seedWrite,
+  type RunResult,
+  type WriteSeed,
+} from "./cli-write-test-harness";
+
+// ===========================================================================
+// cvm chapter writes: add / update / move / delete, plus list / get.
+//
+// Structurally mirrors cli-clip-writes.test.ts. No service faking is needed —
+// these are pure DB writes over the RPC transport. Clips (seeded directly, the
+// way clip writes are) share the timeline order space with chapters, so the
+// positioning tests interleave both.
+// ===========================================================================
+
+let testDb: TestDb;
+let seedLayer: Layer.Layer<ClipOperationsService>;
+let run: (argv: ReadonlyArray<string>) => Promise<RunResult>;
+
+beforeAll(async () => {
+  const result = await createTestDb();
+  testDb = result.testDb;
+  seedLayer = ClipOperationsService.Default.pipe(
+    Layer.provide(Layer.succeed(DrizzleService, testDb as never))
+  );
+  run = makeRun(buildWriteLayer(testDb));
+});
+
+let s: WriteSeed;
+beforeEach(async () => {
+  await truncateAllTables(testDb);
+  s = await seedWrite(testDb);
+});
+
+interface ChapterRow {
+  id: string;
+  videoId: string;
+  name: string;
+  order: string;
+  archived: boolean;
+}
+
+interface ClipRow {
+  id: string;
+}
+
+const chapters = async (videoId: string): Promise<ChapterRow[]> =>
+  ndjson(
+    (await run(["chapter", "list", "--video", videoId])).stdout
+  ) as ChapterRow[];
+
+/** The merged clip+chapter timeline order, as ids. */
+const timelineIds = (videoId: string) =>
+  Effect.gen(function* () {
+    const clipOps = yield* ClipOperationsService;
+    return (yield* clipOps.listTimelineOrder(videoId)).map((i) => i.id);
+  }).pipe(Effect.provide(seedLayer), Effect.runPromise);
+
+/** Seed a clip directly (chapters share its order space) — no CLI clip creator. */
+const seedClip = (videoId: string, after?: string): Promise<ClipRow> =>
+  Effect.gen(function* () {
+    const clipOps = yield* ClipOperationsService;
+    const [clip] = yield* clipOps.appendClips({
+      videoId,
+      insertionPoint:
+        after === undefined
+          ? { type: "start" }
+          : { type: "after-clip", databaseClipId: after },
+      clips: [{ inputVideo: "test.mkv", startTime: 0, endTime: 1 }],
+    });
+    return clip as unknown as ClipRow;
+  }).pipe(Effect.provide(seedLayer), Effect.runPromise);
+
+const add = async (
+  videoId: string,
+  title: string,
+  extra: ReadonlyArray<string> = []
+): Promise<ChapterRow> =>
+  one<ChapterRow>(
+    (
+      await run([
+        "chapter",
+        "add",
+        "--video",
+        videoId,
+        "--title",
+        title,
+        ...extra,
+      ])
+    ).stdout
+  );
+
+describe("chapter add", () => {
+  it("adds a chapter with the given title, appended by default", async () => {
+    const r = await run([
+      "chapter",
+      "add",
+      "--video",
+      s.standaloneActiveId,
+      "--title",
+      "Introduction",
+    ]);
+    expect(r.exitCode).toBe(0);
+    const chapter = one<ChapterRow>(r.stdout);
+    expect(chapter.videoId).toBe(s.standaloneActiveId);
+    expect(chapter.name).toBe("Introduction");
+    expect(chapter.archived).toBe(false);
+
+    expect((await chapters(s.standaloneActiveId)).map((c) => c.name)).toEqual([
+      "Introduction",
+    ]);
+  });
+
+  it("appends to the end across multiple adds", async () => {
+    const a = await add(s.standaloneActiveId, "One");
+    const b = await add(s.standaloneActiveId, "Two");
+    expect((await chapters(s.standaloneActiveId)).map((c) => c.id)).toEqual([
+      a.id,
+      b.id,
+    ]);
+  });
+
+  it("--after a clip opens the chapter right after that clip in the shared order", async () => {
+    const c1 = await seedClip(s.standaloneActiveId);
+    const c2 = await seedClip(s.standaloneActiveId, c1.id);
+    const chapter = await add(s.standaloneActiveId, "Mid", ["--after", c1.id]);
+
+    expect(await timelineIds(s.standaloneActiveId)).toEqual([
+      c1.id,
+      chapter.id,
+      c2.id,
+    ]);
+  });
+
+  it("--before positions ahead of an existing chapter", async () => {
+    const first = await add(s.standaloneActiveId, "First");
+    const inserted = await add(s.standaloneActiveId, "Zeroth", [
+      "--before",
+      first.id,
+    ]);
+    expect((await chapters(s.standaloneActiveId)).map((c) => c.id)).toEqual([
+      inserted.id,
+      first.id,
+    ]);
+  });
+
+  it("both --before and --after => invalid input, exit 3", async () => {
+    const c = await add(s.standaloneActiveId, "One");
+    const { exitCode, stdout } = await run([
+      "chapter",
+      "add",
+      "--video",
+      s.standaloneActiveId,
+      "--title",
+      "Two",
+      "--before",
+      c.id,
+      "--after",
+      c.id,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+  });
+
+  it("an unknown video => NotFoundError, exit 2", async () => {
+    const { exitCode, stderr } = await run([
+      "chapter",
+      "add",
+      "--video",
+      "video_nope",
+      "--title",
+      "X",
+    ]);
+    expect(exitCode).toBe(2);
+    expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
+      "video"
+    );
+  });
+});
+
+describe("chapter update", () => {
+  it("renames a chapter", async () => {
+    const c = await add(s.standaloneActiveId, "Old");
+    const updated = one<ChapterRow>(
+      (await run(["chapter", "update", "--title", "New", c.id])).stdout
+    );
+    expect(updated.id).toBe(c.id);
+    expect(updated.name).toBe("New");
+  });
+
+  it("an unknown id => NotFoundError, exit 2", async () => {
+    const { exitCode } = await run([
+      "chapter",
+      "update",
+      "--title",
+      "X",
+      "chap_missing",
+    ]);
+    expect(exitCode).toBe(2);
+  });
+});
+
+describe("chapter move", () => {
+  it("--before jumps to an earlier position", async () => {
+    const a = await add(s.standaloneActiveId, "A");
+    const b = await add(s.standaloneActiveId, "B");
+    const c = await add(s.standaloneActiveId, "C");
+    expect((await chapters(s.standaloneActiveId)).map((x) => x.id)).toEqual([
+      a.id,
+      b.id,
+      c.id,
+    ]);
+
+    await run(["chapter", "move", "--before", a.id, c.id]);
+    expect((await chapters(s.standaloneActiveId)).map((x) => x.id)).toEqual([
+      c.id,
+      a.id,
+      b.id,
+    ]);
+  });
+
+  it("--after a clip repositions across the shared order space", async () => {
+    const clip = await seedClip(s.standaloneActiveId);
+    const chapter = await add(s.standaloneActiveId, "A", ["--before", clip.id]);
+    // Currently [chapter, clip]; move the chapter after the clip.
+    await run(["chapter", "move", "--after", clip.id, chapter.id]);
+    expect(await timelineIds(s.standaloneActiveId)).toEqual([
+      clip.id,
+      chapter.id,
+    ]);
+  });
+
+  it("with neither --before nor --after => invalid input, exit 3", async () => {
+    const c = await add(s.standaloneActiveId, "A");
+    expect((await run(["chapter", "move", c.id])).exitCode).toBe(3);
+  });
+
+  it("--before an unknown id => NotFoundError, exit 2", async () => {
+    const c = await add(s.standaloneActiveId, "A");
+    const { exitCode } = await run([
+      "chapter",
+      "move",
+      "--before",
+      "nope",
+      c.id,
+    ]);
+    expect(exitCode).toBe(2);
+  });
+});
+
+describe("chapter delete", () => {
+  it("archives the chapter, hides it from list, no restore", async () => {
+    const c = await add(s.standaloneActiveId, "A");
+    const del = one<ChapterRow>(
+      (await run(["chapter", "delete", c.id])).stdout
+    );
+    expect(del.id).toBe(c.id);
+    expect(del.archived).toBe(true);
+    expect(
+      (await chapters(s.standaloneActiveId)).map((x) => x.id)
+    ).not.toContain(c.id);
+  });
+
+  it("any write on an already-deleted chapter => NotFoundError, exit 2", async () => {
+    const c = await add(s.standaloneActiveId, "A");
+    await run(["chapter", "delete", c.id]);
+    expect(
+      (await run(["chapter", "update", "--title", "X", c.id])).exitCode
+    ).toBe(2);
+    expect((await run(["chapter", "delete", c.id])).exitCode).toBe(2);
+  });
+});
+
+describe("chapter list / get", () => {
+  it("list prints nothing (exit 0) for a video with no chapters", async () => {
+    const r = await run(["chapter", "list", "--video", s.standaloneActiveId]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+
+  it("list is a not-found (exit 2) for an unknown video", async () => {
+    expect(
+      (await run(["chapter", "list", "--video", "video_nope"])).exitCode
+    ).toBe(2);
+  });
+
+  it("get returns one chapter, and 404s a missing / archived id", async () => {
+    const c = await add(s.standaloneActiveId, "A");
+    const got = one<ChapterRow>((await run(["chapter", "get", c.id])).stdout);
+    expect(got.id).toBe(c.id);
+
+    expect((await run(["chapter", "get", "chap_missing"])).exitCode).toBe(2);
+
+    await run(["chapter", "delete", c.id]);
+    expect((await run(["chapter", "get", c.id])).exitCode).toBe(2);
+  });
+
+  it("get is variadic and reports missing ids on stderr (exit 2)", async () => {
+    const a = await add(s.standaloneActiveId, "A");
+    const b = await add(s.standaloneActiveId, "B");
+    const r = await run(["chapter", "get", a.id, "nope", b.id]);
+    expect(r.exitCode).toBe(2);
+    expect(ndjson(r.stdout).map((x) => (x as ChapterRow).id)).toEqual([
+      a.id,
+      b.id,
+    ]);
+  });
+});

--- a/apps/local/app/cli/cli-clip-writes.test.ts
+++ b/apps/local/app/cli/cli-clip-writes.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Effect, Layer } from "effect";
+import nodeFs from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
 import {
   createTestDb,
   truncateAllTables,
@@ -37,6 +40,8 @@ let testDb: TestDb;
  */
 let seedLayer: Layer.Layer<ClipOperationsService>;
 let run: (argv: ReadonlyArray<string>) => Promise<RunResult>;
+/** Temp dir for the fake footage sidecar caches `clip add` reads. */
+let sourceDir: string;
 
 beforeAll(async () => {
   const result = await createTestDb();
@@ -45,7 +50,48 @@ beforeAll(async () => {
     Layer.provide(Layer.succeed(DrizzleService, testDb as never))
   );
   run = makeRun(buildWriteLayer(testDb));
+  sourceDir = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "cvm-clip-src-"));
 });
+
+afterAll(() => {
+  nodeFs.rmSync(sourceDir, { recursive: true, force: true });
+});
+
+/**
+ * Write a fake footage transcript sidecar (the format `footage transcribe`
+ * produces) and return the source PATH `clip add --source` should point at.
+ * The source file itself need not exist — `clip add` only reads the sidecar.
+ */
+const seedFootageTranscript = (
+  name: string,
+  transcript: {
+    words: Array<{ start: number; end: number; text: string }>;
+    segments: Array<{ start: number; end: number; text: string }>;
+  }
+): string => {
+  const source = nodePath.join(sourceDir, name);
+  nodeFs.writeFileSync(
+    source + ".transcript.json",
+    JSON.stringify({
+      version: 1,
+      sourcePath: source,
+      sourceHash: "0".repeat(64),
+      transcribedAt: new Date().toISOString(),
+      ...transcript,
+    })
+  );
+  return source;
+};
+
+const SAMPLE_TRANSCRIPT = {
+  words: [
+    { start: 0, end: 2, text: "the" },
+    { start: 2, end: 4, text: "quick" },
+    { start: 4, end: 6, text: "brown" },
+    { start: 6, end: 8, text: "fox" },
+  ],
+  segments: [{ start: 0, end: 8, text: " the quick brown fox" }],
+};
 
 let s: WriteSeed;
 beforeEach(async () => {
@@ -347,5 +393,178 @@ describe("clip writes (update / move / delete)", () => {
       ]);
       expect(exitCode).toBe(2);
     });
+  });
+});
+
+describe("clip add", () => {
+  it("slices text from the cached transcript and appends to the end by default", async () => {
+    const source = seedFootageTranscript("take.mkv", SAMPLE_TRANSCRIPT);
+    // Seed one existing clip so "append to end" is observable.
+    const existing = await seedClip(s.standaloneActiveId, { start: 0, end: 1 });
+
+    const added = one<ClipRow>(
+      (
+        await run([
+          "clip",
+          "add",
+          "--video",
+          s.standaloneActiveId,
+          "--source",
+          source,
+          "--start",
+          "2",
+          "--end",
+          "6",
+        ])
+      ).stdout
+    );
+
+    expect(added.videoId).toBe(s.standaloneActiveId);
+    expect(added.sourceStartTime).toBe(2);
+    expect(added.sourceEndTime).toBe(6);
+    // Words overlapping [2, 6): "quick" (2–4) and "brown" (4–6).
+    expect(added.text).toBe("quick brown");
+    expect((added as unknown as { videoFilename: string }).videoFilename).toBe(
+      source
+    );
+
+    expect((await list(s.standaloneActiveId)).map((r) => r.id)).toEqual([
+      existing.id,
+      added.id,
+    ]);
+  });
+
+  it("positions with --after (and behaves like any other clip afterwards)", async () => {
+    const source = seedFootageTranscript("take.mkv", SAMPLE_TRANSCRIPT);
+    const a = await seedClip(s.standaloneActiveId, { start: 0, end: 1 });
+    const b = await seedClip(s.standaloneActiveId, {
+      start: 1,
+      end: 2,
+      after: a.id,
+    });
+
+    const added = one<ClipRow>(
+      (
+        await run([
+          "clip",
+          "add",
+          "--video",
+          s.standaloneActiveId,
+          "--source",
+          source,
+          "--start",
+          "2",
+          "--end",
+          "4",
+          "--after",
+          a.id,
+        ])
+      ).stdout
+    );
+
+    expect((await list(s.standaloneActiveId)).map((r) => r.id)).toEqual([
+      a.id,
+      added.id,
+      b.id,
+    ]);
+
+    // No second-class type: the new clip moves/deletes like any other.
+    await run(["clip", "delete", added.id]);
+    expect((await list(s.standaloneActiveId)).map((r) => r.id)).toEqual([
+      a.id,
+      b.id,
+    ]);
+  });
+
+  it("positions with --before", async () => {
+    const source = seedFootageTranscript("take.mkv", SAMPLE_TRANSCRIPT);
+    const a = await seedClip(s.standaloneActiveId, { start: 0, end: 1 });
+    const b = await seedClip(s.standaloneActiveId, {
+      start: 1,
+      end: 2,
+      after: a.id,
+    });
+
+    const added = one<ClipRow>(
+      (
+        await run([
+          "clip",
+          "add",
+          "--video",
+          s.standaloneActiveId,
+          "--source",
+          source,
+          "--start",
+          "2",
+          "--end",
+          "4",
+          "--before",
+          b.id,
+        ])
+      ).stdout
+    );
+
+    expect((await list(s.standaloneActiveId)).map((r) => r.id)).toEqual([
+      a.id,
+      added.id,
+      b.id,
+    ]);
+  });
+
+  it("fails cleanly (exit 3) when the source has no cached transcript", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "clip",
+      "add",
+      "--video",
+      s.standaloneActiveId,
+      "--source",
+      nodePath.join(sourceDir, "never-transcribed.mkv"),
+      "--start",
+      "2",
+      "--end",
+      "6",
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+    expect((JSON.parse(stderr.trim()) as { _tag: string })._tag).toBe(
+      "ParseError"
+    );
+  });
+
+  it("an unknown video => NotFoundError, exit 2", async () => {
+    const source = seedFootageTranscript("take.mkv", SAMPLE_TRANSCRIPT);
+    const { exitCode, stderr } = await run([
+      "clip",
+      "add",
+      "--video",
+      "video_nope",
+      "--source",
+      source,
+      "--start",
+      "2",
+      "--end",
+      "6",
+    ]);
+    expect(exitCode).toBe(2);
+    const err = JSON.parse(stderr.trim()) as { _tag: string; entity: string };
+    expect(err._tag).toBe("NotFoundError");
+    expect(err.entity).toBe("video");
+  });
+
+  it("start >= end => invalid input, exit 3", async () => {
+    const source = seedFootageTranscript("take.mkv", SAMPLE_TRANSCRIPT);
+    const { exitCode } = await run([
+      "clip",
+      "add",
+      "--video",
+      s.standaloneActiveId,
+      "--source",
+      source,
+      "--start",
+      "6",
+      "--end",
+      "6",
+    ]);
+    expect(exitCode).toBe(3);
   });
 });

--- a/apps/local/app/cli/cli-clip-writes.test.ts
+++ b/apps/local/app/cli/cli-clip-writes.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Effect, Layer } from "effect";
+import { createHash } from "node:crypto";
 import nodeFs from "node:fs";
 import os from "node:os";
 import nodePath from "node:path";
@@ -58,24 +59,32 @@ afterAll(() => {
 });
 
 /**
- * Write a fake footage transcript sidecar (the format `footage transcribe`
- * produces) and return the source PATH `clip add --source` should point at.
- * The source file itself need not exist — `clip add` only reads the sidecar.
+ * Write a fake footage source file AND its transcript sidecar, returning the
+ * source PATH `clip add --source` points at. `clip add` re-hashes the source to
+ * confirm the cache is FRESH, so the source must exist and its hash must match
+ * the sidecar's — `{ staleHash: true }` seeds a mismatch (footage re-recorded
+ * after transcribing), which `clip add` must refuse.
  */
 const seedFootageTranscript = (
   name: string,
   transcript: {
     words: Array<{ start: number; end: number; text: string }>;
     segments: Array<{ start: number; end: number; text: string }>;
-  }
+  },
+  opts: { staleHash?: boolean } = {}
 ): string => {
   const source = nodePath.join(sourceDir, name);
+  const content = `fake footage bytes for ${name}`;
+  nodeFs.writeFileSync(source, content);
+  const sourceHash = opts.staleHash
+    ? "0".repeat(64)
+    : createHash("sha256").update(content).digest("hex");
   nodeFs.writeFileSync(
     source + ".transcript.json",
     JSON.stringify({
       version: 1,
       sourcePath: source,
-      sourceHash: "0".repeat(64),
+      sourceHash,
       transcribedAt: new Date().toISOString(),
       ...transcript,
     })
@@ -114,6 +123,28 @@ interface ClipRow {
 
 const list = async (videoId: string): Promise<ClipRow[]> =>
   ndjson((await run(["clip", "list", "--video", videoId])).stdout) as ClipRow[];
+
+interface ChapterRow {
+  id: string;
+  videoId: string;
+  name: string;
+}
+
+/** Add a Chapter via the CLI (a legit --before/--after anchor for clip add/move). */
+const addChapter = async (
+  videoId: string,
+  title: string
+): Promise<ChapterRow> =>
+  one<ChapterRow>(
+    (await run(["chapter", "add", "--video", videoId, "--title", title])).stdout
+  );
+
+/** The merged clip+chapter timeline, as ids in order (clip `list` is clips-only). */
+const timelineIds = (videoId: string): Promise<string[]> =>
+  Effect.gen(function* () {
+    const clipOps = yield* ClipOperationsService;
+    return (yield* clipOps.listTimelineOrder(videoId)).map((i) => i.id);
+  }).pipe(Effect.provide(seedLayer), Effect.runPromise);
 
 /**
  * Seed a clip directly through the service — clip has no CLI `add` verb.
@@ -393,6 +424,31 @@ describe("clip writes (update / move / delete)", () => {
       ]);
       expect(exitCode).toBe(2);
     });
+
+    it("--after a CHAPTER anchor positions the clip after it (shared order space)", async () => {
+      const a = await seedClip(s.standaloneActiveId, { start: 0, end: 1 });
+      const b = await seedClip(s.standaloneActiveId, {
+        start: 1,
+        end: 2,
+        after: a.id,
+      });
+      const ch = await addChapter(s.standaloneActiveId, "Part Two");
+      // Timeline is [a, b, ch]; move a to immediately after the chapter.
+      expect(await timelineIds(s.standaloneActiveId)).toEqual([
+        a.id,
+        b.id,
+        ch.id,
+      ]);
+      const moved = one<ClipRow>(
+        (await run(["clip", "move", "--after", ch.id, a.id])).stdout
+      );
+      expect(moved.id).toBe(a.id);
+      expect(await timelineIds(s.standaloneActiveId)).toEqual([
+        b.id,
+        ch.id,
+        a.id,
+      ]);
+    });
   });
 });
 
@@ -509,6 +565,99 @@ describe("clip add", () => {
       added.id,
       b.id,
     ]);
+  });
+
+  it("positions with --after a CHAPTER anchor (clips and chapters share one order space)", async () => {
+    const source = seedFootageTranscript("take.mkv", SAMPLE_TRANSCRIPT);
+    const a = await seedClip(s.standaloneActiveId, { start: 0, end: 1 });
+    const ch = await addChapter(s.standaloneActiveId, "Part Two");
+    // Timeline is [a, ch]; --after the chapter should land the new clip last.
+    expect(await timelineIds(s.standaloneActiveId)).toEqual([a.id, ch.id]);
+
+    const added = one<ClipRow>(
+      (
+        await run([
+          "clip",
+          "add",
+          "--video",
+          s.standaloneActiveId,
+          "--source",
+          source,
+          "--start",
+          "2",
+          "--end",
+          "4",
+          "--after",
+          ch.id,
+        ])
+      ).stdout
+    );
+
+    // Words overlapping [2, 4): "quick" (2–4).
+    expect(added.text).toBe("quick");
+    expect(await timelineIds(s.standaloneActiveId)).toEqual([
+      a.id,
+      ch.id,
+      added.id,
+    ]);
+  });
+
+  it("positions with --before a CHAPTER anchor", async () => {
+    const source = seedFootageTranscript("take.mkv", SAMPLE_TRANSCRIPT);
+    const a = await seedClip(s.standaloneActiveId, { start: 0, end: 1 });
+    const ch = await addChapter(s.standaloneActiveId, "Part Two");
+    expect(await timelineIds(s.standaloneActiveId)).toEqual([a.id, ch.id]);
+
+    const added = one<ClipRow>(
+      (
+        await run([
+          "clip",
+          "add",
+          "--video",
+          s.standaloneActiveId,
+          "--source",
+          source,
+          "--start",
+          "2",
+          "--end",
+          "4",
+          "--before",
+          ch.id,
+        ])
+      ).stdout
+    );
+
+    // Lands between the clip and the chapter.
+    expect(await timelineIds(s.standaloneActiveId)).toEqual([
+      a.id,
+      added.id,
+      ch.id,
+    ]);
+  });
+
+  it("refuses a STALE cached transcript (source re-recorded since transcribe), exit 3", async () => {
+    // Sidecar hash no longer matches the source bytes: clip add must not slice
+    // from the stale cache; it fails exactly like a missing transcript.
+    const source = seedFootageTranscript("restale.mkv", SAMPLE_TRANSCRIPT, {
+      staleHash: true,
+    });
+    const { stdout, stderr, exitCode } = await run([
+      "clip",
+      "add",
+      "--video",
+      s.standaloneActiveId,
+      "--source",
+      source,
+      "--start",
+      "2",
+      "--end",
+      "6",
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+    expect((JSON.parse(stderr.trim()) as { _tag: string })._tag).toBe(
+      "ParseError"
+    );
   });
 
   it("fails cleanly (exit 3) when the source has no cached transcript", async () => {

--- a/apps/local/app/cli/cli-footage-writes.test.ts
+++ b/apps/local/app/cli/cli-footage-writes.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { Effect, Layer } from "effect";
+import nodeFs from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
+import { createTestDb, type TestDb } from "@/test-utils/pglite";
+import { VideoProcessingService } from "@/services/video-processing-service";
+import { buildProgram } from "@/cli/main";
+import { makeTestCliOutput } from "@/cli/output";
+import { LOCAL_MACHINE_ENV_KEY } from "./env";
+import {
+  buildWriteLayer,
+  one,
+  ndjson,
+  type RunResult,
+} from "./cli-write-test-harness";
+
+// ===========================================================================
+// cvm footage: list / transcribe / transcript
+//
+// Footage has NO database row — its identity is a path and its transcript is a
+// sidecar file on disk. These verbs touch the DISK (and would run ffmpeg +
+// Whisper), so the whole VideoProcessingService is FAKED via
+// Layer.succeed(VideoProcessingService, {...}) — the same pattern as
+// render-vertical-video-service.test.ts — and NO real ffmpeg / OpenAI ever
+// runs. Touching the disk is also what makes footage LOCAL-ONLY, so the suite
+// declares the machine local the way cli-file-writes.test.ts does; the refusals
+// live in cli-local-only.test.ts.
+// ===========================================================================
+
+const FAKE_TRANSCRIPT = {
+  words: [
+    { start: 0, end: 1, text: "hello" },
+    { start: 1, end: 2, text: "world" },
+    { start: 2, end: 3, text: "again" },
+  ],
+  segments: [{ start: 0, end: 3, text: " hello world again" }],
+};
+
+// A fake whose transcribeFootageFile ignores its input and returns a canned
+// transcript — the command under test is what hashes the source and writes the
+// sidecar, so this never has to be real.
+const fakeVideoProcessing = Layer.succeed(VideoProcessingService, {
+  transcribeFootageFile: () => Effect.succeed(FAKE_TRANSCRIPT),
+} as unknown as VideoProcessingService);
+
+let testDb: TestDb;
+let run: (argv: ReadonlyArray<string>) => Promise<RunResult>;
+let footageDir: string;
+const originalLocalMachine = process.env[LOCAL_MACHINE_ENV_KEY];
+const originalObsDir = process.env.OBS_RECORDING_DIR;
+
+beforeAll(async () => {
+  const result = await createTestDb();
+  testDb = result.testDb;
+
+  const layer = Layer.merge(buildWriteLayer(testDb), fakeVideoProcessing);
+  run = async (argv) => {
+    const out = makeTestCliOutput();
+    const exitCode = await Effect.runPromise(
+      buildProgram(argv).pipe(Effect.provide(out.layer), Effect.provide(layer))
+    );
+    return { stdout: out.stdout(), stderr: out.stderr(), exitCode };
+  };
+
+  process.env[LOCAL_MACHINE_ENV_KEY] = "true";
+});
+
+afterAll(() => {
+  if (originalLocalMachine === undefined) {
+    delete process.env[LOCAL_MACHINE_ENV_KEY];
+  } else {
+    process.env[LOCAL_MACHINE_ENV_KEY] = originalLocalMachine;
+  }
+  if (originalObsDir === undefined) delete process.env.OBS_RECORDING_DIR;
+  else process.env.OBS_RECORDING_DIR = originalObsDir;
+});
+
+beforeEach(() => {
+  footageDir = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "cvm-footage-"));
+  // footage list without --dir reads OBS_RECORDING_DIR (see getLatestOBSVideoClips).
+  process.env.OBS_RECORDING_DIR = footageDir;
+});
+
+/** Write a fake footage file with the given bytes, returning its path. */
+const footageFile = (name: string, bytes: string): string => {
+  const full = nodePath.join(footageDir, name);
+  nodeFs.writeFileSync(full, bytes);
+  return full;
+};
+
+const sidecarOf = (sourcePath: string): string =>
+  sourcePath + ".transcript.json";
+
+interface TranscribeSummary {
+  path: string;
+  sidecar: string;
+  sourceHash: string;
+  transcribedAt: string;
+  words: number;
+  segments: number;
+}
+
+describe("footage list", () => {
+  it("lists only video files, sorted, with size + transcribed flag", async () => {
+    footageFile("b-take.mkv", "bbbb");
+    footageFile("a-take.mp4", "aaa");
+    footageFile("notes.txt", "not a video");
+
+    const r = await run(["footage", "list"]);
+    expect(r.exitCode).toBe(0);
+    const rows = ndjson(r.stdout) as Array<{
+      path: string;
+      size: number;
+      transcribed: boolean;
+    }>;
+    expect(rows.map((x) => nodePath.basename(x.path))).toEqual([
+      "a-take.mp4",
+      "b-take.mkv",
+    ]);
+    expect(rows[0]).toMatchObject({ size: 3, transcribed: false });
+    expect(rows[1]).toMatchObject({ size: 4, transcribed: false });
+  });
+
+  it("reports transcribed:true once a sidecar exists, and honours --dir", async () => {
+    const other = nodeFs.mkdtempSync(nodePath.join(os.tmpdir(), "cvm-foot2-"));
+    try {
+      const file = nodePath.join(other, "clip.mov");
+      nodeFs.writeFileSync(file, "xyz");
+      await run(["footage", "transcribe", file]);
+
+      const rows = ndjson(
+        (await run(["footage", "list", "--dir", other])).stdout
+      ) as Array<{ path: string; transcribed: boolean }>;
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.transcribed).toBe(true);
+    } finally {
+      nodeFs.rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it("prints nothing (exit 0) for an empty directory", async () => {
+    const r = await run(["footage", "list"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("");
+  });
+});
+
+describe("footage transcribe", () => {
+  it("writes a sidecar next to the source and echoes a summary", async () => {
+    const file = footageFile("take.mkv", "the-bytes");
+    const r = await run(["footage", "transcribe", file]);
+
+    expect(r.exitCode).toBe(0);
+    const summary = one<TranscribeSummary>(r.stdout);
+    expect(summary.path).toBe(nodePath.resolve(file));
+    expect(summary.sidecar).toBe(sidecarOf(file));
+    expect(summary.words).toBe(3);
+    expect(summary.segments).toBe(1);
+    expect(summary.sourceHash).toMatch(/^[0-9a-f]{64}$/);
+
+    // The sidecar is real, on disk, keyed by the content hash.
+    const sidecar = JSON.parse(nodeFs.readFileSync(sidecarOf(file), "utf8"));
+    expect(sidecar.sourceHash).toBe(summary.sourceHash);
+    expect(sidecar.words).toEqual(FAKE_TRANSCRIPT.words);
+    expect(sidecar.segments).toEqual(FAKE_TRANSCRIPT.segments);
+  });
+
+  it("is invalid input (exit 3) for a source that does not exist", async () => {
+    const r = await run([
+      "footage",
+      "transcribe",
+      nodePath.join(footageDir, "nope.mp4"),
+    ]);
+    expect(r.exitCode).toBe(3);
+    expect(r.stdout).toBe("");
+    expect((JSON.parse(r.stderr.trim()) as { _tag: string })._tag).toBe(
+      "ParseError"
+    );
+  });
+
+  it("re-transcribes (new hash) when the file's bytes change", async () => {
+    const file = footageFile("take.mkv", "first-recording");
+    const first = one<TranscribeSummary>(
+      (await run(["footage", "transcribe", file])).stdout
+    );
+
+    nodeFs.writeFileSync(file, "a totally different re-recording");
+    const second = one<TranscribeSummary>(
+      (await run(["footage", "transcribe", file])).stdout
+    );
+
+    expect(second.sourceHash).not.toBe(first.sourceHash);
+  });
+});
+
+describe("footage transcript", () => {
+  it("reads back the cached words + segments", async () => {
+    const file = footageFile("take.mkv", "bytes");
+    await run(["footage", "transcribe", file]);
+
+    const r = await run(["footage", "transcript", file]);
+    expect(r.exitCode).toBe(0);
+    const t = one<{
+      path: string;
+      words: typeof FAKE_TRANSCRIPT.words;
+      segments: typeof FAKE_TRANSCRIPT.segments;
+    }>(r.stdout);
+    expect(t.path).toBe(nodePath.resolve(file));
+    expect(t.words).toEqual(FAKE_TRANSCRIPT.words);
+    expect(t.segments).toEqual(FAKE_TRANSCRIPT.segments);
+  });
+
+  it("is a not-found (exit 2) when never transcribed", async () => {
+    const file = footageFile("take.mkv", "bytes");
+    const r = await run(["footage", "transcript", file]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stdout).toBe("");
+    expect((JSON.parse(r.stderr.trim()) as { _tag: string })._tag).toBe(
+      "NotFoundError"
+    );
+  });
+
+  it("is a not-found (exit 2) when the sidecar is stale (bytes changed)", async () => {
+    const file = footageFile("take.mkv", "original bytes");
+    await run(["footage", "transcribe", file]);
+    // Replace the file's bytes WITHOUT re-transcribing: the cached hash no
+    // longer matches, so the transcript is treated as absent.
+    nodeFs.writeFileSync(file, "replaced bytes, sidecar now stale");
+
+    const r = await run(["footage", "transcript", file]);
+    expect(r.exitCode).toBe(2);
+  });
+});

--- a/apps/local/app/cli/cli-local-only.test.ts
+++ b/apps/local/app/cli/cli-local-only.test.ts
@@ -83,6 +83,29 @@ describe("on a box that is not the author's", () => {
     }
   });
 
+  it("refuses every cvm footage verb", async () => {
+    const invocations: ReadonlyArray<ReadonlyArray<string>> = [
+      ["footage", "list"],
+      ["footage", "list", "--dir", "/tmp/whatever"],
+      ["footage", "transcribe", "/tmp/whatever.mkv"],
+      ["footage", "transcript", "/tmp/whatever.mkv"],
+    ];
+
+    for (const argv of invocations) {
+      const result = await run(argv);
+
+      expect(result.exitCode, argv.join(" ")).toBe(7);
+      expect(failureOf(result)._tag).toBe("LocalOnlyCommandError");
+      expect(result.stdout).toBe("");
+    }
+  });
+
+  it("names footage as the resource cvm footage would have needed", async () => {
+    const footage = failureOf(await run(["footage", "list"]));
+    expect(footage.command).toBe("cvm footage");
+    expect(footage.message).toContain("raw footage");
+  });
+
   it("refuses cvm course readiness", async () => {
     const result = await run(["course", "readiness", await courseIdOf()]);
 

--- a/apps/local/app/cli/commands/chapter.help.ts
+++ b/apps/local/app/cli/commands/chapter.help.ts
@@ -1,0 +1,104 @@
+/**
+ * Long-form --help text for the `cvm chapter` verbs, split out of chapter.ts to
+ * keep that command module under the repo's per-file token budget. These are
+ * domain-teaching prose strings consumed only by Command.withDescription.
+ */
+export const HELP = `chapter — a named divider grouping clips on a Video's timeline.
+
+A Chapter is a titled marker within a Video that visually groups the Clips that
+follow it (it maps 1:1 to a YouTube chapter). Clips and Chapters share ONE
+fractional 'order' space — interleaving them in timeline order is exactly what
+forms the Video's Transcript, where each Chapter renders as a '## <title>'
+header. Chapters are children of a Video, addressed by id only; there is no
+version scoping and archived chapters are always hidden (no --archived flag, no
+restore verb — same one-way convention as 'clip delete').
+
+Do NOT confuse a Chapter (the recorded-timeline grouping) with a Beat (the
+pre-recording plan) — see 'cvm beat'.
+
+Verbs:
+  chapter list --video <videoId>          every active chapter on a Video (NDJSON)
+  chapter get <id...>                      fetch one or more chapters by id (variadic)
+  chapter add --video <id> --title <t>     add a chapter (append by default, or
+              [--before | --after <id>]    place relative to a clip/chapter id)
+  chapter update <id> --title <t>          rename a chapter
+  chapter move <id> --before/--after <id>  reposition within the timeline
+  chapter delete <id>                       archive the chapter (soft delete; no restore)
+
+All writes are immediate — no confirmation, no dry-run (agent-facing tool). Like
+every clip/chapter write they need the owning CourseVersion to be a Draft.`;
+
+export const LIST_HELP = `List every active (non-archived) Chapter on a Video, in timeline order.
+
+Requires --video <videoId>. Output is NDJSON — one compact chapter object per
+line; a Video with no chapters prints nothing and exits 0. An unknown video id
+is a not-found (exit 2).
+
+Each line carries the chapter row: id, videoId, name (its title), order,
+createdAt.
+
+Examples:
+  cvm chapter list --video vid_123
+  cvm chapter list --video vid_123 | jq -r '.name'`;
+
+export const GET_HELP = `Fetch one or more Chapters by id. Variadic: 'chapter get <id> [<id> ...]'.
+
+Output contract (same as 'clip get'):
+  - one id, found     -> a single pretty-printed JSON object (exit 0)
+  - one id, missing   -> NotFoundError on stderr, exit 2
+  - many ids          -> NDJSON of the FOUND chapters on stdout; any missing ids
+                         are reported on stderr and the process exits 2
+
+Archived chapters are treated as deleted and are never returned. Args are ids
+ONLY — find them with 'chapter list --video <id>'.
+
+Examples:
+  cvm chapter get chap_abc
+  cvm chapter get chap_abc chap_def`;
+
+export const ADD_HELP = `Add a Chapter to a Video's timeline.
+
+Requires --video <id> and --title <t>. Optionally one of --before / --after
+<id> to place it against another item on the SAME video; because clips and
+chapters share one order space, the anchor may be a Clip OR a Chapter id
+(so 'chapter add --after <clipId>' opens a chapter right after a given clip).
+With neither flag the chapter is appended to the END of the timeline.
+
+Echoes the created chapter row. An unknown --video is a not-found (exit 2);
+passing both --before and --after is invalid input (exit 3). Immediate, no
+confirmation (agent-facing tool); needs the owning CourseVersion to be a Draft.
+
+Examples:
+  cvm chapter add --video vid_123 --title "Introduction"
+  cvm chapter add --video vid_123 --title "Setup" --after clip_abc
+  cvm chapter add --video vid_123 --title "Wrap up" --before chap_def`;
+
+export const UPDATE_HELP = `Rename a Chapter. Requires --title <t> (the new title). Echoes the updated row.
+
+An unknown or archived id is a not-found (exit 2). Immediate, no confirmation
+(agent-facing tool); needs the owning CourseVersion to be a Draft.
+
+Example:
+  cvm chapter update chap_abc --title "Getting started"`;
+
+export const MOVE_HELP = `Reposition a Chapter within its Video's timeline.
+
+Requires exactly one of --before / --after <id>, where <id> is another item on
+the SAME video (a Clip OR a Chapter, since they share one order space). Jumps
+straight to the position in one call. An unknown anchor, or a chapter that does
+not exist / is archived, is a not-found (exit 2); passing both flags or neither
+is invalid input (exit 3). Needs the owning CourseVersion to be a Draft.
+
+Examples:
+  cvm chapter move chap_abc --before chap_def
+  cvm chapter move chap_abc --after clip_ghi`;
+
+export const DELETE_HELP = `Archive (soft-delete) a Chapter.
+
+Sets 'archived: true'. Archived chapters are ALWAYS filtered out (no --archived
+flag, no 'chapter get' access, no restore) — same one-way convention as
+'clip delete'. Immediate, no confirmation (agent-facing tool); needs the owning
+CourseVersion to be a Draft. Echoes the archived row.
+
+Example:
+  cvm chapter delete chap_abc`;

--- a/apps/local/app/cli/commands/chapter.ts
+++ b/apps/local/app/cli/commands/chapter.ts
@@ -1,0 +1,256 @@
+import { Args, Command, Options } from "@effect/cli";
+import { Effect, Option } from "effect";
+import { ClipOperationsService } from "@/services/db-clip-operations.server";
+import { VideoOperationsService } from "@/services/db-video-operations.server";
+import {
+  detail,
+  emitNdjson,
+  emitObject,
+  notFound,
+  notFoundMany,
+  parseError,
+  rejectBothFlags,
+} from "@/cli/helpers";
+import {
+  HELP,
+  LIST_HELP,
+  GET_HELP,
+  ADD_HELP,
+  UPDATE_HELP,
+  MOVE_HELP,
+  DELETE_HELP,
+} from "./chapter.help";
+
+// ---------------------------------------------------------------------------
+// Options / Args
+// ---------------------------------------------------------------------------
+
+const videoOpt = Options.text("video").pipe(
+  Options.withDescription("Parent Video id (required).")
+);
+
+const titleOpt = Options.text("title").pipe(
+  Options.withDescription("The Chapter's title (its 'name'). Required.")
+);
+
+const beforeOpt = Options.text("before").pipe(
+  Options.withDescription(
+    "Place immediately before this clip/chapter id (mutually exclusive with --after)."
+  ),
+  Options.optional
+);
+
+const afterOpt = Options.text("after").pipe(
+  Options.withDescription(
+    "Place immediately after this clip/chapter id (mutually exclusive with --before)."
+  ),
+  Options.optional
+);
+
+const idArg = Args.text({ name: "id" });
+const ids = Args.text({ name: "id" }).pipe(Args.repeated);
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve --before/--after into the single "anchor id" the chapter service
+ * positions against, over the MERGED clip+chapter order space (the same one
+ * `clip move` uses). The anchor may be a Clip OR a Chapter, since they share one
+ * fractional order key. Neither flag returns `null` — "append to the end" for
+ * `add`; `move` requires exactly one and rejects the neither case itself.
+ */
+const resolveBeforeItemId = (params: {
+  readonly videoId: string;
+  readonly before: Option.Option<string>;
+  readonly after: Option.Option<string>;
+  readonly excludeId?: string;
+}) =>
+  Effect.gen(function* () {
+    const before = Option.getOrUndefined(params.before);
+    const after = Option.getOrUndefined(params.after);
+
+    yield* rejectBothFlags({
+      a: before,
+      b: after,
+      flags: ["--before", "--after"],
+      entity: "chapter",
+    });
+    if (before === undefined && after === undefined) {
+      return null;
+    }
+
+    const clipOps = yield* ClipOperationsService;
+    const items = (yield* clipOps.listTimelineOrder(params.videoId)).filter(
+      (item) => item.id !== params.excludeId
+    );
+
+    if (before !== undefined) {
+      if (!items.some((item) => item.id === before)) {
+        return yield* notFound("chapter", before);
+      }
+      return before;
+    }
+
+    const idx = items.findIndex((item) => item.id === after);
+    if (idx === -1) {
+      return yield* notFound("chapter", after!);
+    }
+    return items[idx + 1]?.id ?? null;
+  });
+
+/**
+ * Resolve + gate a chapter for a write: a bad id is a clean not-found (exit 2),
+ * and archived chapters are deleted as far as this noun is concerned, so they
+ * are not-found too (mirrors `requireActiveClip`).
+ */
+const requireActiveChapter = (id: string) =>
+  Effect.gen(function* () {
+    const clipOps = yield* ClipOperationsService;
+    const [existing] = yield* clipOps.getChaptersByIds([id]);
+    if (!existing || existing.archived) {
+      return yield* notFound("chapter", id);
+    }
+    return existing;
+  });
+
+/** A video must exist before we read/write its chapters — clean not-found. */
+const requireVideo = (videoId: string) =>
+  Effect.gen(function* () {
+    const videoOps = yield* VideoOperationsService;
+    yield* videoOps
+      .getVideoWithClipsById(videoId)
+      .pipe(Effect.catchTag("NotFoundError", () => notFound("video", videoId)));
+  });
+
+// ---------------------------------------------------------------------------
+// Verbs
+// ---------------------------------------------------------------------------
+
+const listCmd = Command.make("list", { video: videoOpt }, ({ video }) =>
+  Effect.gen(function* () {
+    yield* requireVideo(video);
+    const clipOps = yield* ClipOperationsService;
+    const rows = yield* clipOps.listChaptersByVideoId(video);
+    yield* emitNdjson(rows);
+  })
+).pipe(Command.withDescription(detail(LIST_HELP)));
+
+const getCmd = Command.make("get", { ids }, ({ ids }) =>
+  Effect.gen(function* () {
+    const clipOps = yield* ClipOperationsService;
+    // Archived = deleted, ALWAYS hidden (no flag): archived ids fall through to
+    // the not-found path, exactly like `clip get`.
+    const rows = (yield* clipOps.getChaptersByIds(ids)).filter(
+      (r) => !r.archived
+    );
+
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    const found = ids
+      .map((id) => byId.get(id))
+      .filter((row): row is NonNullable<typeof row> => row !== undefined);
+    const missing = ids.filter((id) => !byId.has(id));
+
+    if (ids.length === 1) {
+      if (found.length === 1) {
+        yield* emitObject(found[0]);
+        return;
+      }
+      return yield* notFound("chapter", ids[0]!);
+    }
+
+    yield* emitNdjson(found);
+    if (missing.length > 0) {
+      return yield* notFoundMany("chapter", missing);
+    }
+  })
+).pipe(Command.withDescription(detail(GET_HELP)));
+
+const addCmd = Command.make(
+  "add",
+  { video: videoOpt, title: titleOpt, before: beforeOpt, after: afterOpt },
+  ({ video, title, before, after }) =>
+    Effect.gen(function* () {
+      yield* requireVideo(video);
+      const beforeItemId = yield* resolveBeforeItemId({
+        videoId: video,
+        before,
+        after,
+      });
+      const clipOps = yield* ClipOperationsService;
+      const chapter = yield* clipOps.createChapterAtItem(
+        video,
+        title,
+        beforeItemId
+      );
+      yield* emitObject(chapter);
+    })
+).pipe(Command.withDescription(detail(ADD_HELP)));
+
+const updateCmd = Command.make(
+  "update",
+  { id: idArg, title: titleOpt },
+  ({ id, title }) =>
+    Effect.gen(function* () {
+      yield* requireActiveChapter(id);
+      const clipOps = yield* ClipOperationsService;
+      const row = yield* clipOps.updateChapter(id, { name: title });
+      yield* emitObject(row);
+    })
+).pipe(Command.withDescription(detail(UPDATE_HELP)));
+
+const moveCmd = Command.make(
+  "move",
+  { id: idArg, before: beforeOpt, after: afterOpt },
+  ({ id, before, after }) =>
+    Effect.gen(function* () {
+      const existing = yield* requireActiveChapter(id);
+      if (Option.isNone(before) && Option.isNone(after)) {
+        return yield* parseError(
+          "move needs one of --before / --after",
+          "chapter"
+        );
+      }
+      const beforeItemId = yield* resolveBeforeItemId({
+        videoId: existing.videoId,
+        before,
+        after,
+        excludeId: id,
+      });
+      const clipOps = yield* ClipOperationsService;
+      const moved = yield* clipOps
+        .moveChapterToPosition(id, beforeItemId)
+        .pipe(
+          Effect.catchTag("NotFoundError", (e) =>
+            notFound(
+              "chapter",
+              (e.params as { chapterId?: string }).chapterId ?? id
+            )
+          )
+        );
+      yield* emitObject(moved);
+    })
+).pipe(Command.withDescription(detail(MOVE_HELP)));
+
+const deleteCmd = Command.make("delete", { id: idArg }, ({ id }) =>
+  Effect.gen(function* () {
+    yield* requireActiveChapter(id);
+    const clipOps = yield* ClipOperationsService;
+    yield* clipOps.archiveChapter(id);
+    const [archived] = yield* clipOps.getChaptersByIds([id]);
+    yield* emitObject(archived);
+  })
+).pipe(Command.withDescription(detail(DELETE_HELP)));
+
+export const chapterCommand = Command.make("chapter").pipe(
+  Command.withDescription(detail(HELP)),
+  Command.withSubcommands([
+    listCmd,
+    getCmd,
+    addCmd,
+    updateCmd,
+    moveCmd,
+    deleteCmd,
+  ])
+);

--- a/apps/local/app/cli/commands/chapter.ts
+++ b/apps/local/app/cli/commands/chapter.ts
@@ -9,8 +9,8 @@ import {
   notFound,
   notFoundMany,
   parseError,
-  rejectBothFlags,
 } from "@/cli/helpers";
+import { resolveBeforeItemId } from "./timeline-position";
 import {
   HELP,
   LIST_HELP,
@@ -54,51 +54,9 @@ const ids = Args.text({ name: "id" }).pipe(Args.repeated);
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Resolve --before/--after into the single "anchor id" the chapter service
- * positions against, over the MERGED clip+chapter order space (the same one
- * `clip move` uses). The anchor may be a Clip OR a Chapter, since they share one
- * fractional order key. Neither flag returns `null` — "append to the end" for
- * `add`; `move` requires exactly one and rejects the neither case itself.
- */
-const resolveBeforeItemId = (params: {
-  readonly videoId: string;
-  readonly before: Option.Option<string>;
-  readonly after: Option.Option<string>;
-  readonly excludeId?: string;
-}) =>
-  Effect.gen(function* () {
-    const before = Option.getOrUndefined(params.before);
-    const after = Option.getOrUndefined(params.after);
-
-    yield* rejectBothFlags({
-      a: before,
-      b: after,
-      flags: ["--before", "--after"],
-      entity: "chapter",
-    });
-    if (before === undefined && after === undefined) {
-      return null;
-    }
-
-    const clipOps = yield* ClipOperationsService;
-    const items = (yield* clipOps.listTimelineOrder(params.videoId)).filter(
-      (item) => item.id !== params.excludeId
-    );
-
-    if (before !== undefined) {
-      if (!items.some((item) => item.id === before)) {
-        return yield* notFound("chapter", before);
-      }
-      return before;
-    }
-
-    const idx = items.findIndex((item) => item.id === after);
-    if (idx === -1) {
-      return yield* notFound("chapter", after!);
-    }
-    return items[idx + 1]?.id ?? null;
-  });
+// `resolveBeforeItemId` (the --before/--after anchor resolver) is shared with
+// `clip` in ./timeline-position — clips and chapters share one order space, so
+// the resolution is identical and an anchor may be a Clip OR a Chapter.
 
 /**
  * Resolve + gate a chapter for a write: a bad id is a clean not-found (exit 2),
@@ -174,6 +132,7 @@ const addCmd = Command.make(
     Effect.gen(function* () {
       yield* requireVideo(video);
       const beforeItemId = yield* resolveBeforeItemId({
+        entity: "chapter",
         videoId: video,
         before,
         after,
@@ -213,6 +172,7 @@ const moveCmd = Command.make(
         );
       }
       const beforeItemId = yield* resolveBeforeItemId({
+        entity: "chapter",
         videoId: existing.videoId,
         before,
         after,

--- a/apps/local/app/cli/commands/clip.help.ts
+++ b/apps/local/app/cli/commands/clip.help.ts
@@ -1,0 +1,145 @@
+/**
+ * Long-form --help text for the `cvm clip` verbs, split out of clip.ts to keep
+ * that command module under the repo's per-file token budget. These are
+ * domain-teaching prose strings consumed only by Command.withDescription.
+ */
+import { MINIMUM_CLIP_LENGTH_SECONDS } from "@/silence-detection-constants";
+
+export const CLIP_HELP = `clip — a timestamped slice of source footage on a Video's recorded timeline.
+
+A Clip is one captured segment of source footage, defined by a source filename and an in/out
+window into it (sourceStartTime/sourceEndTime, seconds). Clips and Chapters share one fractional
+'order' space; interleaving them in order is what forms the Video's Transcript. A clip's 'text' is
+its spoken transcription. Clips are children of a Video, addressed by id only; there is no version
+scoping and archived clips are always hidden (no --archived flag, no restore verb).
+
+Verbs:
+  clip list --video <videoId>          every active clip on a Video, in timeline order (NDJSON)
+  clip get <id...>                     fetch one or more clips by id (variadic)
+  clip add --video <id> --source <p> --start <t> --end <t>
+                                       cut a new clip, text sliced from <source>'s cached transcript
+  clip update <id> [flags]             set --zoom and/or retime --start/--end
+  clip move <id> --before/--after <id> reposition within the timeline
+  clip delete <id>                     archive the clip (soft delete; irreversible from the CLI)
+
+All writes are immediate — no confirmation, no dry-run (agent-facing tool). There is no 'clip tree'
+(clips are leaves) — use 'video tree' then 'clip get'. 'clip add' cuts a single clip from a footage
+file + time range and takes its text from that footage's cached transcript (see 'cvm footage').`;
+
+export const UPDATE_HELP = `Update a Clip: set its Clip Zoom and/or retime its cut.
+
+At least one of --zoom / --start / --end is required.
+
+--zoom <t>: "none" (as filmed) or "subtle", rendering the clip slightly tighter so a run of
+face-only camera clips has some visual change across its cuts. Only camera scenes can be zoomed —
+'Camera' and 'TikTok Face'. Anything else (a 'Code' clip, or a clip filmed before CVM recorded
+scenes) is refused with exit 3. Reaches the Export Hash, so setting it marks the Video for
+re-export.
+
+--start / --end <seconds>: move the in/out point into the source file. Either can be passed alone
+(the other keeps its current value) or both together. Rejected with exit 3 if the resulting range
+has start >= end, or is shorter than the ${MINIMUM_CLIP_LENGTH_SECONDS}s minimum clip length.
+
+IMPORTANT: retiming does NOT touch 'text' or 'transcribedAt' — the transcript is not
+re-generated for the new range. A retimed clip's text can be stale until something re-transcribes
+it; there is currently no CLI signal for "this text no longer matches this range" (only the
+pre-existing "never transcribed" signal, transcribedAt == null).
+
+Examples:
+  cvm clip update clip_abc --zoom subtle
+  cvm clip update clip_abc --start 12.4 --end 18.9
+  cvm clip update clip_abc --end 18.9 --zoom none
+
+  # Zoom every camera clip on a video:
+  cvm clip list --video vid_123 \
+    | jq -r 'select(.scene == "Camera") | .id' \
+    | xargs -n1 -I{} cvm clip update {} --zoom subtle`;
+
+export const MOVE_HELP = `Reposition a Clip within its Video's timeline.
+
+Requires exactly one of --before / --after <id>, where <id> is another active clip on the SAME
+video (a clip cannot move across videos via this command). Clips and Chapters share one fractional
+order space, so the new position is computed against both — landing a clip "after" the last clip
+before a Chapter is well-defined even though the anchor id is a clip.
+
+This jumps straight to an arbitrary position in one call, unlike a step-by-step up/down nudge.
+
+Immediate — there is no confirmation prompt (this is an agent-facing tool).
+
+Examples:
+  cvm clip move clip_abc --before clip_def   # clip_abc lands immediately before clip_def
+  cvm clip move clip_abc --after clip_def    # clip_abc lands immediately after clip_def`;
+
+export const ADD_HELP = `Add a single Clip to a Video's timeline, cut from a source footage file.
+
+Requires --video <id>, --source <path>, --start <t> and --end <t> (seconds).
+Optionally one of --before / --after <id> to place it; with neither, the clip is
+appended to the END of the Video's timeline.
+
+TEXT comes from the CACHED footage transcript, not a fresh transcription: the
+words of '<source>'s cached transcript (produced by 'cvm footage transcribe')
+that fall in [start, end) are sliced out as the clip's 'text'. If '<source>' has
+no cached transcript this is refused (exit 3) — run 'cvm footage transcribe
+<source>' first. There is no live Whisper call here.
+
+--before / --after resolve exactly like 'clip move': the anchor is another item
+on the SAME video, and because clips and chapters share one order space the new
+clip lands correctly even when the neighbour is a Chapter. The resulting clip is
+an ordinary Clip in every way — zoomable, movable, deletable, listed by
+'clip list'. Rejected (exit 3) if start >= end or the range is shorter than the
+${MINIMUM_CLIP_LENGTH_SECONDS}s minimum clip length; an unknown --video is a
+not-found (exit 2).
+
+Immediate — no confirmation (agent-facing tool). Like every clip write it needs
+the owning CourseVersion to be a Draft (a non-Draft is refused).
+
+Examples:
+  cvm footage transcribe /footage/take.mkv
+  cvm clip add --video vid_123 --source /footage/take.mkv --start 12.4 --end 40.0
+  cvm clip add --video vid_123 --source /footage/take.mkv --start 5 --end 9 --before clip_def`;
+
+export const DELETE_HELP = `Archive (soft-delete) a Clip.
+
+Sets 'archived: true'. Archived clips are ALWAYS filtered out everywhere (no --archived flag, no
+'clip get' access, no restore verb) — same one-way convention as 'beat delete'. The row still
+exists in the database (unlike 'file delete', which is a real unlink), but nothing in this CLI can
+bring it back.
+
+Immediately, no confirmation prompt (this is an agent-facing tool). Only its ClipWebLinks cascade
+on delete at the database level; nothing else references a Clip by foreign key, so deleting one
+does not orphan any Beat, Script, or Deliverable.
+
+Examples:
+  cvm clip delete clip_abc`;
+
+export const LIST_HELP = `List every active (non-archived) Clip on a Video, in timeline order.
+
+Requires --video <videoId>: the parent Video whose clips to source. Derived from the Video's
+clip set (getVideoWithClipsById), already ordered by the shared clip/chapter 'order' key, so the
+output reflects the recorded timeline. Output is NDJSON — one compact clip object per line; an
+empty video prints nothing and exits 0. An unknown video id is a not-found error (exit 2).
+
+Each line is identity-rich (id, videoId, order, text) so an agent can map content to ids in one
+call, then drill in with 'clip get'.
+
+Examples:
+  cvm clip list --video vid_123
+  cvm clip list --video vid_123 | jq -r '.text'
+  cvm clip list --video vid_123 | jq 'select(.transcribedAt==null) | .id'`;
+
+export const GET_HELP = `Fetch one or more Clips by id. Variadic: 'clip get <id> [<id> ...]'.
+
+Backed by the native multi-id getter (getClipsByIds), so many ids resolve in a single query.
+
+Output contract:
+  - one id, found     -> a single pretty-printed JSON object (exit 0)
+  - one id, missing   -> NotFoundError on stderr, exit 2
+  - many ids          -> NDJSON of the FOUND clips on stdout; if any id is missing, those ids are
+                         reported on stderr and the process exits 2 (stdout stays pure data)
+
+Args are ids ONLY (never names/paths). Find ids first with 'clip list --video <id>' or 'video tree'.
+
+Examples:
+  cvm clip get clip_abc
+  cvm clip get clip_abc clip_def clip_ghi
+  cvm clip get clip_abc | jq '{id, text, start: .sourceStartTime, end: .sourceEndTime}'`;

--- a/apps/local/app/cli/commands/clip.ts
+++ b/apps/local/app/cli/commands/clip.ts
@@ -16,6 +16,17 @@ import {
   type ClipZoomType,
 } from "@/features/videos/clip-zoom";
 import { MINIMUM_CLIP_LENGTH_SECONDS } from "@/silence-detection-constants";
+import { readFootageSidecar } from "@/services/footage-cache";
+import { sliceTranscriptText } from "@/services/footage-chunking";
+import {
+  CLIP_HELP,
+  LIST_HELP,
+  GET_HELP,
+  ADD_HELP,
+  UPDATE_HELP,
+  MOVE_HELP,
+  DELETE_HELP,
+} from "./clip.help";
 
 /**
  * clip — a timestamped slice of source footage inside a Video.
@@ -57,6 +68,8 @@ import { MINIMUM_CLIP_LENGTH_SECONDS } from "@/silence-detection-constants";
  * VERBS:
  *   clip list --video <videoId>          every active clip on a Video, timeline order
  *   clip get <id...>                     one or more clips by id (variadic)
+ *   clip add --video <id> --source <p>   cut a new clip, text sliced from the
+ *     --start <t> --end <t>              cached footage transcript
  *   clip update <id> [flags]             set --zoom and/or retime --start/--end
  *   clip move <id> --before/--after <id> reposition within the Video's timeline
  *   clip delete <id>                     archive (soft delete; no restore)
@@ -71,9 +84,9 @@ import { MINIMUM_CLIP_LENGTH_SECONDS } from "@/silence-detection-constants";
  * owning CourseVersion to be a draft, so published content can't be clobbered from here.
  *
  * Clips are leaf timeline rows — there is no `clip tree`. To explore a Video's structure use
- * `video tree`, then resolve ids with `clip get`. There is no `clip add`: every existing creator
- * (OBS capture append, "create video from selection") needs a real footage file + time range on
- * disk, so manual single-clip creation doesn't have anywhere to hang off yet.
+ * `video tree`, then resolve ids with `clip get`. A clip is normally captured by OBS append or
+ * "create video from selection", but `clip add` also creates one by hand from a footage file and a
+ * time range, taking its text from that footage's cached transcript (see `cvm footage transcribe`).
  *
  * EXAMPLES:
  *   # All clips on a video, in timeline order (NDJSON):
@@ -90,115 +103,6 @@ import { MINIMUM_CLIP_LENGTH_SECONDS } from "@/silence-detection-constants";
  *     | jq -r '.. | objects | select(.kind=="clip") | .id' \
  *     | xargs cvm clip get
  */
-const CLIP_HELP = `clip — a timestamped slice of source footage on a Video's recorded timeline.
-
-A Clip is one captured segment of source footage, defined by a source filename and an in/out
-window into it (sourceStartTime/sourceEndTime, seconds). Clips and Chapters share one fractional
-'order' space; interleaving them in order is what forms the Video's Transcript. A clip's 'text' is
-its spoken transcription. Clips are children of a Video, addressed by id only; there is no version
-scoping and archived clips are always hidden (no --archived flag, no restore verb).
-
-Verbs:
-  clip list --video <videoId>          every active clip on a Video, in timeline order (NDJSON)
-  clip get <id...>                     fetch one or more clips by id (variadic)
-  clip update <id> [flags]             set --zoom and/or retime --start/--end
-  clip move <id> --before/--after <id> reposition within the timeline
-  clip delete <id>                     archive the clip (soft delete; irreversible from the CLI)
-
-All writes are immediate — no confirmation, no dry-run (agent-facing tool). There is no 'clip tree'
-(clips are leaves) — use 'video tree' then 'clip get'. There is no 'clip add': creating a clip needs
-a real footage file + time range, which no CLI-facing creator exists for yet.`;
-
-const UPDATE_HELP = `Update a Clip: set its Clip Zoom and/or retime its cut.
-
-At least one of --zoom / --start / --end is required.
-
---zoom <t>: "none" (as filmed) or "subtle", rendering the clip slightly tighter so a run of
-face-only camera clips has some visual change across its cuts. Only camera scenes can be zoomed —
-'Camera' and 'TikTok Face'. Anything else (a 'Code' clip, or a clip filmed before CVM recorded
-scenes) is refused with exit 3. Reaches the Export Hash, so setting it marks the Video for
-re-export.
-
---start / --end <seconds>: move the in/out point into the source file. Either can be passed alone
-(the other keeps its current value) or both together. Rejected with exit 3 if the resulting range
-has start >= end, or is shorter than the ${MINIMUM_CLIP_LENGTH_SECONDS}s minimum clip length.
-
-IMPORTANT: retiming does NOT touch 'text' or 'transcribedAt' — the transcript is not
-re-generated for the new range. A retimed clip's text can be stale until something re-transcribes
-it; there is currently no CLI signal for "this text no longer matches this range" (only the
-pre-existing "never transcribed" signal, transcribedAt == null).
-
-Examples:
-  cvm clip update clip_abc --zoom subtle
-  cvm clip update clip_abc --start 12.4 --end 18.9
-  cvm clip update clip_abc --end 18.9 --zoom none
-
-  # Zoom every camera clip on a video:
-  cvm clip list --video vid_123 \
-    | jq -r 'select(.scene == "Camera") | .id' \
-    | xargs -n1 -I{} cvm clip update {} --zoom subtle`;
-
-const MOVE_HELP = `Reposition a Clip within its Video's timeline.
-
-Requires exactly one of --before / --after <id>, where <id> is another active clip on the SAME
-video (a clip cannot move across videos via this command). Clips and Chapters share one fractional
-order space, so the new position is computed against both — landing a clip "after" the last clip
-before a Chapter is well-defined even though the anchor id is a clip.
-
-This jumps straight to an arbitrary position in one call, unlike a step-by-step up/down nudge.
-
-Immediate — there is no confirmation prompt (this is an agent-facing tool).
-
-Examples:
-  cvm clip move clip_abc --before clip_def   # clip_abc lands immediately before clip_def
-  cvm clip move clip_abc --after clip_def    # clip_abc lands immediately after clip_def`;
-
-const DELETE_HELP = `Archive (soft-delete) a Clip.
-
-Sets 'archived: true'. Archived clips are ALWAYS filtered out everywhere (no --archived flag, no
-'clip get' access, no restore verb) — same one-way convention as 'beat delete'. The row still
-exists in the database (unlike 'file delete', which is a real unlink), but nothing in this CLI can
-bring it back.
-
-Immediately, no confirmation prompt (this is an agent-facing tool). Only its ClipWebLinks cascade
-on delete at the database level; nothing else references a Clip by foreign key, so deleting one
-does not orphan any Beat, Script, or Deliverable.
-
-Examples:
-  cvm clip delete clip_abc`;
-
-const LIST_HELP = `List every active (non-archived) Clip on a Video, in timeline order.
-
-Requires --video <videoId>: the parent Video whose clips to source. Derived from the Video's
-clip set (getVideoWithClipsById), already ordered by the shared clip/chapter 'order' key, so the
-output reflects the recorded timeline. Output is NDJSON — one compact clip object per line; an
-empty video prints nothing and exits 0. An unknown video id is a not-found error (exit 2).
-
-Each line is identity-rich (id, videoId, order, text) so an agent can map content to ids in one
-call, then drill in with 'clip get'.
-
-Examples:
-  cvm clip list --video vid_123
-  cvm clip list --video vid_123 | jq -r '.text'
-  cvm clip list --video vid_123 | jq 'select(.transcribedAt==null) | .id'`;
-
-const GET_HELP = `Fetch one or more Clips by id. Variadic: 'clip get <id> [<id> ...]'.
-
-Backed by the native multi-id getter (getClipsByIds), so many ids resolve in a single query.
-
-Output contract:
-  - one id, found     -> a single pretty-printed JSON object (exit 0)
-  - one id, missing   -> NotFoundError on stderr, exit 2
-  - many ids          -> NDJSON of the FOUND clips on stdout; if any id is missing, those ids are
-                         reported on stderr and the process exits 2 (stdout stays pure data)
-
-Args are ids ONLY (never names/paths). Find ids first with 'clip list --video <id>' or 'video tree'.
-
-Examples:
-  cvm clip get clip_abc
-  cvm clip get clip_abc clip_def clip_ghi
-  cvm clip get clip_abc | jq '{id, text, start: .sourceStartTime, end: .sourceEndTime}'`;
-
 const videoOpt = Options.text("video").pipe(
   Options.withDescription("Parent Video id whose clips to list")
 );
@@ -281,6 +185,25 @@ const afterOpt = Options.text("after").pipe(
 
 const idArg = Args.text({ name: "id" });
 
+const videoAddOpt = Options.text("video").pipe(
+  Options.withDescription("The Video id to add the clip to (required).")
+);
+
+const sourceOpt = Options.text("source").pipe(
+  Options.withDescription(
+    "Path to the source footage file the clip is cut from (required). Its " +
+      "cached transcript (from 'cvm footage transcribe') supplies the clip text."
+  )
+);
+
+const addStartOpt = Options.float("start").pipe(
+  Options.withDescription("In-point into the source file, seconds (required).")
+);
+
+const addEndOpt = Options.float("end").pipe(
+  Options.withDescription("Out-point into the source file, seconds (required).")
+);
+
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
@@ -301,18 +224,24 @@ const requireActiveClip = (id: string) =>
   });
 
 /**
- * Resolve `clip move`'s --before/--after into the single "anchor id" the
- * service positions against (mirrors `beat move`'s resolveBeforeBeatId, but
+ * Resolve `clip move`/`clip add`'s --before/--after into the single "anchor id"
+ * the service positions against (mirrors `beat move`'s resolveBeforeBeatId, but
  * over the merged clip+chapter order space since clips and chapters share
  * one fractional order key). --after X resolves to whatever item currently
  * follows X — which may legitimately be a Chapter id, since the service's
- * `moveClipToPosition` positions against either.
+ * `moveClipToPosition`/`createClip` positions against either.
+ *
+ * Neither flag returns `null` — "append to the end" for `add`. `clip move`
+ * requires exactly one and rejects the neither case at its own call site (a move
+ * that keeps a clip where it is would be a silent no-op, not an append).
+ * `excludeId` is the clip being MOVED (skipped so it never anchors to itself);
+ * `add` omits it, since the new clip is not on the timeline yet.
  */
 const resolveBeforeItemId = (params: {
   readonly videoId: string;
   readonly before: Option.Option<string>;
   readonly after: Option.Option<string>;
-  readonly excludeId: string;
+  readonly excludeId?: string;
 }) =>
   Effect.gen(function* () {
     const before = Option.getOrUndefined(params.before);
@@ -325,7 +254,7 @@ const resolveBeforeItemId = (params: {
       entity: "clip",
     });
     if (before === undefined && after === undefined) {
-      return yield* parseError("move needs one of --before / --after", "clip");
+      return null;
     }
 
     const clipOps = yield* ClipOperationsService;
@@ -352,6 +281,71 @@ const resolveBeforeItemId = (params: {
 // ---------------------------------------------------------------------------
 // Verbs
 // ---------------------------------------------------------------------------
+
+const addCmd = Command.make(
+  "add",
+  {
+    video: videoAddOpt,
+    source: sourceOpt,
+    start: addStartOpt,
+    end: addEndOpt,
+    before: beforeOpt,
+    after: afterOpt,
+  },
+  ({ video, source, start, end, before, after }) =>
+    Effect.gen(function* () {
+      if (start >= end) {
+        return yield* parseError(
+          `--start (${start}) must be before --end (${end})`,
+          "clip"
+        );
+      }
+      if (end - start < MINIMUM_CLIP_LENGTH_SECONDS) {
+        return yield* parseError(
+          `clip would be ${(end - start).toFixed(3)}s, below the ` +
+            `${MINIMUM_CLIP_LENGTH_SECONDS}s minimum clip length`,
+          "clip"
+        );
+      }
+
+      // The video must exist. `createClip`'s draft-guard passes a missing video
+      // straight through (the insert would then fail on the FK), so confirm here
+      // for a clean not-found (exit 2) instead.
+      const videoOps = yield* VideoOperationsService;
+      yield* videoOps
+        .getVideoWithClipsById(video)
+        .pipe(Effect.catchTag("NotFoundError", () => notFound("video", video)));
+
+      // Text is SLICED FROM THE CACHED footage transcript — never a live Whisper
+      // call. No cache -> tell the agent to transcribe the footage first.
+      const sidecar = yield* readFootageSidecar(source);
+      if (sidecar === null) {
+        return yield* parseError(
+          `no cached transcript for ${source} — run ` +
+            `'cvm footage transcribe ${source}' first`,
+          "clip"
+        );
+      }
+      const text = sliceTranscriptText(sidecar, start, end);
+
+      const beforeItemId = yield* resolveBeforeItemId({
+        videoId: video,
+        before,
+        after,
+      });
+
+      const clipOps = yield* ClipOperationsService;
+      const clip = yield* clipOps.createClip({
+        videoId: video,
+        videoFilename: source,
+        sourceStartTime: start,
+        sourceEndTime: end,
+        text,
+        beforeItemId,
+      });
+      yield* emitObject(clip);
+    })
+).pipe(Command.withDescription(detail(ADD_HELP)));
 
 const updateCmd = Command.make(
   "update",
@@ -417,6 +411,12 @@ const moveCmd = Command.make(
   ({ id, before, after }) =>
     Effect.gen(function* () {
       const existing = yield* requireActiveClip(id);
+      if (Option.isNone(before) && Option.isNone(after)) {
+        return yield* parseError(
+          "move needs one of --before / --after",
+          "clip"
+        );
+      }
       const beforeItemId = yield* resolveBeforeItemId({
         videoId: existing.videoId,
         before,
@@ -448,5 +448,12 @@ const deleteCmd = Command.make("delete", { id: idArg }, ({ id }) =>
 
 export const clipCommand = Command.make("clip").pipe(
   Command.withDescription(detail(CLIP_HELP)),
-  Command.withSubcommands([listCmd, getCmd, updateCmd, moveCmd, deleteCmd])
+  Command.withSubcommands([
+    listCmd,
+    getCmd,
+    addCmd,
+    updateCmd,
+    moveCmd,
+    deleteCmd,
+  ])
 );

--- a/apps/local/app/cli/commands/clip.ts
+++ b/apps/local/app/cli/commands/clip.ts
@@ -9,14 +9,14 @@ import {
   notFound,
   notFoundMany,
   parseError,
-  rejectBothFlags,
 } from "@/cli/helpers";
+import { resolveBeforeItemId } from "./timeline-position";
 import {
   CLIP_ZOOM_TYPES,
   type ClipZoomType,
 } from "@/features/videos/clip-zoom";
 import { MINIMUM_CLIP_LENGTH_SECONDS } from "@/silence-detection-constants";
-import { readFootageSidecar } from "@/services/footage-cache";
+import { readFootageTranscript } from "@/services/footage-cache";
 import { sliceTranscriptText } from "@/services/footage-chunking";
 import {
   CLIP_HELP,
@@ -223,60 +223,9 @@ const requireActiveClip = (id: string) =>
     return existing;
   });
 
-/**
- * Resolve `clip move`/`clip add`'s --before/--after into the single "anchor id"
- * the service positions against (mirrors `beat move`'s resolveBeforeBeatId, but
- * over the merged clip+chapter order space since clips and chapters share
- * one fractional order key). --after X resolves to whatever item currently
- * follows X — which may legitimately be a Chapter id, since the service's
- * `moveClipToPosition`/`createClip` positions against either.
- *
- * Neither flag returns `null` — "append to the end" for `add`. `clip move`
- * requires exactly one and rejects the neither case at its own call site (a move
- * that keeps a clip where it is would be a silent no-op, not an append).
- * `excludeId` is the clip being MOVED (skipped so it never anchors to itself);
- * `add` omits it, since the new clip is not on the timeline yet.
- */
-const resolveBeforeItemId = (params: {
-  readonly videoId: string;
-  readonly before: Option.Option<string>;
-  readonly after: Option.Option<string>;
-  readonly excludeId?: string;
-}) =>
-  Effect.gen(function* () {
-    const before = Option.getOrUndefined(params.before);
-    const after = Option.getOrUndefined(params.after);
-
-    yield* rejectBothFlags({
-      a: before,
-      b: after,
-      flags: ["--before", "--after"],
-      entity: "clip",
-    });
-    if (before === undefined && after === undefined) {
-      return null;
-    }
-
-    const clipOps = yield* ClipOperationsService;
-    const items = (yield* clipOps.listTimelineOrder(params.videoId)).filter(
-      (item) => item.id !== params.excludeId
-    );
-
-    if (before !== undefined) {
-      if (!items.some((item) => item.type === "clip" && item.id === before)) {
-        return yield* notFound("clip", before);
-      }
-      return before;
-    }
-
-    const idx = items.findIndex(
-      (item) => item.type === "clip" && item.id === after
-    );
-    if (idx === -1) {
-      return yield* notFound("clip", after!);
-    }
-    return items[idx + 1]?.id ?? null;
-  });
+// `resolveBeforeItemId` (the --before/--after anchor resolver) is shared with
+// `chapter` in ./timeline-position — clips and chapters share one order space,
+// so the resolution is identical and an anchor may be a Clip OR a Chapter.
 
 // ---------------------------------------------------------------------------
 // Verbs
@@ -317,11 +266,14 @@ const addCmd = Command.make(
         .pipe(Effect.catchTag("NotFoundError", () => notFound("video", video)));
 
       // Text is SLICED FROM THE CACHED footage transcript — never a live Whisper
-      // call. No cache -> tell the agent to transcribe the footage first.
-      const sidecar = yield* readFootageSidecar(source);
+      // call. `readFootageTranscript` re-hashes the source and treats a cache
+      // whose hash no longer matches (the footage was re-recorded/replaced) as
+      // absent, so a STALE transcript is refused exactly like a missing one —
+      // never silently sliced. Either way: tell the agent to transcribe first.
+      const sidecar = yield* readFootageTranscript(source);
       if (sidecar === null) {
         return yield* parseError(
-          `no cached transcript for ${source} — run ` +
+          `no fresh cached transcript for ${source} — run ` +
             `'cvm footage transcribe ${source}' first`,
           "clip"
         );
@@ -329,6 +281,7 @@ const addCmd = Command.make(
       const text = sliceTranscriptText(sidecar, start, end);
 
       const beforeItemId = yield* resolveBeforeItemId({
+        entity: "clip",
         videoId: video,
         before,
         after,
@@ -418,6 +371,7 @@ const moveCmd = Command.make(
         );
       }
       const beforeItemId = yield* resolveBeforeItemId({
+        entity: "clip",
         videoId: existing.videoId,
         before,
         after,

--- a/apps/local/app/cli/commands/footage.help.ts
+++ b/apps/local/app/cli/commands/footage.help.ts
@@ -1,0 +1,98 @@
+/**
+ * Long-form --help text for the `cvm footage` verbs, split out of footage.ts to
+ * keep that command module under the repo's per-file token budget. These are
+ * domain-teaching prose strings consumed only by Command.withDescription.
+ */
+export const HELP = `Footage — a raw recording on disk, before it is a Video.
+
+Footage is a source video FILE on the author's machine (an OBS capture, a screen
+recording) that has not been cut into Clips yet. Unlike every other noun in the
+domain model it has NO DATABASE ROW: its identity is its filesystem path, and
+its transcript is cached in a SIDECAR file next to it
+("<path>.transcript.json") — the same "the filesystem is the state" convention
+as a Video File. There is no 'RawFootage' table and no id; you always address
+footage by path.
+
+The point of transcribing footage is to read what was said BEFORE editing, so an
+agent can decide where Clips and Chapters should fall. The loop is:
+  cvm footage list                       # what raw files are around
+  cvm footage transcribe <path>          # cache a whole-file transcript
+  cvm footage transcript <path>          # read it back (words + segments)
+  cvm clip add --video <id> --source <path> --start <t> --end <t>
+                                         # cut a Clip whose text is sliced from
+                                         # that cached transcript (no re-Whisper)
+
+Transcription is whole-file and speaker-agnostic: mono 64kbps audio, Whisper
+'whisper-1' with segment + word timestamps, NO diarization. A file too large for
+Whisper's 25MB upload is split into ~27-minute chunks cut at detected silence
+(never mid-word) and merged back onto one timeline. The cache is keyed by a
+content hash of the source, so replacing/re-recording a file re-transcribes it
+rather than serving stale words.
+
+LOCAL-ONLY. Footage lives on the author's disk, so every verb here needs that
+machine; on any other box it is refused before doing anything (_tag
+"LocalOnlyCommandError", exit 7). That is a full stop, not a retry.
+
+Verbs:
+  list       [--dir <path>]              List video files in a directory
+  transcribe <path>                      Transcribe a file, caching the result
+  transcript <path>                      Read the cached transcript (never runs
+                                         Whisper; not-found if never transcribed)`;
+
+export const LIST_HELP = `List the video files in a directory as NDJSON (one compact object per line;
+an empty directory prints nothing, exit 0).
+
+--dir <path> chooses the directory; without it, the OBS_RECORDING_DIR config key
+is used (the same directory the recorder writes to), falling back to ~/Videos.
+
+Only video files are listed (mp4/mkv/mov/webm/avi/m4v), sorted by path. Each line
+carries:
+  path         absolute path to the file (feed straight to 'footage transcribe')
+  size         bytes
+  transcribed  whether a transcript sidecar exists next to it
+
+'transcribed' only reports that a sidecar is PRESENT; whether it is still fresh
+for the current bytes is checked by 'footage transcript' / 'footage transcribe',
+which re-hash the file.
+
+Examples:
+  cvm footage list
+  cvm footage list --dir /mnt/d/raw-footage
+  cvm footage list | jq -r 'select(.transcribed | not) | .path'`;
+
+export const TRANSCRIBE_HELP = `Transcribe a raw footage file and cache the transcript beside it.
+
+Extracts the file's audio (mono, 64kbps), transcribes it with Whisper
+('whisper-1', segment + word timestamps, no diarization), and writes a sidecar
+cache at "<path>.transcript.json". A file whose audio exceeds Whisper's 25MB
+upload cap is split into ~27-minute chunks, each cut at a detected silence point
+(never mid-word), transcribed independently, and merged back onto the file's own
+timeline.
+
+The cache is keyed by a CONTENT HASH of the source file. Re-recording or
+replacing the file at the same path changes the hash, so the next transcribe
+re-does the work instead of serving the previous file's words; an unchanged file
+overwrites its own sidecar. This is SYNCHRONOUS — a long file blocks until done.
+
+Echoes one JSON object: { path, sidecar, sourceHash, transcribedAt, words,
+segments } (words/segments are counts). Read the transcript itself back with
+'footage transcript'.
+
+Examples:
+  cvm footage transcribe /mnt/d/raw-footage/take.mkv
+  cvm footage transcribe ./rec.mp4 | jq '{words, segments}'`;
+
+export const TRANSCRIPT_HELP = `Read a footage file's cached transcript. NEVER transcribes — this only reads the
+sidecar written by 'footage transcribe'.
+
+Echoes one JSON object: { path, sourceHash, transcribedAt, words, segments },
+where words and segments are the full arrays of { start, end, text } on the
+file's own timeline.
+
+A file that was never transcribed — or whose sidecar is stale because the file's
+bytes have changed since (its content hash no longer matches) — is a not-found
+(exit 2). Run 'footage transcribe' first.
+
+Examples:
+  cvm footage transcript /mnt/d/raw-footage/take.mkv
+  cvm footage transcript ./rec.mp4 | jq -r '.segments[].text'`;

--- a/apps/local/app/cli/commands/footage.ts
+++ b/apps/local/app/cli/commands/footage.ts
@@ -1,0 +1,195 @@
+import { Args, Command, Options } from "@effect/cli";
+import { FileSystem } from "@effect/platform";
+import { Config, ConfigProvider, Effect, Option } from "effect";
+import { homedir } from "node:os";
+import path from "node:path";
+import { VideoProcessingService } from "@/services/video-processing-service";
+import {
+  computeFileContentHash,
+  readFootageTranscript,
+  sidecarPathFor,
+  writeFootageTranscript,
+} from "@/services/footage-cache";
+import {
+  detail,
+  emitNdjson,
+  emitObject,
+  notFound,
+  parseError,
+} from "@/cli/helpers";
+import { loadRepoEnv } from "@/cli/env";
+import { NEEDS_FOOTAGE_ON_DISK, requireLocalMachine } from "@/cli/local-only";
+import {
+  HELP,
+  LIST_HELP,
+  TRANSCRIBE_HELP,
+  TRANSCRIPT_HELP,
+} from "./footage.help";
+
+// ---------------------------------------------------------------------------
+// Footage is on the author's DISK, so every verb here is local-only. Each
+// subcommand yields this first, before its argument is even looked at (see
+// local-only.ts) — a Remote Box has no raw footage and could never succeed.
+// ---------------------------------------------------------------------------
+
+const requireLocalFootage = requireLocalMachine(
+  "cvm footage",
+  NEEDS_FOOTAGE_ON_DISK
+);
+
+const VIDEO_EXTENSIONS = new Set([
+  ".mp4",
+  ".mkv",
+  ".mov",
+  ".webm",
+  ".avi",
+  ".m4v",
+]);
+
+const dirOption = Options.text("dir").pipe(
+  Options.withDescription(
+    "Directory to list (default: OBS_RECORDING_DIR, else ~/Videos)."
+  ),
+  Options.optional
+);
+
+const pathArg = Args.text({ name: "path" });
+
+// ---------------------------------------------------------------------------
+// footage list
+// ---------------------------------------------------------------------------
+
+const listCmd = Command.make("list", { dir: dirOption }, ({ dir }) =>
+  Effect.gen(function* () {
+    yield* requireLocalFootage;
+    const fs = yield* FileSystem.FileSystem;
+
+    // Load the repo .env so OBS_RECORDING_DIR resolves the same way it does for
+    // the recorder (see getLatestOBSVideoClips), then read it via Config.
+    yield* Effect.sync(() => loadRepoEnv());
+    const directory = yield* Option.match(dir, {
+      onSome: (d) => Effect.succeed(d),
+      onNone: () =>
+        Config.string("OBS_RECORDING_DIR").pipe(
+          Effect.orElseSucceed(() => path.join(homedir(), "Videos"))
+        ),
+    }).pipe(Effect.withConfigProvider(ConfigProvider.fromEnv()));
+
+    const entries = yield* fs
+      .readDirectory(directory)
+      .pipe(
+        Effect.catchAll(() =>
+          parseError(`cannot read footage directory ${directory}`, "footage")
+        )
+      );
+
+    const files = entries
+      .filter((name) => VIDEO_EXTENSIONS.has(path.extname(name).toLowerCase()))
+      .sort();
+
+    const rows = yield* Effect.forEach(files, (name) =>
+      Effect.gen(function* () {
+        const full = path.join(directory, name);
+        const stat = yield* fs.stat(full);
+        const transcribed = yield* fs.exists(sidecarPathFor(full));
+        return { path: full, size: Number(stat.size), transcribed };
+      })
+    );
+
+    yield* emitNdjson(rows);
+  })
+).pipe(Command.withDescription(detail(LIST_HELP)));
+
+// ---------------------------------------------------------------------------
+// footage transcribe
+// ---------------------------------------------------------------------------
+
+/**
+ * The heavy service graph `footage transcribe` runs its Whisper/ffmpeg work
+ * inside, built LOCALLY here rather than merged into the shared cliRuntime —
+ * exactly like `course publish` (see course-publish.ts): VideoProcessingService
+ * reads OPENAI_API_KEY at BUILD time, and no read command should have to satisfy
+ * that key. It is only reached on the branch below where the service was not
+ * already provided — which is what lets a test inject a fake VideoProcessingService
+ * and never touch real ffmpeg or OpenAI.
+ */
+const footageProcessingLayer = VideoProcessingService.Default;
+
+const transcribeCmd = Command.make(
+  "transcribe",
+  { path: pathArg },
+  ({ path: sourcePath }) =>
+    Effect.gen(function* () {
+      yield* requireLocalFootage;
+      const fs = yield* FileSystem.FileSystem;
+
+      if (!(yield* fs.exists(sourcePath))) {
+        return yield* parseError(
+          `no such footage file: ${sourcePath}`,
+          "footage"
+        );
+      }
+
+      // Use an ambiently-provided VideoProcessingService if there is one (a test
+      // fake); otherwise build the real one here, loading the repo .env first so
+      // OPENAI_API_KEY is present at the layer's build time.
+      const provided = yield* Effect.serviceOption(VideoProcessingService);
+      const transcript = yield* Option.match(provided, {
+        onSome: (svc) => svc.transcribeFootageFile(sourcePath),
+        onNone: () =>
+          Effect.gen(function* () {
+            yield* Effect.sync(() => loadRepoEnv());
+            const svc = yield* VideoProcessingService;
+            return yield* svc.transcribeFootageFile(sourcePath);
+          }).pipe(
+            Effect.provide(footageProcessingLayer),
+            Effect.withConfigProvider(ConfigProvider.fromEnv())
+          ),
+      });
+
+      const sourceHash = yield* computeFileContentHash(sourcePath);
+      const sidecar = yield* writeFootageTranscript({
+        sourcePath,
+        sourceHash,
+        transcript,
+      });
+
+      yield* emitObject({
+        path: sidecar.sourcePath,
+        sidecar: sidecarPathFor(sourcePath),
+        sourceHash: sidecar.sourceHash,
+        transcribedAt: sidecar.transcribedAt,
+        words: sidecar.words.length,
+        segments: sidecar.segments.length,
+      });
+    })
+).pipe(Command.withDescription(detail(TRANSCRIBE_HELP)));
+
+// ---------------------------------------------------------------------------
+// footage transcript
+// ---------------------------------------------------------------------------
+
+const transcriptCmd = Command.make(
+  "transcript",
+  { path: pathArg },
+  ({ path: sourcePath }) =>
+    Effect.gen(function* () {
+      yield* requireLocalFootage;
+      const sidecar = yield* readFootageTranscript(sourcePath);
+      if (sidecar === null) {
+        return yield* notFound("footage transcript", sourcePath);
+      }
+      yield* emitObject({
+        path: sidecar.sourcePath,
+        sourceHash: sidecar.sourceHash,
+        transcribedAt: sidecar.transcribedAt,
+        words: sidecar.words,
+        segments: sidecar.segments,
+      });
+    })
+).pipe(Command.withDescription(detail(TRANSCRIPT_HELP)));
+
+export const footageCommand = Command.make("footage").pipe(
+  Command.withDescription(detail(HELP)),
+  Command.withSubcommands([listCmd, transcribeCmd, transcriptCmd])
+);

--- a/apps/local/app/cli/commands/timeline-position.ts
+++ b/apps/local/app/cli/commands/timeline-position.ts
@@ -1,0 +1,66 @@
+import { Effect, Option } from "effect";
+import { ClipOperationsService } from "@/services/db-clip-operations.server";
+import { notFound, rejectBothFlags } from "@/cli/helpers";
+
+/**
+ * Resolve `clip`/`chapter` `add`/`move`'s --before/--after into the single
+ * "anchor id" the positioning service writes against, over the MERGED
+ * clip+chapter order space.
+ *
+ * Clips and Chapters share ONE fractional `order` key (see
+ * `app/cli/commands/clip.ts` docstring), so an anchor may legitimately be
+ * EITHER a Clip or a Chapter — both `clip add --after <chapterId>` and
+ * `chapter add --after <clipId>` are well-defined. The lookup therefore matches
+ * against any timeline item by id, never filtering by type.
+ *
+ * `--after X` resolves to whatever item currently follows X (again, possibly a
+ * Chapter). Neither flag returns `null` — "append to the end" for `add`; `move`
+ * requires exactly one and rejects the neither case at its own call site (a
+ * move that keeps an item where it is would be a silent no-op, not an append).
+ * `excludeId` is the item being MOVED (skipped so it never anchors to itself);
+ * `add` omits it, since the new item is not on the timeline yet.
+ *
+ * `entity` only steers the messages of the errors surfaced here (which noun the
+ * CLI is reporting the not-found/both-flags against); the resolution logic is
+ * identical for both, which is exactly why it lives here rather than being
+ * duplicated per command.
+ */
+export const resolveBeforeItemId = (params: {
+  readonly entity: "clip" | "chapter";
+  readonly videoId: string;
+  readonly before: Option.Option<string>;
+  readonly after: Option.Option<string>;
+  readonly excludeId?: string;
+}) =>
+  Effect.gen(function* () {
+    const before = Option.getOrUndefined(params.before);
+    const after = Option.getOrUndefined(params.after);
+
+    yield* rejectBothFlags({
+      a: before,
+      b: after,
+      flags: ["--before", "--after"],
+      entity: params.entity,
+    });
+    if (before === undefined && after === undefined) {
+      return null;
+    }
+
+    const clipOps = yield* ClipOperationsService;
+    const items = (yield* clipOps.listTimelineOrder(params.videoId)).filter(
+      (item) => item.id !== params.excludeId
+    );
+
+    if (before !== undefined) {
+      if (!items.some((item) => item.id === before)) {
+        return yield* notFound(params.entity, before);
+      }
+      return before;
+    }
+
+    const idx = items.findIndex((item) => item.id === after);
+    if (idx === -1) {
+      return yield* notFound(params.entity, after!);
+    }
+    return items[idx + 1]?.id ?? null;
+  });

--- a/apps/local/app/cli/index.ts
+++ b/apps/local/app/cli/index.ts
@@ -5,8 +5,10 @@ import { sectionCommand } from "./commands/section";
 import { lessonCommand } from "./commands/lesson";
 import { videoCommand } from "./commands/video";
 import { clipCommand } from "./commands/clip";
+import { chapterCommand } from "./commands/chapter";
 import { beatCommand } from "./commands/beat";
 import { fileCommand } from "./commands/file";
+import { footageCommand } from "./commands/footage";
 import { pitchCommand } from "./commands/pitch";
 import { deliverableCommand } from "./commands/deliverable";
 import { searchCommand } from "./commands/search";
@@ -20,10 +22,11 @@ import { searchCommand } from "./commands/search";
 const ROOT_HELP = `cvm — agent-facing access to this Course Video Manager project's domain data.
 
 Read-mostly: most verbs are READS. A growing set of nouns has WRITE verbs —
-'beat' (add/update/move/delete), 'lesson' (create/update/move), 'video'
-(create/move/update), 'file' (add/delete), 'pitch' (create/update),
-'deliverable' (create/update/archive) and 'course' (publish). Every
-other verb is read-only, and each verb's own --help is authoritative about
+'beat' (add/update/move/delete), 'clip' (add/update/move/delete), 'chapter'
+(add/update/move/delete), 'lesson' (create/update/move), 'video'
+(create/move/update), 'file' (add/delete), 'footage' (transcribe), 'pitch'
+(create/update), 'deliverable' (create/update/archive) and 'course' (publish).
+Every other verb is read-only, and each verb's own --help is authoritative about
 whether it reads or writes.
 
 DOMAIN MODEL
@@ -89,9 +92,10 @@ WHERE THE DATA LIVES
   this repo on this box — retrying as-is will keep failing.
 
 WHAT NEEDS A MACHINE
-  Three commands need the AUTHOR'S MACHINE rather than the data, because they
+  A few commands need the AUTHOR'S MACHINE rather than the data, because they
   read and write its disk:
     cvm file …              the Video Files directory
+    cvm footage …           raw footage files on disk (transcribed with ffmpeg)
     cvm course readiness    the finished videos directory (exportedness)
     cvm course publish      the same, plus ffmpeg
   Anywhere else they are refused before doing any work — exit 7, _tag
@@ -106,6 +110,12 @@ WRITES
   any positional <id> (a flag after it exits 3). The write surface:
     beat    add/update/move/delete   author a Video's Beat plan
                                      (add --pitch <id> targets a pitch's video)
+    clip    add/update/move/delete   cut/retime/reorder/archive a Clip ('add'
+                                     needs a footage file transcribed first)
+    chapter add/update/move/delete   author a Video's Chapters (timeline
+                                     dividers that group its Clips)
+    footage transcribe               cache a raw footage file's transcript on
+                                     disk (LOCAL-ONLY; feeds 'clip add')
     lesson  create/update/move       create a lesson, rename its title,
                                      or reorder / re-home it
     video   create/move/update       create a Video, re-home it to a lesson/
@@ -133,7 +143,8 @@ WRITES
   (Dropbox) and reads publish-only config from the repo .env.
 
 NOUNS
-  course version section lesson video clip beat file pitch deliverable
+  course version section lesson video clip chapter beat file footage pitch
+  deliverable
 
 SEARCH
   search <query>   Case-insensitive substring search DOWN THE TREE across every
@@ -155,8 +166,10 @@ export const rootCommand = Command.make("cvm").pipe(
     lessonCommand,
     videoCommand,
     clipCommand,
+    chapterCommand,
     beatCommand,
     fileCommand,
+    footageCommand,
     pitchCommand,
     deliverableCommand,
     searchCommand,

--- a/apps/local/app/cli/local-only.ts
+++ b/apps/local/app/cli/local-only.ts
@@ -30,6 +30,8 @@ export const NEEDS_FINISHED_VIDEOS_DIRECTORY =
   "it reads the finished videos directory on this machine's disk to work out which Videos are exported";
 export const NEEDS_FINISHED_VIDEOS_AND_FFMPEG =
   "it renders Videos with ffmpeg and reads the finished videos directory on this machine's disk";
+export const NEEDS_FOOTAGE_ON_DISK =
+  "it reads raw footage files on this machine's disk (with ffmpeg) and caches their transcripts beside them";
 
 /**
  * Refuse `command` unless this is the author's machine.

--- a/apps/local/app/cli/rpc-layer.ts
+++ b/apps/local/app/cli/rpc-layer.ts
@@ -192,6 +192,7 @@ const clipService = (client: RpcClient) =>
     listTimelineOrder: rpcMethod((json) =>
       client.rpc.clip.listTimelineOrder.$post({ json })
     ),
+    createClip: rpcMethod((json) => client.rpc.clip.createClip.$post({ json })),
     updateClip: rpcMethod((json) => client.rpc.clip.updateClip.$post({ json })),
     setClipZoom: rpcMethod((json) =>
       client.rpc.clip.setClipZoom.$post({ json })
@@ -201,6 +202,27 @@ const clipService = (client: RpcClient) =>
     ),
     archiveClip: rpcMethod((json) =>
       client.rpc.clip.archiveClip.$post({ json })
+    ),
+    // Chapters live on this same service (ClipOperationsService merges the
+    // chapter ops in), so `cvm chapter`'s verbs are RPC methods here too, backed
+    // by the /rpc/chapter route group.
+    getChaptersByIds: rpcMethod((json) =>
+      client.rpc.chapter.getChaptersByIds.$post({ json })
+    ),
+    listChaptersByVideoId: rpcMethod((json) =>
+      client.rpc.chapter.listChaptersByVideoId.$post({ json })
+    ),
+    createChapterAtItem: rpcMethod((json) =>
+      client.rpc.chapter.createChapterAtItem.$post({ json })
+    ),
+    updateChapter: rpcMethod((json) =>
+      client.rpc.chapter.updateChapter.$post({ json })
+    ),
+    moveChapterToPosition: rpcMethod((json) =>
+      client.rpc.chapter.moveChapterToPosition.$post({ json })
+    ),
+    archiveChapter: rpcMethod((json) =>
+      client.rpc.chapter.archiveChapter.$post({ json })
     ),
   }) satisfies RemoteService<ClipOperationsService>;
 

--- a/apps/local/app/services/footage-cache.ts
+++ b/apps/local/app/services/footage-cache.ts
@@ -1,0 +1,135 @@
+import { Effect } from "effect";
+import { FileSystem } from "@effect/platform";
+import type { PlatformError } from "@effect/platform/Error";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { FootageTranscript } from "./footage-chunking";
+
+/**
+ * The on-disk cache for a **Footage** transcript (see CONTEXT.md "Footage").
+ *
+ * FOOTAGE HAS NO DATABASE ROW. Its identity is a filesystem path, and its
+ * transcript is cached in a SIDECAR file next to the source — the same
+ * "filesystem is the state" convention as a Video File. The sidecar for
+ * `/videos/rec.mkv` is `/videos/rec.mkv.transcript.json`.
+ *
+ * The cache is KEYED BY A CONTENT HASH of the source file, stored inside the
+ * sidecar. If the source is re-recorded or replaced, its hash changes and the
+ * cached transcript no longer matches — `readFootageTranscript` reports the
+ * cache as absent (stale), so `footage transcribe` re-transcribes rather than
+ * silently serving the old file's words, and `footage transcript` reports
+ * not-found rather than a stale transcript.
+ */
+
+const SIDECAR_SUFFIX = ".transcript.json";
+const SIDECAR_VERSION = 1 as const;
+
+export interface FootageSidecar {
+  readonly version: typeof SIDECAR_VERSION;
+  /** The source file this transcript was produced from (absolute). */
+  readonly sourcePath: string;
+  /** SHA-256 of the source file's contents when it was transcribed. */
+  readonly sourceHash: string;
+  /** When the transcript was produced (ISO 8601). */
+  readonly transcribedAt: string;
+  readonly words: FootageTranscript["words"];
+  readonly segments: FootageTranscript["segments"];
+}
+
+/** The sidecar cache path for a source footage path. */
+export const sidecarPathFor = (sourcePath: string): string =>
+  path.resolve(sourcePath) + SIDECAR_SUFFIX;
+
+/**
+ * SHA-256 of a file's contents, streamed rather than read whole — raw footage
+ * can be many gigabytes, and hashing it must not pull it all into memory.
+ */
+export const computeFileContentHash = (
+  sourcePath: string
+): Effect.Effect<string> =>
+  Effect.async<string>((resume) => {
+    const hash = crypto.createHash("sha256");
+    const stream = fs.createReadStream(sourcePath);
+    stream.on("error", (error) => resume(Effect.die(error)));
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resume(Effect.succeed(hash.digest("hex"))));
+  });
+
+/**
+ * Read and parse the sidecar next to `sourcePath`, WITHOUT checking it against
+ * the source file — `null` if there is no sidecar, it is malformed, or it is a
+ * version this build does not understand. This is what `cvm clip add` uses: it
+ * only needs the cached words, and re-hashing (possibly gigabytes of) source on
+ * every clip would be wasteful and would require the source present at all.
+ */
+export const readFootageSidecar = (
+  sourcePath: string
+): Effect.Effect<FootageSidecar | null, PlatformError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fsvc = yield* FileSystem.FileSystem;
+    const sidecarPath = sidecarPathFor(sourcePath);
+
+    if (!(yield* fsvc.exists(sidecarPath))) return null;
+
+    const raw = yield* fsvc.readFileString(sidecarPath);
+    const parsed = yield* Effect.try(
+      () => JSON.parse(raw) as FootageSidecar
+    ).pipe(Effect.catchAll(() => Effect.succeed(null)));
+    if (parsed === null || parsed.version !== SIDECAR_VERSION) return null;
+
+    return parsed;
+  });
+
+/**
+ * Read the cached transcript for `sourcePath` AND confirm it still matches the
+ * file on disk, returning `null` if there is none — where "none" also covers a
+ * sidecar left behind by a DIFFERENT version of the file (its stored hash no
+ * longer matches), or one whose source has since been deleted. This is what
+ * `cvm footage transcript` reads, so a stale transcript is reported not-found
+ * rather than served.
+ */
+export const readFootageTranscript = (
+  sourcePath: string
+): Effect.Effect<FootageSidecar | null, PlatformError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fsvc = yield* FileSystem.FileSystem;
+
+    const parsed = yield* readFootageSidecar(sourcePath);
+    if (parsed === null) return null;
+
+    // Can't confirm freshness against a source that is gone — treat as stale.
+    if (!(yield* fsvc.exists(sourcePath))) return null;
+
+    const hash = yield* computeFileContentHash(sourcePath);
+    if (parsed.sourceHash !== hash) return null;
+
+    return parsed;
+  });
+
+/**
+ * Write (overwriting any existing) the sidecar cache for `sourcePath`. The
+ * caller passes the already-computed content hash so the write and the freshness
+ * key can never disagree.
+ */
+export const writeFootageTranscript = (opts: {
+  readonly sourcePath: string;
+  readonly sourceHash: string;
+  readonly transcript: FootageTranscript;
+}): Effect.Effect<FootageSidecar, PlatformError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fsvc = yield* FileSystem.FileSystem;
+    const sidecar: FootageSidecar = {
+      version: SIDECAR_VERSION,
+      sourcePath: path.resolve(opts.sourcePath),
+      sourceHash: opts.sourceHash,
+      transcribedAt: new Date().toISOString(),
+      words: opts.transcript.words,
+      segments: opts.transcript.segments,
+    };
+    yield* fsvc.writeFileString(
+      sidecarPathFor(opts.sourcePath),
+      JSON.stringify(sidecar, null, 2)
+    );
+    return sidecar;
+  });

--- a/apps/local/app/services/footage-cache.ts
+++ b/apps/local/app/services/footage-cache.ts
@@ -1,8 +1,7 @@
-import { Effect } from "effect";
+import { Effect, Stream } from "effect";
 import { FileSystem } from "@effect/platform";
 import type { PlatformError } from "@effect/platform/Error";
-import crypto from "node:crypto";
-import fs from "node:fs";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import type { FootageTranscript } from "./footage-chunking";
 
@@ -44,24 +43,32 @@ export const sidecarPathFor = (sourcePath: string): string =>
 /**
  * SHA-256 of a file's contents, streamed rather than read whole — raw footage
  * can be many gigabytes, and hashing it must not pull it all into memory.
+ *
+ * Streams through Effect's `FileSystem` (not raw `node:fs`) so the read is
+ * DI-injectable and its I/O failures land in the typed error channel as a
+ * `PlatformError`, consistent with the rest of this module (see
+ * CODING_STANDARDS.md — prefer Effect primitives over promises/callbacks).
  */
 export const computeFileContentHash = (
   sourcePath: string
-): Effect.Effect<string> =>
-  Effect.async<string>((resume) => {
-    const hash = crypto.createHash("sha256");
-    const stream = fs.createReadStream(sourcePath);
-    stream.on("error", (error) => resume(Effect.die(error)));
-    stream.on("data", (chunk) => hash.update(chunk));
-    stream.on("end", () => resume(Effect.succeed(hash.digest("hex"))));
+): Effect.Effect<string, PlatformError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fsvc = yield* FileSystem.FileSystem;
+    const hash = createHash("sha256");
+    yield* fsvc
+      .stream(sourcePath)
+      .pipe(
+        Stream.runForEach((chunk) => Effect.sync(() => hash.update(chunk)))
+      );
+    return hash.digest("hex");
   });
 
 /**
  * Read and parse the sidecar next to `sourcePath`, WITHOUT checking it against
  * the source file — `null` if there is no sidecar, it is malformed, or it is a
- * version this build does not understand. This is what `cvm clip add` uses: it
- * only needs the cached words, and re-hashing (possibly gigabytes of) source on
- * every clip would be wasteful and would require the source present at all.
+ * version this build does not understand. The raw primitive underneath
+ * `readFootageTranscript`, which layers the freshness (hash) check on top; not
+ * used on its own by any caller that could be served a stale transcript.
  */
 export const readFootageSidecar = (
   sourcePath: string

--- a/apps/local/app/services/footage-chunking.test.ts
+++ b/apps/local/app/services/footage-chunking.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import { Effect } from "effect";
+import { NodeContext } from "@effect/platform-node";
+import { findSilenceInVideo } from "./silence-detection";
+import type { FFmpegCommandsService } from "./ffmpeg-commands";
+import {
+  mergeChunkTranscripts,
+  planChunkBoundaries,
+  sliceTranscriptText,
+} from "./footage-chunking";
+
+/**
+ * The chunk-boundary + timestamp-merge algorithm, tested as pure functions —
+ * no real ffmpeg and no Whisper. Where a boundary is derived from detected
+ * silence we drive it through `findSilenceInVideo` with a mocked
+ * FFmpegCommandsService (mirroring silence-detection.test.ts), so the same
+ * silencedetect-parsing path that production uses feeds the planner.
+ */
+
+function mockFFmpeg(opts: {
+  fps: number;
+  silenceOutput: string;
+}): FFmpegCommandsService {
+  return {
+    getFPS: () => Effect.succeed(opts.fps),
+    detectSilence: () => Effect.succeed(opts.silenceOutput),
+  } as unknown as FFmpegCommandsService;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const run = <A>(effect: Effect.Effect<A, any, any>): Promise<A> =>
+  Effect.runPromise(
+    effect.pipe(Effect.provide(NodeContext.layer)) as Effect.Effect<A>
+  );
+
+describe("planChunkBoundaries", () => {
+  it("cuts at the silence point nearest the target, not at a fixed interval", () => {
+    // Target 1620s (27min). Silence at 1600 and 1650 — 1600 is closer to 1620.
+    const boundaries = planChunkBoundaries({
+      durationSeconds: 3600,
+      silencePoints: [1600, 1650, 3200],
+      targetChunkSeconds: 1620,
+    });
+
+    expect(boundaries).toEqual([
+      { start: 0, end: 1600 },
+      { start: 1600, end: 3600 },
+    ]);
+    // The chosen boundary is a genuine silence point, near the target.
+    expect([1600, 1650]).toContain(boundaries[0]!.end);
+    expect(Math.abs(boundaries[0]!.end - 1620)).toBeLessThan(60);
+  });
+
+  it("splits a very long file into multiple chunks, each landing on silence", () => {
+    const boundaries = planChunkBoundaries({
+      durationSeconds: 6000,
+      silencePoints: [1590, 1610, 3150, 3300, 4800],
+      targetChunkSeconds: 1620,
+    });
+
+    expect(boundaries).toEqual([
+      { start: 0, end: 1610 },
+      { start: 1610, end: 3300 },
+      { start: 3300, end: 4800 },
+      { start: 4800, end: 6000 },
+    ]);
+    // Every internal boundary is one of the supplied silence points.
+    for (const b of boundaries.slice(0, -1)) {
+      expect([1590, 1610, 3150, 3300, 4800]).toContain(b.end);
+    }
+  });
+
+  it("falls back to a hard cut at the target when no silence is in the window", () => {
+    const boundaries = planChunkBoundaries({
+      durationSeconds: 3600,
+      silencePoints: [10, 20], // all far outside the window around 1620
+      targetChunkSeconds: 1620,
+    });
+
+    expect(boundaries).toEqual([
+      { start: 0, end: 1620 },
+      { start: 1620, end: 3600 },
+    ]);
+  });
+
+  it("returns a single chunk when the file is shorter than 1.5× the target", () => {
+    expect(
+      planChunkBoundaries({
+        durationSeconds: 1800,
+        silencePoints: [900],
+        targetChunkSeconds: 1620,
+      })
+    ).toEqual([{ start: 0, end: 1800 }]);
+  });
+
+  it("derives its silence points from findSilenceInVideo's speaking clips", async () => {
+    // Two speaking gaps: 2.0–5.07 and (after a silence) a later clip. The end
+    // of a speaking clip is where silence begins — a legal cut point.
+    const silenceOutput = [
+      "[silencedetect @ 0x1] silence_start: 0",
+      "[silencedetect @ 0x1] silence_end: 2.0 | silence_duration: 2.0",
+      "[silencedetect @ 0x1] silence_start: 5.0",
+      "[silencedetect @ 0x1] silence_end: 30.0 | silence_duration: 25.0",
+      "[silencedetect @ 0x1] silence_start: 33.0",
+      "[silencedetect @ 0x1] silence_end: 34.0 | silence_duration: 1.0",
+    ].join("\n");
+    const ffmpeg = mockFFmpeg({ fps: 30, silenceOutput });
+
+    const { clips } = await run(findSilenceInVideo(ffmpeg, "/test/video.mkv"));
+    const silencePoints = clips.map((c) => c.endTime);
+
+    // Target 5s so the single silence point (~5.07) is the natural boundary.
+    const boundaries = planChunkBoundaries({
+      durationSeconds: 34,
+      silencePoints,
+      targetChunkSeconds: 5,
+    });
+
+    expect(boundaries[0]!.start).toBe(0);
+    expect(silencePoints).toContain(boundaries[0]!.end);
+    expect(boundaries.at(-1)!.end).toBe(34);
+  });
+});
+
+describe("mergeChunkTranscripts", () => {
+  it("offsets every word and segment by its chunk's start", () => {
+    const merged = mergeChunkTranscripts([
+      {
+        offset: 0,
+        words: [{ start: 0, end: 0.5, text: "hello" }],
+        segments: [{ start: 0, end: 0.5, text: "hello" }],
+      },
+      {
+        offset: 100,
+        words: [
+          { start: 1, end: 1.5, text: "world" },
+          { start: 2, end: 2.5, text: "again" },
+        ],
+        segments: [{ start: 1, end: 2.5, text: "world again" }],
+      },
+    ]);
+
+    expect(merged.words).toEqual([
+      { start: 0, end: 0.5, text: "hello" },
+      { start: 101, end: 101.5, text: "world" },
+      { start: 102, end: 102.5, text: "again" },
+    ]);
+    expect(merged.segments).toEqual([
+      { start: 0, end: 0.5, text: "hello" },
+      { start: 101, end: 102.5, text: "world again" },
+    ]);
+  });
+
+  it("is a no-op offset for a single chunk at zero", () => {
+    const merged = mergeChunkTranscripts([
+      {
+        offset: 0,
+        words: [{ start: 3, end: 4, text: "x" }],
+        segments: [],
+      },
+    ]);
+    expect(merged.words).toEqual([{ start: 3, end: 4, text: "x" }]);
+    expect(merged.segments).toEqual([]);
+  });
+});
+
+describe("sliceTranscriptText", () => {
+  const transcript = {
+    words: [
+      { start: 0, end: 1, text: "the" },
+      { start: 1, end: 2, text: "quick" },
+      { start: 2, end: 3, text: "brown" },
+      { start: 3, end: 4, text: "fox" },
+    ],
+    segments: [{ start: 0, end: 4, text: " the quick brown fox" }],
+  };
+
+  it("returns the words overlapping the window, space-joined", () => {
+    expect(sliceTranscriptText(transcript, 1, 3)).toBe("quick brown");
+  });
+
+  it("includes a word that straddles the window edge", () => {
+    // [1.5, 2.5) overlaps "quick" (1–2) and "brown" (2–3).
+    expect(sliceTranscriptText(transcript, 1.5, 2.5)).toBe("quick brown");
+  });
+
+  it("falls back to overlapping segments when there are no words", () => {
+    expect(
+      sliceTranscriptText({ words: [], segments: transcript.segments }, 0, 4)
+    ).toBe("the quick brown fox");
+  });
+
+  it("is empty when the window overlaps nothing", () => {
+    expect(sliceTranscriptText(transcript, 10, 20)).toBe("");
+  });
+});

--- a/apps/local/app/services/footage-chunking.ts
+++ b/apps/local/app/services/footage-chunking.ts
@@ -1,0 +1,169 @@
+/**
+ * Pure helpers for whole-file **Footage** transcription (see CONTEXT.md
+ * "Footage"). Extracted from VideoProcessingService so the two decisions that
+ * are easy to get wrong — WHERE to split a long recording, and how to STITCH
+ * the per-chunk transcripts back onto one timeline — are plain functions with
+ * no ffmpeg, no Whisper and no filesystem, unit-tested directly.
+ *
+ * Whisper caps an upload at 25MB. A long recording's mono 64kbps audio exceeds
+ * that, so it is transcribed in pieces; each piece is cut at a real silence
+ * point (never mid-word) near a target duration, transcribed on its own, and
+ * its timestamps are shifted back by the piece's start before merging — so the
+ * merged transcript reads as if the whole file were transcribed at once.
+ */
+
+export interface TranscriptWord {
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+}
+
+export interface TranscriptSegment {
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+}
+
+export interface FootageTranscript {
+  readonly words: ReadonlyArray<TranscriptWord>;
+  readonly segments: ReadonlyArray<TranscriptSegment>;
+}
+
+/** A half-open window `[start, end)` into the source file, in seconds. */
+export interface ChunkBoundary {
+  readonly start: number;
+  readonly end: number;
+}
+
+/**
+ * ~27 minutes. At mono 64kbps that is ~13MB — comfortably under Whisper's 25MB
+ * cap even if the nearest silence lands a few minutes late, so a chunk chosen
+ * around this target never has to be re-split.
+ */
+export const FOOTAGE_TARGET_CHUNK_SECONDS = 27 * 60;
+
+/**
+ * Split `[0, durationSeconds)` into consecutive chunks each roughly
+ * `targetChunkSeconds` long, choosing every internal boundary at the SILENCE
+ * POINT nearest the target rather than at a fixed interval — so a cut never
+ * lands inside a spoken word (which would drop or duplicate it across the two
+ * pieces, the exact failure fixed-interval + overlap chunking exists to paper
+ * over).
+ *
+ * `silencePoints` are absolute times (seconds) where the file is silent — the
+ * ends of speaking clips from `findSilenceInVideo` are the natural source. A
+ * boundary is picked from the points falling in the acceptable window around
+ * the target; if none do (a stretch of unbroken speech longer than the window),
+ * the chunk is cut at the target time itself, so a pathological input still
+ * yields chunks under the size cap.
+ *
+ * The last chunk always runs to `durationSeconds`, and can be up to 1.5× the
+ * target so a short tail is absorbed rather than left as a sliver.
+ */
+export const planChunkBoundaries = (opts: {
+  readonly durationSeconds: number;
+  readonly silencePoints: ReadonlyArray<number>;
+  readonly targetChunkSeconds?: number;
+}): ChunkBoundary[] => {
+  const { durationSeconds } = opts;
+  const target = opts.targetChunkSeconds ?? FOOTAGE_TARGET_CHUNK_SECONDS;
+  const maxChunk = target * 1.5;
+
+  if (!(durationSeconds > 0)) return [];
+
+  const sorted = [...opts.silencePoints].sort((a, b) => a - b);
+  const boundaries: ChunkBoundary[] = [];
+  let start = 0;
+
+  // A remainder no bigger than one over-long chunk becomes the final piece.
+  while (durationSeconds - start > maxChunk) {
+    const ideal = start + target;
+    // The window keeps a chunk between half the target and 1.5× it, so a cut
+    // is always a plausible chunk length even when silence is sparse.
+    const minEnd = start + target * 0.5;
+    const maxEnd = Math.min(start + maxChunk, durationSeconds);
+    const inWindow = sorted.filter((p) => p > minEnd && p < maxEnd);
+
+    const cut =
+      inWindow.length > 0
+        ? inWindow.reduce((best, p) =>
+            Math.abs(p - ideal) < Math.abs(best - ideal) ? p : best
+          )
+        : Math.min(ideal, durationSeconds);
+
+    boundaries.push({ start, end: cut });
+    start = cut;
+  }
+
+  boundaries.push({ start, end: durationSeconds });
+  return boundaries;
+};
+
+/** One chunk's own-timeline transcript plus the offset it sits at in the file. */
+export interface ChunkTranscript extends FootageTranscript {
+  /** Seconds to add to every timestamp — the chunk's start in the source. */
+  readonly offset: number;
+}
+
+/**
+ * Concatenate per-chunk transcripts into one whole-file transcript, shifting
+ * every word and segment timestamp by its chunk's `offset`. Chunks are merged
+ * in the order given (which is timeline order — see `planChunkBoundaries`), so
+ * the result's timestamps are strictly the source file's own.
+ */
+export const mergeChunkTranscripts = (
+  chunks: ReadonlyArray<ChunkTranscript>
+): FootageTranscript => {
+  const words: TranscriptWord[] = [];
+  const segments: TranscriptSegment[] = [];
+
+  for (const chunk of chunks) {
+    for (const w of chunk.words) {
+      words.push({
+        start: w.start + chunk.offset,
+        end: w.end + chunk.offset,
+        text: w.text,
+      });
+    }
+    for (const s of chunk.segments) {
+      segments.push({
+        start: s.start + chunk.offset,
+        end: s.end + chunk.offset,
+        text: s.text,
+      });
+    }
+  }
+
+  return { words, segments };
+};
+
+/**
+ * The text of a Footage transcript sliced to the window `[startTime, endTime)`
+ * — every word that OVERLAPS the window, joined into one string. This is what
+ * `cvm clip add` uses to populate a new Clip's `text` from the cached whole-file
+ * transcript, with no fresh Whisper call.
+ *
+ * Words are preferred (they slice tightly); a transcript that somehow carries
+ * segments but no words falls back to overlapping segments. Whisper word tokens
+ * arrive without surrounding spaces, so they are trimmed and space-joined.
+ */
+export const sliceTranscriptText = (
+  transcript: FootageTranscript,
+  startTime: number,
+  endTime: number
+): string => {
+  const overlaps = (s: number, e: number) => s < endTime && e > startTime;
+
+  const wordText = transcript.words
+    .filter((w) => overlaps(w.start, w.end))
+    .map((w) => w.text.trim())
+    .filter((t) => t.length > 0)
+    .join(" ");
+  if (wordText.length > 0) return wordText;
+
+  return transcript.segments
+    .filter((s) => overlaps(s.start, s.end))
+    .map((s) => s.text.trim())
+    .filter((t) => t.length > 0)
+    .join(" ");
+};

--- a/apps/local/app/services/footage-transcription.ts
+++ b/apps/local/app/services/footage-transcription.ts
@@ -1,0 +1,186 @@
+import { Command, FileSystem } from "@effect/platform";
+import { Data, Effect } from "effect";
+import crypto from "node:crypto";
+import path from "node:path";
+import { tmpdir } from "os";
+import type { FFmpegCommandsService } from "./ffmpeg-commands";
+import { findSilenceInVideo } from "./silence-detection";
+import {
+  mergeChunkTranscripts,
+  planChunkBoundaries,
+  type FootageTranscript,
+} from "./footage-chunking";
+
+/**
+ * Whole-file **Footage** transcription — the ffmpeg + chunking orchestration
+ * behind `VideoProcessingService.transcribeFootageFile`. Split out of that
+ * service purely to keep it under the repo's per-file token budget; it is not a
+ * seam. `transcribeFootage` takes the service's own `transcribeAudioFile` (the
+ * Whisper call, with its semaphore and API key) as a parameter, so every chunk
+ * still transcribes through exactly that one path and the whole thing stays
+ * fakeable by faking VideoProcessingService.
+ *
+ * DELIBERATELY SEPARATE from the per-clip transcription path: the audio here is
+ * mono 64kbps (small enough that most files upload in one Whisper pass), never
+ * the 384kbps stereo `extractAudioClip` produces.
+ */
+
+/**
+ * Whisper refuses an upload over 25MB. Footage whose extracted mono-64kbps audio
+ * exceeds this is transcribed in silence-aligned chunks; anything at or under it
+ * is one pass.
+ */
+const WHISPER_MAX_UPLOAD_BYTES = 25 * 1024 * 1024;
+
+export class CouldNotExtractFootageAudioError extends Data.TaggedError(
+  "CouldNotExtractFootageAudioError"
+)<{
+  cause: unknown;
+  message: string;
+}> {}
+
+/**
+ * Extract footage audio as mono, 64kbps mp3. Pass a `startTime`/`durationSeconds`
+ * to extract one chunk of a long file.
+ */
+const extractFootageAudio = Effect.fn("extractFootageAudio")(function* (
+  inputVideo: string,
+  startTime?: number,
+  durationSeconds?: number
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const outputDir = path.join(tmpdir(), "whisper-footage-audio");
+  yield* fs.makeDirectory(outputDir, { recursive: true });
+
+  const outputHash = crypto
+    .createHash("sha256")
+    .update(`${inputVideo}-${startTime ?? "full"}-${durationSeconds ?? "full"}`)
+    .digest("hex")
+    .slice(0, 12);
+  const outputFile = path.join(outputDir, `${outputHash}.mp3`);
+
+  const args = ["-y", "-hide_banner"];
+  if (startTime !== undefined) args.push("-ss", startTime.toString());
+  if (durationSeconds !== undefined)
+    args.push("-t", durationSeconds.toString());
+  args.push(
+    "-i",
+    inputVideo,
+    "-vn",
+    "-ac",
+    "1",
+    "-c:a",
+    "libmp3lame",
+    "-b:a",
+    "64k",
+    outputFile
+  );
+
+  const code = yield* Command.exitCode(Command.make("ffmpeg", ...args)).pipe(
+    Effect.mapError(
+      (e) =>
+        new CouldNotExtractFootageAudioError({
+          cause: e,
+          message: `Failed to extract footage audio: ${e.message}`,
+        })
+    )
+  );
+  if (code !== 0) {
+    yield* new CouldNotExtractFootageAudioError({
+      cause: null,
+      message: `Failed to extract footage audio, exit code: ${code}`,
+    });
+  }
+
+  return outputFile;
+});
+
+const getAudioDurationSeconds = Effect.fn("getAudioDurationSeconds")(function* (
+  audioPath: string
+) {
+  const result = yield* Command.string(
+    Command.make(
+      "ffprobe",
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration",
+      "-of",
+      "default=noprint_wrappers=1:nokey=1",
+      audioPath
+    )
+  ).pipe(
+    Effect.mapError(
+      (e) =>
+        new CouldNotExtractFootageAudioError({
+          cause: e,
+          message: `Failed to read audio duration: ${e.message}`,
+        })
+    )
+  );
+  return Number(result.trim());
+});
+
+/**
+ * Transcribe a whole raw footage file. Extracts the full audio (mono 64k); if it
+ * fits under Whisper's 25MB cap it is one pass, otherwise the file is split into
+ * ~27-minute chunks cut at detected silence (never mid-word), each transcribed
+ * on its own, and the pieces' timestamps offset back onto the file's timeline
+ * and merged. No diarization, ever.
+ */
+export const transcribeFootage = <E, R>(
+  deps: {
+    readonly ffmpegCommands: FFmpegCommandsService;
+    readonly transcribeAudioFile: (
+      audioPath: string
+    ) => Effect.Effect<FootageTranscript, E, R>;
+  },
+  inputVideo: string
+) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+
+    const fullAudio = yield* extractFootageAudio(inputVideo);
+    const stat = yield* fs.stat(fullAudio);
+
+    if (Number(stat.size) <= WHISPER_MAX_UPLOAD_BYTES) {
+      const transcription = yield* deps.transcribeAudioFile(fullAudio);
+      yield* fs.remove(fullAudio).pipe(Effect.catchAll(() => Effect.void));
+      return transcription;
+    }
+
+    // Too large for one upload: split at silence near the target size.
+    const durationSeconds = yield* getAudioDurationSeconds(fullAudio);
+    const { clips } = yield* findSilenceInVideo(
+      deps.ffmpegCommands,
+      inputVideo
+    );
+    // The end of each speaking clip is where the file falls silent — the only
+    // place it is safe to cut without splitting a spoken word.
+    const silencePoints = clips.map((clip) => clip.endTime);
+    const boundaries = planChunkBoundaries({ durationSeconds, silencePoints });
+
+    // Sequential: transcribeAudioFile already bounds Whisper concurrency with a
+    // semaphore, and chunking exists to stay UNDER a limit, not to fan one file
+    // out across the whole permit budget.
+    const chunks = yield* Effect.forEach(boundaries, (boundary) =>
+      Effect.gen(function* () {
+        const chunkAudio = yield* extractFootageAudio(
+          inputVideo,
+          boundary.start,
+          boundary.end - boundary.start
+        );
+        const transcription = yield* deps.transcribeAudioFile(chunkAudio);
+        yield* fs.remove(chunkAudio).pipe(Effect.catchAll(() => Effect.void));
+        return {
+          offset: boundary.start,
+          words: transcription.words,
+          segments: transcription.segments,
+        };
+      })
+    );
+
+    yield* fs.remove(fullAudio).pipe(Effect.catchAll(() => Effect.void));
+
+    return mergeChunkTranscripts(chunks);
+  });

--- a/apps/local/app/services/video-processing-service.ts
+++ b/apps/local/app/services/video-processing-service.ts
@@ -8,6 +8,7 @@ import { homedir, tmpdir } from "os";
 import OpenAI from "openai";
 import { FFmpegCommandsService } from "./ffmpeg-commands";
 import { findSilenceInVideo } from "./silence-detection";
+import { transcribeFootage } from "./footage-transcription";
 import { VideoEditorLoggerService } from "./video-editor-logger-service";
 import { makeFfmpegLogger } from "./ffmpeg-video-logger";
 import type { SilenceLength } from "@/silence-detection-constants";
@@ -414,6 +415,17 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
         return transcription;
       });
 
+      /**
+       * Transcribe a whole raw FOOTAGE file (see CONTEXT.md "Footage"): a file on
+       * disk that is not — and never becomes — a database row. The ffmpeg +
+       * silence-chunking orchestration lives in {@link transcribeFootage} (split
+       * out only for the file-size budget); it reuses THIS service's
+       * {@link transcribeAudioFile} per chunk, so faking VideoProcessingService
+       * still fakes all of footage transcription. No diarization, ever.
+       */
+      const transcribeFootageFile = (inputVideo: string) =>
+        transcribeFootage({ ffmpegCommands, transcribeAudioFile }, inputVideo);
+
       const getLastFrame = Effect.fn("getLastFrame")(function* (
         inputVideo: string,
         seekTo: number
@@ -617,6 +629,7 @@ export class VideoProcessingService extends Effect.Service<VideoProcessingServic
         exportVideoClips,
         transcribeClips,
         transcribeVideoFile,
+        transcribeFootageFile,
         getLastFrame,
         getFirstFrame,
         sendClipsToDavinciResolve,

--- a/apps/remote/app.ts
+++ b/apps/remote/app.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { authenticate } from "./auth.js";
 import { beatRoutes } from "./routes/beat.js";
+import { chapterRoutes } from "./routes/chapter.js";
 import { clipRoutes } from "./routes/clip.js";
 import { courseRoutes } from "./routes/course.js";
 import { deliverableRoutes } from "./routes/deliverable.js";
@@ -48,6 +49,7 @@ export const createApp = (runtime: RemoteRuntime) =>
     .route("/rpc/lesson", lessonRoutes(runtime))
     .route("/rpc/video", videoRoutes(runtime))
     .route("/rpc/clip", clipRoutes(runtime))
+    .route("/rpc/chapter", chapterRoutes(runtime))
     .route("/rpc/beat", beatRoutes(runtime))
     .route("/rpc/pitch", pitchRoutes(runtime))
     .route("/rpc/deliverable", deliverableRoutes(runtime));

--- a/apps/remote/routes/chapter.ts
+++ b/apps/remote/routes/chapter.ts
@@ -1,0 +1,41 @@
+import { ClipOperationsService } from "@cvm/core/services/db-clip-operations.server";
+import { Hono } from "hono";
+import { forward } from "../rpc.js";
+import type { RemoteRuntime } from "../runtime.js";
+
+/**
+ * The `chapter` verb group: `cvm chapter list | get | add | update | move |
+ * delete`.
+ *
+ * Chapters live on the SAME service as Clips (ClipOperationsService merges the
+ * chapter ops in), because Clips and Chapters share one fractional order space —
+ * so `add`/`move` position against the merged clip+chapter timeline the CLI
+ * reads through `clip.listTimelineOrder`. These endpoints just expose the
+ * chapter methods already on that service; the DB logic is unchanged.
+ */
+export const chapterRoutes = (runtime: RemoteRuntime) =>
+  new Hono()
+    .post(
+      "/getChaptersByIds",
+      forward(runtime, ClipOperationsService, "getChaptersByIds")
+    )
+    .post(
+      "/listChaptersByVideoId",
+      forward(runtime, ClipOperationsService, "listChaptersByVideoId")
+    )
+    .post(
+      "/createChapterAtItem",
+      forward(runtime, ClipOperationsService, "createChapterAtItem")
+    )
+    .post(
+      "/updateChapter",
+      forward(runtime, ClipOperationsService, "updateChapter")
+    )
+    .post(
+      "/moveChapterToPosition",
+      forward(runtime, ClipOperationsService, "moveChapterToPosition")
+    )
+    .post(
+      "/archiveChapter",
+      forward(runtime, ClipOperationsService, "archiveChapter")
+    );

--- a/apps/remote/routes/clip.ts
+++ b/apps/remote/routes/clip.ts
@@ -4,10 +4,11 @@ import { forward } from "../rpc.js";
 import type { RemoteRuntime } from "../runtime.js";
 
 /**
- * The `clip` verb group: `cvm clip list | get | update | move | delete`.
+ * The `clip` verb group: `cvm clip list | get | add | update | move | delete`.
  *
- * `listTimelineOrder` is what `move` positions against — Clips and Chapters
- * share one fractional order key, so the anchor an agent names may be either.
+ * `listTimelineOrder` is what `move` and `add` position against — Clips and
+ * Chapters share one fractional order key, so the anchor an agent names may be
+ * either.
  */
 export const clipRoutes = (runtime: RemoteRuntime) =>
   new Hono()
@@ -15,6 +16,7 @@ export const clipRoutes = (runtime: RemoteRuntime) =>
       "/getClipsByIds",
       forward(runtime, ClipOperationsService, "getClipsByIds")
     )
+    .post("/createClip", forward(runtime, ClipOperationsService, "createClip"))
     .post(
       "/listTimelineOrder",
       forward(runtime, ClipOperationsService, "listTimelineOrder")

--- a/packages/core/lib/sort-by-order.ts
+++ b/packages/core/lib/sort-by-order.ts
@@ -1,3 +1,5 @@
+import { generateNKeysBetween } from "fractional-indexing";
+
 /**
  * Compare two order strings using ASCII/byte ordering.
  * This matches PostgreSQL's COLLATE "C" behavior.
@@ -19,4 +21,36 @@ export const compareOrderStrings = (a: string, b: string): number => {
  */
 export const sortByOrder = <T extends { order: string }>(items: T[]): T[] => {
   return [...items].sort((a, b) => compareOrderStrings(a.order, b.order));
+};
+
+/**
+ * The fractional `order` key for a new-or-moved timeline item that should land
+ * immediately BEFORE `beforeItemId` in `items` — an already merged-and-sorted
+ * clip+chapter timeline (with the item being MOVED, if any, already filtered
+ * out by the caller). `beforeItemId === null` means "append to the end".
+ *
+ * Returns `null` (and only then) when `beforeItemId` is given but not present in
+ * `items`, so the caller can raise its own noun-specific NotFoundError — a
+ * successful placement always yields a non-null key. This is the single
+ * positioning primitive shared by `createClip`/`moveClipToPosition` and
+ * `createChapterAtItem`/`moveChapterToPosition`, which otherwise repeated it
+ * verbatim and could drift apart.
+ */
+export const orderKeyBeforeItem = (
+  items: readonly { readonly id: string; readonly order: string }[],
+  beforeItemId: string | null
+): string | null => {
+  let prevOrder: string | null;
+  let nextOrder: string | null;
+  if (beforeItemId === null) {
+    prevOrder = items.at(-1)?.order ?? null;
+    nextOrder = null;
+  } else {
+    const idx = items.findIndex((item) => item.id === beforeItemId);
+    if (idx === -1) return null;
+    prevOrder = items[idx - 1]?.order ?? null;
+    nextOrder = items[idx]!.order;
+  }
+  const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
+  return order!;
 };

--- a/packages/core/services/db-chapter-operations.server.ts
+++ b/packages/core/services/db-chapter-operations.server.ts
@@ -8,7 +8,10 @@ import {
   requireDraftVersionForChapter,
   requireDraftVersionForVideo,
 } from "./draft-guard.server.js";
-import { compareOrderStrings } from "../lib/sort-by-order.js";
+import {
+  compareOrderStrings,
+  orderKeyBeforeItem,
+} from "../lib/sort-by-order.js";
 
 const makeDbCall = <T>(fn: () => Promise<T>) => {
   return Effect.tryPromise({
@@ -483,29 +486,18 @@ export const createChapterOperationsUnwrapped = (db: Database) => {
     yield* requireDraftVersionForVideo(db, videoId);
     const items = yield* mergedTimeline(videoId);
 
-    let prevOrder: string | null;
-    let nextOrder: string | null;
-    if (beforeItemId === null) {
-      prevOrder = items.at(-1)?.order ?? null;
-      nextOrder = null;
-    } else {
-      const idx = items.findIndex((item) => item.id === beforeItemId);
-      if (idx === -1) {
-        return yield* new NotFoundError({
-          type: "createChapterAtItem",
-          params: { videoId, beforeItemId },
-        });
-      }
-      prevOrder = items[idx - 1]?.order ?? null;
-      nextOrder = items[idx]!.order;
+    const order = orderKeyBeforeItem(items, beforeItemId);
+    if (order === null) {
+      return yield* new NotFoundError({
+        type: "createChapterAtItem",
+        params: { videoId, beforeItemId },
+      });
     }
-
-    const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
 
     const [chapter] = yield* makeDbCall(() =>
       db
         .insert(chapters)
-        .values({ videoId, name, order: order!, archived: false })
+        .values({ videoId, name, order, archived: false })
         .returning()
     );
     if (!chapter) {
@@ -533,30 +525,16 @@ export const createChapterOperationsUnwrapped = (db: Database) => {
       (item) => item.id !== chapterId
     );
 
-    let prevOrder: string | null;
-    let nextOrder: string | null;
-    if (beforeItemId === null) {
-      prevOrder = items.at(-1)?.order ?? null;
-      nextOrder = null;
-    } else {
-      const idx = items.findIndex((item) => item.id === beforeItemId);
-      if (idx === -1) {
-        return yield* new NotFoundError({
-          type: "moveChapterToPosition",
-          params: { chapterId: beforeItemId },
-        });
-      }
-      prevOrder = items[idx - 1]?.order ?? null;
-      nextOrder = items[idx]!.order;
+    const order = orderKeyBeforeItem(items, beforeItemId);
+    if (order === null) {
+      return yield* new NotFoundError({
+        type: "moveChapterToPosition",
+        params: { chapterId: beforeItemId },
+      });
     }
 
-    const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
-
     yield* makeDbCall(() =>
-      db
-        .update(chapters)
-        .set({ order: order! })
-        .where(eq(chapters.id, chapterId))
+      db.update(chapters).set({ order }).where(eq(chapters.id, chapterId))
     );
 
     return yield* getChapterById(chapterId);

--- a/packages/core/services/db-chapter-operations.server.ts
+++ b/packages/core/services/db-chapter-operations.server.ts
@@ -1,7 +1,7 @@
 import type { Database } from "./drizzle-service.server.js";
 import { clips, chapters } from "../db/schema.js";
 import { NotFoundError, UnknownDBServiceError } from "./db-service-errors.js";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, inArray } from "drizzle-orm";
 import { Effect } from "effect";
 import { generateNKeysBetween } from "fractional-indexing";
 import {
@@ -410,13 +410,169 @@ export const createChapterOperationsUnwrapped = (db: Database) => {
     return { success: true };
   });
 
+  /**
+   * Non-archived clips and chapters of a Video, merged and sorted by the shared
+   * fractional `order` key — the same view db-clip-operations.server.ts builds,
+   * assembled here too so `chapter add`/`chapter move` can position against both
+   * without reaching back into the Clip ops (which would re-couple the split).
+   */
+  const mergedTimeline = Effect.fn("mergedTimeline")(function* (
+    videoId: string
+  ) {
+    const allClips = yield* makeDbCall(() =>
+      db.query.clips.findMany({
+        where: and(eq(clips.videoId, videoId), eq(clips.archived, false)),
+        orderBy: asc(clips.order),
+      })
+    );
+    const allChapters = yield* makeDbCall(() =>
+      db.query.chapters.findMany({
+        where: and(eq(chapters.videoId, videoId), eq(chapters.archived, false)),
+        orderBy: asc(chapters.order),
+      })
+    );
+    return [
+      ...allClips.map((c) => ({
+        type: "clip" as const,
+        id: c.id,
+        order: c.order,
+      })),
+      ...allChapters.map((c) => ({
+        type: "chapter" as const,
+        id: c.id,
+        order: c.order,
+      })),
+    ].sort((a, b) => compareOrderStrings(a.order, b.order));
+  });
+
+  /** Active chapters of a Video, in timeline order — backs `chapter list`. */
+  const listChaptersByVideoId = Effect.fn("listChaptersByVideoId")(function* (
+    videoId: string
+  ) {
+    return yield* makeDbCall(() =>
+      db.query.chapters.findMany({
+        where: and(eq(chapters.videoId, videoId), eq(chapters.archived, false)),
+        orderBy: asc(chapters.order),
+      })
+    );
+  });
+
+  /** Fetch chapters by id (any archived state) — backs `chapter get`. */
+  const getChaptersByIds = Effect.fn("getChaptersByIds")(function* (
+    chapterIds: readonly string[]
+  ) {
+    return yield* makeDbCall(() =>
+      db.query.chapters.findMany({
+        where: inArray(chapters.id, chapterIds),
+      })
+    );
+  });
+
+  /**
+   * Create a Chapter positioned against the shared clip/chapter order space,
+   * anchored immediately before `beforeItemId` (a Clip OR Chapter id) — `null`
+   * appends to the end. The `cvm chapter add` primitive, symmetric with the
+   * Clip ops' `createClip`; the UI's autofill keeps using
+   * `createChapterAtInsertionPoint`/`createChapterAtPosition`.
+   */
+  const createChapterAtItem = Effect.fn("createChapterAtItem")(function* (
+    videoId: string,
+    name: string,
+    beforeItemId: string | null
+  ) {
+    yield* requireDraftVersionForVideo(db, videoId);
+    const items = yield* mergedTimeline(videoId);
+
+    let prevOrder: string | null;
+    let nextOrder: string | null;
+    if (beforeItemId === null) {
+      prevOrder = items.at(-1)?.order ?? null;
+      nextOrder = null;
+    } else {
+      const idx = items.findIndex((item) => item.id === beforeItemId);
+      if (idx === -1) {
+        return yield* new NotFoundError({
+          type: "createChapterAtItem",
+          params: { videoId, beforeItemId },
+        });
+      }
+      prevOrder = items[idx - 1]?.order ?? null;
+      nextOrder = items[idx]!.order;
+    }
+
+    const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
+
+    const [chapter] = yield* makeDbCall(() =>
+      db
+        .insert(chapters)
+        .values({ videoId, name, order: order!, archived: false })
+        .returning()
+    );
+    if (!chapter) {
+      return yield* new UnknownDBServiceError({
+        cause: "No chapter was returned from the database",
+      });
+    }
+    return chapter;
+  });
+
+  /**
+   * Reposition a Chapter to an explicit point in its Video's timeline, anchored
+   * immediately before `beforeItemId` (a Clip OR Chapter id) — `null` appends to
+   * the end. Mirrors the Clip ops' `moveClipToPosition`; `reorderChapter` is the
+   * one-slot nudge, this is the jump-to-position the `chapter move` CLI needs.
+   */
+  const moveChapterToPosition = Effect.fn("moveChapterToPosition")(function* (
+    chapterId: string,
+    beforeItemId: string | null
+  ) {
+    yield* requireDraftVersionForChapter(db, chapterId);
+    const chapter = yield* getChapterById(chapterId);
+
+    const items = (yield* mergedTimeline(chapter.videoId)).filter(
+      (item) => item.id !== chapterId
+    );
+
+    let prevOrder: string | null;
+    let nextOrder: string | null;
+    if (beforeItemId === null) {
+      prevOrder = items.at(-1)?.order ?? null;
+      nextOrder = null;
+    } else {
+      const idx = items.findIndex((item) => item.id === beforeItemId);
+      if (idx === -1) {
+        return yield* new NotFoundError({
+          type: "moveChapterToPosition",
+          params: { chapterId: beforeItemId },
+        });
+      }
+      prevOrder = items[idx - 1]?.order ?? null;
+      nextOrder = items[idx]!.order;
+    }
+
+    const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
+
+    yield* makeDbCall(() =>
+      db
+        .update(chapters)
+        .set({ order: order! })
+        .where(eq(chapters.id, chapterId))
+    );
+
+    return yield* getChapterById(chapterId);
+  });
+
   return {
     createChapter,
     createChapterAtInsertionPoint,
     createChapterAtPosition,
+    createChapterAtItem,
     getChapterById,
+    getChaptersByIds,
+    listChaptersByVideoId,
     updateChapter,
     archiveChapter,
     reorderChapter,
+    moveChapterToPosition,
   };
 };

--- a/packages/core/services/db-clip-operations.server.ts
+++ b/packages/core/services/db-clip-operations.server.ts
@@ -294,6 +294,67 @@ const createClipOperationsUnwrapped = (db: Database) => {
     return yield* getClipById(clipId);
   });
 
+  /**
+   * Create ONE Clip on a Video's timeline, positioned against the shared
+   * clip/chapter order space exactly like `moveClipToPosition`: anchored
+   * immediately before `beforeItemId` (a Clip OR Chapter id), or appended to the
+   * end when it is `null`.
+   *
+   * Unlike `appendClips` (the OBS-capture / create-from-selection bulk path,
+   * which always writes empty `text`), this carries the `text` the caller has
+   * already sliced from the cached Footage transcript — the manual
+   * `cvm clip add` path. It goes through the SAME draft-version write-closure
+   * guard as every other clip write (a non-Draft owning version is refused).
+   */
+  const createClip = Effect.fn("createClip")(function* (opts: {
+    videoId: string;
+    videoFilename: string;
+    sourceStartTime: number;
+    sourceEndTime: number;
+    text: string;
+    beforeItemId: string | null;
+  }) {
+    yield* requireDraftVersionForVideo(db, opts.videoId);
+
+    const items = yield* listTimelineOrder(opts.videoId);
+
+    let prevOrder: string | null;
+    let nextOrder: string | null;
+    if (opts.beforeItemId === null) {
+      prevOrder = items.at(-1)?.order ?? null;
+      nextOrder = null;
+    } else {
+      const idx = items.findIndex((item) => item.id === opts.beforeItemId);
+      if (idx === -1) {
+        return yield* new NotFoundError({
+          type: "createClip",
+          params: { videoId: opts.videoId, beforeItemId: opts.beforeItemId },
+        });
+      }
+      prevOrder = items[idx - 1]?.order ?? null;
+      nextOrder = items[idx]!.order;
+    }
+
+    const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
+
+    const [clip] = yield* makeDbCall(() =>
+      db
+        .insert(clips)
+        .values({
+          videoId: opts.videoId,
+          videoFilename: opts.videoFilename,
+          sourceStartTime: opts.sourceStartTime,
+          sourceEndTime: opts.sourceEndTime,
+          order: order!,
+          archived: false,
+          text: opts.text,
+        })
+        .returning()
+    );
+
+    return clip!;
+  });
+
   const chapterOps = createChapterOperationsUnwrapped(db);
 
   const appendClips = Effect.fn("addClips")(function* (opts: {
@@ -459,6 +520,7 @@ const createClipOperationsUnwrapped = (db: Database) => {
     reorderClip,
     listTimelineOrder,
     moveClipToPosition,
+    createClip,
     ...chapterOps,
     appendClips,
     createClipWebLinks,
@@ -474,12 +536,15 @@ export const createClipOperations = (db: Database) =>
     "archiveClip",
     "reorderClip",
     "moveClipToPosition",
+    "createClip",
     "createChapter",
     "createChapterAtInsertionPoint",
     "createChapterAtPosition",
+    "createChapterAtItem",
     "updateChapter",
     "archiveChapter",
     "reorderChapter",
+    "moveChapterToPosition",
     "appendClips",
     "createClipWebLinks",
     "deleteClipWebLink",

--- a/packages/core/services/db-clip-operations.server.ts
+++ b/packages/core/services/db-clip-operations.server.ts
@@ -10,7 +10,10 @@ import {
   requireDraftVersionForVideo,
 } from "./draft-guard.server.js";
 import { transactionalizeWrites } from "./with-db-transaction.server.js";
-import { compareOrderStrings } from "../lib/sort-by-order.js";
+import {
+  compareOrderStrings,
+  orderKeyBeforeItem,
+} from "../lib/sort-by-order.js";
 import {
   checkClipZoomEligibility,
   clipZoomIneligibilityMessage,
@@ -268,27 +271,16 @@ const createClipOperationsUnwrapped = (db: Database) => {
       (item) => item.id !== clipId
     );
 
-    let prevOrder: string | null;
-    let nextOrder: string | null;
-    if (beforeItemId === null) {
-      prevOrder = items.at(-1)?.order ?? null;
-      nextOrder = null;
-    } else {
-      const idx = items.findIndex((item) => item.id === beforeItemId);
-      if (idx === -1) {
-        return yield* new NotFoundError({
-          type: "moveClipToPosition",
-          params: { clipId: beforeItemId },
-        });
-      }
-      prevOrder = items[idx - 1]?.order ?? null;
-      nextOrder = items[idx]!.order;
+    const order = orderKeyBeforeItem(items, beforeItemId);
+    if (order === null) {
+      return yield* new NotFoundError({
+        type: "moveClipToPosition",
+        params: { clipId: beforeItemId },
+      });
     }
 
-    const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
-
     yield* makeDbCall(() =>
-      db.update(clips).set({ order: order! }).where(eq(clips.id, clipId))
+      db.update(clips).set({ order }).where(eq(clips.id, clipId))
     );
 
     return yield* getClipById(clipId);
@@ -318,24 +310,13 @@ const createClipOperationsUnwrapped = (db: Database) => {
 
     const items = yield* listTimelineOrder(opts.videoId);
 
-    let prevOrder: string | null;
-    let nextOrder: string | null;
-    if (opts.beforeItemId === null) {
-      prevOrder = items.at(-1)?.order ?? null;
-      nextOrder = null;
-    } else {
-      const idx = items.findIndex((item) => item.id === opts.beforeItemId);
-      if (idx === -1) {
-        return yield* new NotFoundError({
-          type: "createClip",
-          params: { videoId: opts.videoId, beforeItemId: opts.beforeItemId },
-        });
-      }
-      prevOrder = items[idx - 1]?.order ?? null;
-      nextOrder = items[idx]!.order;
+    const order = orderKeyBeforeItem(items, opts.beforeItemId);
+    if (order === null) {
+      return yield* new NotFoundError({
+        type: "createClip",
+        params: { videoId: opts.videoId, beforeItemId: opts.beforeItemId },
+      });
     }
-
-    const [order] = generateNKeysBetween(prevOrder, nextOrder, 1);
 
     const [clip] = yield* makeDbCall(() =>
       db
@@ -345,7 +326,7 @@ const createClipOperationsUnwrapped = (db: Database) => {
           videoFilename: opts.videoFilename,
           sourceStartTime: opts.sourceStartTime,
           sourceEndTime: opts.sourceEndTime,
-          order: order!,
+          order,
           archived: false,
           text: opts.text,
         })


### PR DESCRIPTION
Closes #1553

Points an agent at raw footage on disk and lets it transcribe, cut into Clips, and group into Chapters — all before the editor.

## What's here

### 1. `cvm footage` — new filesystem-native noun, NO database row
Identity is a path; the transcript is cached in a sidecar (`<path>.transcript.json`) next to the source, keyed by a **content hash** of the source so a re-recorded/replaced file re-transcribes instead of serving stale data. All verbs are local-only (`requireLocalMachine` with a new `NEEDS_FOOTAGE_ON_DISK` reason).
- `footage list [--dir <path>]` — video files in a dir (default `OBS_RECORDING_DIR`, else `~/Videos`), with a `transcribed` flag.
- `footage transcribe <path>` — extracts **mono 64kbps** audio (a new path, separate from the 384kbps stereo per-clip one); a file whose audio exceeds Whisper's 25MB cap is split into ~27-min chunks cut at detected silence (built on `findSilenceInVideo`), each transcribed with `whisper-1` (`["segment","word"]`), then offset + merged onto one timeline. No diarization.
- `footage transcript <path>` — reads the sidecar only (re-validates the hash; stale/absent ⇒ not-found).

### 2. `cvm clip add` — new write verb
`clip add --video <id> --source <path> --start <t> --end <t> [--before <id> | --after <id>]`. Text is sliced from the source footage's **cached** transcript (no live Whisper; fails cleanly if not transcribed). Goes through the full RPC path (new `createClip` on `ClipOperationsService` → `/rpc/clip/createClip` → rpc-layer), positions with `generateNKeysBetween` over the shared clip/chapter order space, and is subject to the same draft-version write guard as every other clip write. The stale "there is no clip add" docstrings in `clip.ts` are updated.

### 3. `cvm chapter` — new noun
`chapter list | get | add | update | move | delete`, mirroring `clip.ts`. Exposes the existing chapter DB ops; adds a symmetric `createChapterAtItem` / `moveChapterToPosition` (arbitrary-position insert/reposint, since only nudge existed) plus `listChaptersByVideoId` / `getChaptersByIds` for read symmetry, new `/rpc/chapter` routes, and rpc-layer entries. Registered in `index.ts`.

### Docs
CONTEXT.md gains a **Footage** entry (noting it has no DB row) + cross-refs on **Clip** and **Video File**; root and per-noun `--help` updated (help split into `clip.help.ts`/`footage.help.ts`/`chapter.help.ts` to stay under the token budget).

## Test plan
- [x] `apps/local/app/services/footage-chunking.test.ts` — chunk-boundary planning (lands near target at real silence, incl. via `mockFFmpeg`+`findSilenceInVideo`) and timestamp-merge offsetting; text slicing.
- [x] `cli-footage-writes.test.ts` — list/transcribe/transcript with `VideoProcessingService` faked via `Layer.succeed` (no real ffmpeg/OpenAI); sidecar written keyed by hash; stale/re-transcribe paths.
- [x] `cli-clip-writes.test.ts` — clip add: text slicing, default append, `--before`/`--after`, missing-transcript error, unknown video.
- [x] `cli-chapter-writes.test.ts` — add/update/move/delete/list/get over the shared order space.
- [x] `cli-local-only.test.ts` — footage verbs refused (exit 7, `LocalOnlyCommandError`).
- [x] `pnpm typecheck`, `pnpm lint:boundaries`, `check:file-tokens`, `format:check` — all green (filesystem/ffmpeg logic stays in `apps/local`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)