### PR TITLE
Centre diagrams around the face-cam, with a live debug panel to tune it

### DIFF
--- a/apps/local/app/features/diagrams/centre-camera-on-content.test.ts
+++ b/apps/local/app/features/diagrams/centre-camera-on-content.test.ts
@@ -1,13 +1,39 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { Editor } from "tldraw";
 import { centreCameraOnContent } from "./centre-camera-on-content";
-import { getCenteringSettings } from "./diagram-centering-settings";
+import {
+  CENTERING_STORAGE_KEYS,
+  type CenteringSettings,
+} from "./diagram-centering-settings";
 
-vi.mock("./diagram-centering-settings", () => ({
-  getCenteringSettings: vi.fn(),
-}));
+/**
+ * `localStorage` is a system boundary, so it is the one thing here worth
+ * faking — `getCenteringSettings` runs for real, through the settings
+ * module's own reads, the same way `recent-icons.test.ts` fakes it for the
+ * palette rather than mocking the module that wraps it.
+ */
+let store: Map<string, string>;
 
-const mockGetCenteringSettings = vi.mocked(getCenteringSettings);
+beforeEach(() => {
+  store = new Map();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+  };
+});
+
+afterEach(() => {
+  delete (globalThis as { localStorage?: unknown }).localStorage;
+});
+
+function seedSettings(settings: Partial<CenteringSettings>) {
+  for (const [key, value] of Object.entries(settings)) {
+    store.set(
+      CENTERING_STORAGE_KEYS[key as keyof typeof CENTERING_STORAGE_KEYS],
+      String(value)
+    );
+  }
+}
 
 /**
  * A stand-in for tldraw's `Editor` — a third-party boundary. Only the camera
@@ -39,14 +65,6 @@ function fakeEditor(opts: {
 }
 
 describe("centreCameraOnContent", () => {
-  beforeEach(() => {
-    mockGetCenteringSettings.mockReturnValue({
-      faceCamWidth: 0,
-      paddingX: 0,
-      paddingY: 0,
-    });
-  });
-
   it("frames the page's content dead-centre when no face-cam room is reserved", () => {
     const { editor, calls } = fakeEditor({
       bounds: { x: 100, y: 200, w: 400, h: 300 },
@@ -61,11 +79,7 @@ describe("centreCameraOnContent", () => {
   });
 
   it("reserves a full-height strip on the right for the face-cam", () => {
-    mockGetCenteringSettings.mockReturnValue({
-      faceCamWidth: 200,
-      paddingX: 0,
-      paddingY: 0,
-    });
+    seedSettings({ faceCamWidth: 200 });
     const { editor, calls } = fakeEditor({
       bounds: { x: 0, y: 0, w: 100, h: 100 },
     });
@@ -78,11 +92,7 @@ describe("centreCameraOnContent", () => {
   });
 
   it("insets the diagram by paddingX/paddingY on every side", () => {
-    mockGetCenteringSettings.mockReturnValue({
-      faceCamWidth: 0,
-      paddingX: 50,
-      paddingY: 20,
-    });
+    seedSettings({ paddingX: 50, paddingY: 20 });
     const { editor, calls } = fakeEditor({
       bounds: { x: 0, y: 0, w: 100, h: 100 },
     });

--- a/apps/local/app/features/diagrams/centre-camera-on-content.test.ts
+++ b/apps/local/app/features/diagrams/centre-camera-on-content.test.ts
@@ -1,32 +1,97 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Editor } from "tldraw";
 import { centreCameraOnContent } from "./centre-camera-on-content";
+import { getCenteringSettings } from "./diagram-centering-settings";
+
+vi.mock("./diagram-centering-settings", () => ({
+  getCenteringSettings: vi.fn(),
+}));
+
+const mockGetCenteringSettings = vi.mocked(getCenteringSettings);
 
 /**
  * A stand-in for tldraw's `Editor` — a third-party boundary. Only the camera
  * call matters here, so the fake records it rather than simulating it.
  */
-function fakeEditor(
-  bounds: { x: number; y: number; w: number; h: number } | undefined,
-  baseZoom = 1
-) {
-  const calls: Array<{ bounds: unknown; opts: unknown }> = [];
+function fakeEditor(opts: {
+  bounds: { x: number; y: number; w: number; h: number } | undefined;
+  viewport?: { x: number; y: number; w: number; h: number };
+  baseZoom?: number;
+  zoomSteps?: number[];
+}) {
+  const {
+    bounds,
+    viewport = { x: 0, y: 0, w: 1000, h: 800 },
+    baseZoom = 1,
+    zoomSteps = [0.1, 8],
+  } = opts;
+  const calls: Array<{ point: unknown; opts: unknown }> = [];
   const editor = {
     getCurrentPageBounds: () => bounds,
+    getViewportScreenBounds: () => viewport,
     getBaseZoom: () => baseZoom,
-    zoomToBounds: (b: unknown, opts: unknown) => {
-      calls.push({ bounds: b, opts });
+    getCameraOptions: () => ({ zoomSteps }),
+    setCamera: (point: unknown, cameraOpts: unknown) => {
+      calls.push({ point, opts: cameraOpts });
     },
   } as unknown as Editor;
   return { editor, calls };
 }
 
 describe("centreCameraOnContent", () => {
-  it("frames the page's content", () => {
-    const { editor, calls } = fakeEditor({ x: 100, y: 200, w: 400, h: 300 });
+  beforeEach(() => {
+    mockGetCenteringSettings.mockReturnValue({
+      faceCamWidth: 0,
+      paddingX: 0,
+      paddingY: 0,
+    });
+  });
+
+  it("frames the page's content dead-centre when no face-cam room is reserved", () => {
+    const { editor, calls } = fakeEditor({
+      bounds: { x: 100, y: 200, w: 400, h: 300 },
+    });
     centreCameraOnContent(editor);
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.bounds).toEqual({ x: 100, y: 200, w: 400, h: 300 });
+    // zoom = min(1000/400, 800/300) = 2.5, capped at baseZoom 1
+    // x = -100 + (0 + (1000 - 400*1)/2)/1 = 200
+    // y = -200 + (0 + (800 - 300*1)/2)/1 = 50
+    expect(calls[0]!.point).toMatchObject({ x: 200, y: 50, z: 1 });
+    expect(calls[0]!.opts).toMatchObject({ immediate: true });
+  });
+
+  it("reserves a full-height strip on the right for the face-cam", () => {
+    mockGetCenteringSettings.mockReturnValue({
+      faceCamWidth: 200,
+      paddingX: 0,
+      paddingY: 0,
+    });
+    const { editor, calls } = fakeEditor({
+      bounds: { x: 0, y: 0, w: 100, h: 100 },
+    });
+    centreCameraOnContent(editor);
+    // safeWidth = 1000 - 200 = 800, safeHeight = 800 (full height, unaffected)
+    // fit zoom = min(800/100, 800/100) = 8, capped at baseZoom 1
+    // x = -0 + (0 + (800 - 100*1)/2)/1 = 350
+    // y = -0 + (0 + (800 - 100*1)/2)/1 = 350
+    expect(calls[0]!.point).toMatchObject({ x: 350, y: 350, z: 1 });
+  });
+
+  it("insets the diagram by paddingX/paddingY on every side", () => {
+    mockGetCenteringSettings.mockReturnValue({
+      faceCamWidth: 0,
+      paddingX: 50,
+      paddingY: 20,
+    });
+    const { editor, calls } = fakeEditor({
+      bounds: { x: 0, y: 0, w: 100, h: 100 },
+    });
+    centreCameraOnContent(editor);
+    // safeWidth = 1000 - 100 = 900, safeHeight = 800 - 40 = 760
+    // fit zoom = min(900/100, 760/100) = 7.6, capped at baseZoom 1
+    // x = -0 + (50 + (900 - 100*1)/2)/1 = 450
+    // y = -0 + (20 + (760 - 100*1)/2)/1 = 350
+    expect(calls[0]!.point).toMatchObject({ x: 450, y: 350, z: 1 });
   });
 
   it("never zooms in past the editor's own 100%", () => {
@@ -34,15 +99,18 @@ describe("centreCameraOnContent", () => {
     // out to fit, but a single small shape does not fill the screen at 8x. The
     // cap is whatever this editor calls 100% — not a hardcoded 1, which camera
     // constraints can move.
-    const { editor, calls } = fakeEditor({ x: 0, y: 0, w: 10, h: 10 }, 2);
+    const { editor, calls } = fakeEditor({
+      bounds: { x: 0, y: 0, w: 10, h: 10 },
+      baseZoom: 2,
+    });
     centreCameraOnContent(editor);
-    expect(calls[0]!.opts).toMatchObject({ targetZoom: 2 });
+    expect(calls[0]!.point).toMatchObject({ z: 2 });
   });
 
   it("leaves the camera alone when the page is empty", () => {
     // Restoring an empty snapshot has nothing to centre on; moving the camera
     // to some arbitrary spot would just lose the author's place.
-    const { editor, calls } = fakeEditor(undefined);
+    const { editor, calls } = fakeEditor({ bounds: undefined });
     centreCameraOnContent(editor);
     expect(calls).toHaveLength(0);
   });

--- a/apps/local/app/features/diagrams/centre-camera-on-content.ts
+++ b/apps/local/app/features/diagrams/centre-camera-on-content.ts
@@ -1,5 +1,8 @@
 import type { Editor } from "tldraw";
-import { getCenteringSettings } from "./diagram-centering-settings";
+import {
+  getCenteringSettings,
+  getSafeAreaInsets,
+} from "./diagram-centering-settings";
 
 /**
  * Bring the whole page into view, centred within whatever space is left
@@ -10,10 +13,11 @@ import { getCenteringSettings } from "./diagram-centering-settings";
  * empty space, which reads as "the restore did nothing". Every load of a
  * scene calls this so the content is always where the author is looking.
  *
- * The face-cam itself is composited on top of the recording by external
- * software — this window has no visibility into it (ADR 0004) — so how much
- * room to leave for it is not something that can be computed, only tuned by
- * eye. `diagram-centering-settings` is that tuned, persisted answer: a
+ * This window doubles as the literal screen-recording surface (ADR 0004),
+ * and the presenter's face-cam is composited on top of that recording by
+ * external software — invisible to tldraw/CVM entirely. So how much room to
+ * leave for it is not something that can be computed, only tuned by eye.
+ * `diagram-centering-settings` is that tuned, persisted answer: a
  * full-height strip of `faceCamWidth` screen pixels is reserved on the
  * right, and the diagram is fit-and-centred within what's left, inset by
  * `paddingX`/`paddingY` on every side. This is the one function that turns
@@ -31,14 +35,15 @@ export function centreCameraOnContent(editor: Editor): void {
   const bounds = editor.getCurrentPageBounds();
   if (!bounds) return;
 
-  const { faceCamWidth, paddingX, paddingY } = getCenteringSettings();
+  const settings = getCenteringSettings();
+  const insets = getSafeAreaInsets(settings);
   const viewport = editor.getViewportScreenBounds();
 
   // The rectangle (in screen pixels) the diagram is allowed to occupy: the
-  // viewport minus the reserved face-cam strip on the right, inset by the
-  // padding on every side.
-  const safeWidth = Math.max(viewport.w - faceCamWidth - paddingX * 2, 1);
-  const safeHeight = Math.max(viewport.h - paddingY * 2, 1);
+  // viewport, inset on every side by `insets` — the same insets the debug
+  // panel's guide-box overlay renders directly as CSS.
+  const safeWidth = Math.max(viewport.w - insets.left - insets.right, 1);
+  const safeHeight = Math.max(viewport.h - insets.top - insets.bottom, 1);
 
   const { zoomSteps } = editor.getCameraOptions();
   const baseZoom = editor.getBaseZoom();
@@ -51,8 +56,8 @@ export function centreCameraOnContent(editor: Editor): void {
 
   editor.setCamera(
     {
-      x: -bounds.x + (paddingX + (safeWidth - bounds.w * zoom) / 2) / zoom,
-      y: -bounds.y + (paddingY + (safeHeight - bounds.h * zoom) / 2) / zoom,
+      x: -bounds.x + (insets.left + (safeWidth - bounds.w * zoom) / 2) / zoom,
+      y: -bounds.y + (insets.top + (safeHeight - bounds.h * zoom) / 2) / zoom,
       z: zoom,
     },
     { immediate: true }

--- a/apps/local/app/features/diagrams/centre-camera-on-content.ts
+++ b/apps/local/app/features/diagrams/centre-camera-on-content.ts
@@ -1,23 +1,60 @@
 import type { Editor } from "tldraw";
+import { getCenteringSettings } from "./diagram-centering-settings";
 
 /**
- * Bring the whole page into view, centred, without zooming past 100%.
+ * Bring the whole page into view, centred within whatever space is left
+ * after reserving room for the presenter's face-cam.
  *
  * Camera state is deliberately not persisted (ADR 0003), so loading a scene
- * leaves the camera wherever the last one left it — routinely pointing at empty
- * space, which reads as "the restore did nothing". Every load of a scene calls
- * this so the content is always where the author is looking.
+ * leaves the camera wherever the last one left it — routinely pointing at
+ * empty space, which reads as "the restore did nothing". Every load of a
+ * scene calls this so the content is always where the author is looking.
  *
- * `targetZoom` is a *cap* in tldraw, not a target: a large diagram still zooms
- * out to fit, while a single small shape is centred at 100% instead of being
- * blown up to the 8x zoom limit. This mirrors tldraw's own behaviour when it
- * follows a deep link.
+ * The face-cam itself is composited on top of the recording by external
+ * software — this window has no visibility into it (ADR 0004) — so how much
+ * room to leave for it is not something that can be computed, only tuned by
+ * eye. `diagram-centering-settings` is that tuned, persisted answer: a
+ * full-height strip of `faceCamWidth` screen pixels is reserved on the
+ * right, and the diagram is fit-and-centred within what's left, inset by
+ * `paddingX`/`paddingY` on every side. This is the one function that turns
+ * those numbers into a camera move, so every automatic recentre (scene load,
+ * restore, palette search, the manual recentre hotkey, and the debug panel's
+ * live preview) agrees on where "centred" means.
+ *
+ * `targetZoom` is a *cap*, not a target: a large diagram still zooms out to
+ * fit, while a single small shape is centred at 100% instead of being blown
+ * up past it. This mirrors tldraw's own `zoomToBounds`, whose fit-and-clamp
+ * math this reimplements by hand — `zoomToBounds` only fits into the full
+ * viewport, centred, and can't target an off-centre sub-region of it.
  */
 export function centreCameraOnContent(editor: Editor): void {
   const bounds = editor.getCurrentPageBounds();
   if (!bounds) return;
-  editor.zoomToBounds(bounds, {
-    targetZoom: editor.getBaseZoom(),
-    immediate: true,
-  });
+
+  const { faceCamWidth, paddingX, paddingY } = getCenteringSettings();
+  const viewport = editor.getViewportScreenBounds();
+
+  // The rectangle (in screen pixels) the diagram is allowed to occupy: the
+  // viewport minus the reserved face-cam strip on the right, inset by the
+  // padding on every side.
+  const safeWidth = Math.max(viewport.w - faceCamWidth - paddingX * 2, 1);
+  const safeHeight = Math.max(viewport.h - paddingY * 2, 1);
+
+  const { zoomSteps } = editor.getCameraOptions();
+  const baseZoom = editor.getBaseZoom();
+  const zoomMin = (zoomSteps?.[0] ?? 1) * baseZoom;
+  const zoomMax = (zoomSteps?.[zoomSteps.length - 1] ?? 1) * baseZoom;
+
+  const fitZoom = Math.min(safeWidth / bounds.w, safeHeight / bounds.h);
+  const clampedZoom = Math.min(Math.max(fitZoom, zoomMin), zoomMax);
+  const zoom = Math.min(baseZoom, clampedZoom);
+
+  editor.setCamera(
+    {
+      x: -bounds.x + (paddingX + (safeWidth - bounds.w * zoom) / 2) / zoom,
+      y: -bounds.y + (paddingY + (safeHeight - bounds.h * zoom) / 2) / zoom,
+      z: zoom,
+    },
+    { immediate: true }
+  );
 }

--- a/apps/local/app/features/diagrams/diagram-centering-debug.tsx
+++ b/apps/local/app/features/diagrams/diagram-centering-debug.tsx
@@ -3,7 +3,10 @@ import type { Editor } from "tldraw";
 import { SlidersHorizontal } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { centreCameraOnContent } from "./centre-camera-on-content";
-import { useCenteringSetting } from "./diagram-centering-settings";
+import {
+  getSafeAreaInsets,
+  useCenteringSetting,
+} from "./diagram-centering-settings";
 
 /**
  * A prototype tuning UI (see `docs/adr` — none written yet on purpose: this
@@ -28,6 +31,10 @@ export function DiagramCenteringDebug({
   const [faceCamWidth, setFaceCamWidth] = useCenteringSetting("faceCamWidth");
   const [paddingX, setPaddingX] = useCenteringSetting("paddingX");
   const [paddingY, setPaddingY] = useCenteringSetting("paddingY");
+  // Same insets `centreCameraOnContent` computes the camera move from — the
+  // guide boxes below render them directly as CSS, so they can't drift from
+  // where the diagram actually lands.
+  const insets = getSafeAreaInsets({ faceCamWidth, paddingX, paddingY });
 
   // Live-update: every persisted change re-runs the same recentre the rest
   // of the app uses, so the debug panel never drifts from real behaviour.
@@ -60,14 +67,15 @@ export function DiagramCenteringDebug({
             style={{ width: Math.max(faceCamWidth, 0) }}
           />
           {/* The padded safe rect the diagram is actually fit-and-centred
-              into — same geometry as `centreCameraOnContent`. */}
+              into — the same `getSafeAreaInsets` `centreCameraOnContent`
+              uses, rendered directly as CSS insets. */}
           <div
             className="pointer-events-none absolute z-40 border-2 border-dashed border-sky-400/70"
             style={{
-              left: Math.max(paddingX, 0),
-              right: Math.max(faceCamWidth, 0) + Math.max(paddingX, 0),
-              top: Math.max(paddingY, 0),
-              bottom: Math.max(paddingY, 0),
+              left: Math.max(insets.left, 0),
+              right: Math.max(insets.right, 0),
+              top: Math.max(insets.top, 0),
+              bottom: Math.max(insets.bottom, 0),
             }}
           />
 

--- a/apps/local/app/features/diagrams/diagram-centering-debug.tsx
+++ b/apps/local/app/features/diagrams/diagram-centering-debug.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState, type RefObject } from "react";
+import type { Editor } from "tldraw";
+import { SlidersHorizontal } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { centreCameraOnContent } from "./centre-camera-on-content";
+import { useCenteringSetting } from "./diagram-centering-settings";
+
+/**
+ * A prototype tuning UI (see `docs/adr` — none written yet on purpose: this
+ * is deliberately a debug tool, not a finished setting screen). It's how the
+ * three numbers `centreCameraOnContent` reads get found in the first place:
+ * open it, drag the values until the guide boxes and the diagram look right
+ * against your actual camera setup, close it. Nothing here needs to be
+ * pretty — it needs to be legible enough to tune live while sat in frame.
+ *
+ * Deliberately independent of Focus Mode: Focus Mode hides the Snapshot
+ * Timeline / Diagram Rail panel on the right, and tuning has to work with
+ * that panel either shown or hidden (it changes the usable canvas width), so
+ * this is mounted as a sibling of that panel, not nested inside its
+ * `!isFocusMode` conditional, and gated on its own open/closed state.
+ */
+export function DiagramCenteringDebug({
+  editorRef,
+}: {
+  editorRef: RefObject<Editor | null>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [faceCamWidth, setFaceCamWidth] = useCenteringSetting("faceCamWidth");
+  const [paddingX, setPaddingX] = useCenteringSetting("paddingX");
+  const [paddingY, setPaddingY] = useCenteringSetting("paddingY");
+
+  // Live-update: every persisted change re-runs the same recentre the rest
+  // of the app uses, so the debug panel never drifts from real behaviour.
+  useEffect(() => {
+    const ed = editorRef.current;
+    if (ed) centreCameraOnContent(ed);
+  }, [faceCamWidth, paddingX, paddingY, editorRef]);
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        title="Diagram centering debug mode"
+        aria-label="Toggle diagram centering debug mode"
+        aria-pressed={open}
+        className={
+          "absolute bottom-40 right-2 z-50 flex h-9 w-9 items-center justify-center rounded-full shadow hover:bg-zinc-600 " +
+          (open ? "bg-sky-600 text-white" : "bg-zinc-700 text-zinc-100")
+        }
+      >
+        <SlidersHorizontal className="h-4 w-4" />
+      </button>
+
+      {open && (
+        <>
+          {/* Reserved face-cam strip — a full-height zone on the right the
+              diagram is kept clear of. */}
+          <div
+            className="pointer-events-none absolute right-0 top-0 z-40 h-full border-l-2 border-red-500/70 bg-red-500/10"
+            style={{ width: Math.max(faceCamWidth, 0) }}
+          />
+          {/* The padded safe rect the diagram is actually fit-and-centred
+              into — same geometry as `centreCameraOnContent`. */}
+          <div
+            className="pointer-events-none absolute z-40 border-2 border-dashed border-sky-400/70"
+            style={{
+              left: Math.max(paddingX, 0),
+              right: Math.max(faceCamWidth, 0) + Math.max(paddingX, 0),
+              top: Math.max(paddingY, 0),
+              bottom: Math.max(paddingY, 0),
+            }}
+          />
+
+          <div className="absolute bottom-52 right-2 z-50 w-56 rounded-md border border-zinc-700 bg-zinc-900/95 p-3 shadow-lg">
+            <div className="mb-2 text-xs font-semibold text-zinc-300">
+              Diagram centering (debug)
+            </div>
+            <NumberField
+              label="Face-cam width"
+              value={faceCamWidth}
+              onChange={setFaceCamWidth}
+            />
+            <NumberField
+              label="Padding X"
+              value={paddingX}
+              onChange={setPaddingX}
+            />
+            <NumberField
+              label="Padding Y"
+              value={paddingY}
+              onChange={setPaddingY}
+            />
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+function NumberField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (next: number) => void;
+}) {
+  return (
+    <label className="mb-2 flex items-center justify-between gap-2 text-xs text-zinc-400 last:mb-0">
+      <span>{label}</span>
+      <Input
+        type="number"
+        step={4}
+        value={value}
+        onChange={(e) => {
+          const next = Number(e.target.value);
+          if (Number.isFinite(next)) onChange(next);
+        }}
+        className="h-7 w-20 px-2 text-right text-xs"
+      />
+    </label>
+  );
+}

--- a/apps/local/app/features/diagrams/diagram-centering-settings.ts
+++ b/apps/local/app/features/diagrams/diagram-centering-settings.ts
@@ -1,0 +1,98 @@
+import { useLocalStorage } from "@/hooks/use-local-storage";
+
+/**
+ * The presenter's face-cam is composited onto the recording by external
+ * software (OBS) in the bottom-right corner of the screen — this window has
+ * no visibility into it at all (ADR 0004: the diagram playground doubles as
+ * the recording surface, but the camera itself lives outside tldraw/CVM).
+ *
+ * These three numbers are how `centreCameraOnContent` knows how much room to
+ * leave for it: a full-height strip reserved on the right, plus breathing
+ * room (padding) around the diagram within whatever's left. There's no way
+ * to derive them — they depend on the physical size of the author's camera
+ * bubble and how it feels once composited — so they're tuned by eye via the
+ * debug panel (`diagram-centering-debug.tsx`) rather than computed.
+ *
+ * Stored globally, not per-diagram: the camera setup is a property of the
+ * recording rig, not of any one diagram.
+ */
+export const CENTERING_STORAGE_KEYS = {
+  faceCamWidth: "diagram-centering:face-cam-width",
+  paddingX: "diagram-centering:padding-x",
+  paddingY: "diagram-centering:padding-y",
+} as const;
+
+export type CenteringSettingKey = keyof typeof CENTERING_STORAGE_KEYS;
+
+/**
+ * Defaults to zero so an untuned install behaves like the old
+ * dead-centre-of-the-whole-viewport camera: no reserved strip, no padding.
+ * The debug panel is where these actually become non-zero.
+ */
+export const CENTERING_DEFAULTS: Record<CenteringSettingKey, number> = {
+  faceCamWidth: 0,
+  paddingX: 0,
+  paddingY: 0,
+};
+
+export interface CenteringSettings {
+  faceCamWidth: number;
+  paddingX: number;
+  paddingY: number;
+}
+
+function hasLocalStorage(): boolean {
+  return (
+    typeof localStorage !== "undefined" &&
+    typeof localStorage.getItem === "function"
+  );
+}
+
+function readStoredNumber(key: string, fallback: number): number {
+  if (!hasLocalStorage()) return fallback;
+  const raw = localStorage.getItem(key);
+  if (raw === null) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/**
+ * Read the current settings straight from `localStorage`. This is the one
+ * place `centreCameraOnContent` (not a React component, called from plain
+ * callbacks all over the diagram playground route) and the debug panel agree
+ * on where the numbers live.
+ */
+export function getCenteringSettings(): CenteringSettings {
+  return {
+    faceCamWidth: readStoredNumber(
+      CENTERING_STORAGE_KEYS.faceCamWidth,
+      CENTERING_DEFAULTS.faceCamWidth
+    ),
+    paddingX: readStoredNumber(
+      CENTERING_STORAGE_KEYS.paddingX,
+      CENTERING_DEFAULTS.paddingX
+    ),
+    paddingY: readStoredNumber(
+      CENTERING_STORAGE_KEYS.paddingY,
+      CENTERING_DEFAULTS.paddingY
+    ),
+  };
+}
+
+/**
+ * React form of a single setting, for the debug panel's number inputs. Reads
+ * and writes the exact same `localStorage` key {@link getCenteringSettings}
+ * reads, via the app's existing `useLocalStorage` hook.
+ */
+export function useCenteringSetting(
+  key: CenteringSettingKey
+): [number, (next: number) => void] {
+  const [raw, setRaw] = useLocalStorage(
+    CENTERING_STORAGE_KEYS[key],
+    String(CENTERING_DEFAULTS[key])
+  );
+  const parsed = Number(raw);
+  const value = Number.isFinite(parsed) ? parsed : CENTERING_DEFAULTS[key];
+  const setValue = (next: number) => setRaw(String(next));
+  return [value, setValue];
+}

--- a/apps/local/app/features/diagrams/diagram-centering-settings.ts
+++ b/apps/local/app/features/diagrams/diagram-centering-settings.ts
@@ -1,4 +1,4 @@
-import { useLocalStorage } from "@/hooks/use-local-storage";
+import { hasLocalStorage, useLocalStorage } from "@/hooks/use-local-storage";
 
 /**
  * The presenter's face-cam is composited onto the recording by external
@@ -41,13 +41,6 @@ export interface CenteringSettings {
   paddingY: number;
 }
 
-function hasLocalStorage(): boolean {
-  return (
-    typeof localStorage !== "undefined" &&
-    typeof localStorage.getItem === "function"
-  );
-}
-
 function readStoredNumber(key: string, fallback: number): number {
   if (!hasLocalStorage()) return fallback;
   const raw = localStorage.getItem(key);
@@ -76,6 +69,30 @@ export function getCenteringSettings(): CenteringSettings {
       CENTERING_STORAGE_KEYS.paddingY,
       CENTERING_DEFAULTS.paddingY
     ),
+  };
+}
+
+/** How far the diagram's safe area is inset from each edge of the viewport. */
+export interface SafeAreaInsets {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+/**
+ * The single definition of "the area the diagram is allowed to occupy":
+ * padding on the left/top/bottom, and the reserved face-cam strip plus
+ * padding on the right. `centreCameraOnContent` turns this into a camera
+ * move; the debug panel's guide-box overlay renders it directly as CSS
+ * insets — both read the same four numbers, so they can't drift apart.
+ */
+export function getSafeAreaInsets(settings: CenteringSettings): SafeAreaInsets {
+  return {
+    left: settings.paddingX,
+    right: settings.faceCamWidth + settings.paddingX,
+    top: settings.paddingY,
+    bottom: settings.paddingY,
   };
 }
 

--- a/apps/local/app/features/diagrams/use-recentre-diagram-shortcut.ts
+++ b/apps/local/app/features/diagrams/use-recentre-diagram-shortcut.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { isTextEntryTarget, type ShortcutTarget } from "./snapshot-navigation";
+
+function isRecentreShortcut(e: {
+  ctrlKey: boolean;
+  metaKey: boolean;
+  key: string;
+}): boolean {
+  // Cmd/Ctrl+0 — the common "reset view" convention (browsers, maps apps).
+  // Free in both tldraw's own keymap and this route's other shortcuts
+  // (Cmd/Ctrl+S/K/F/[/]).
+  return (e.ctrlKey || e.metaKey) && e.key === "0";
+}
+
+/**
+ * Snap the camera back to the tuned, face-cam-aware centred position on
+ * demand — separate from the automatic recentre on scene load/switch, for
+ * whenever the author has panned or zoomed around while working and wants to
+ * get back before hitting record.
+ */
+export function useRecentreDiagramShortcut(onRecentre: (() => void) | null) {
+  useEffect(() => {
+    if (!onRecentre) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isTextEntryTarget(e.target as ShortcutTarget | null)) return;
+      if (isRecentreShortcut(e)) {
+        e.preventDefault();
+        onRecentre();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onRecentre]);
+}

--- a/apps/local/app/hooks/use-local-storage.ts
+++ b/apps/local/app/hooks/use-local-storage.ts
@@ -15,7 +15,7 @@ import {
  * `--localstorage-file`. SSR (`renderToStaticMarkup` et al) never sets that
  * flag, so this also checks that `getItem` actually exists before use.
  */
-function hasLocalStorage(): boolean {
+export function hasLocalStorage(): boolean {
   return (
     typeof localStorage !== "undefined" &&
     typeof localStorage.getItem === "function" &&

--- a/apps/local/app/routes/diagram-playground.$diagramId.tsx
+++ b/apps/local/app/routes/diagram-playground.$diagramId.tsx
@@ -13,7 +13,9 @@ import { RestoreSnapshotDialog } from "@/features/diagrams/restore-snapshot-dial
 import { renderThumbnailPngBase64 } from "@/features/diagrams/render-thumbnail";
 import { usePreserveSnapshotShortcut } from "@/features/diagrams/preserve-snapshot-shortcut";
 import { useSnapshotStepShortcut } from "@/features/diagrams/use-snapshot-step-shortcut";
+import { useRecentreDiagramShortcut } from "@/features/diagrams/use-recentre-diagram-shortcut";
 import { centreCameraOnContent } from "@/features/diagrams/centre-camera-on-content";
+import { DiagramCenteringDebug } from "@/features/diagrams/diagram-centering-debug";
 import { copyDiagramContents } from "@/features/diagrams/copy-scene-to-clipboard";
 import {
   TimelinePanel,
@@ -210,12 +212,18 @@ export default function DiagramPlaygroundActive({
     }
   }, [saveHead]);
 
+  const recentreDiagram = useCallback(() => {
+    const ed = editorRef.current;
+    if (ed) centreCameraOnContent(ed);
+  }, []);
+
   usePreserveSnapshotShortcut(diagramId ? preserveSnapshot : null);
   useSnapshotStepShortcut({
     diagramId,
     flushPendingSave,
     onRestoreRequest: handleRestoreRequest,
   });
+  useRecentreDiagramShortcut(diagramId ? recentreDiagram : null);
 
   // Emit activeDiagramChanged on mount
   useEffect(() => {
@@ -525,6 +533,7 @@ export default function DiagramPlaygroundActive({
           editorConnected={editorConnected}
           windowFocused={windowFocused}
         />
+        {diagramId && <DiagramCenteringDebug editorRef={editorRef} />}
       </div>
       {!isFocusMode && (
         <div className="flex w-64 shrink-0 flex-col border-l border-zinc-700 bg-zinc-900">


### PR DESCRIPTION
## Summary

- The diagram playground always centred content in the *full* viewport, so it routinely lands under your face-cam — composited on top by external recording software (OBS), which this window has no visibility into (ADR 0004: it's a plain screen-recording surface). `centreCameraOnContent` now reserves a full-height strip on the right and fits the diagram into what's left, inset by X/Y padding.
- Those three numbers (`faceCamWidth`, `paddingX`, `paddingY`) can't be derived — they depend on your physical camera bubble and how it feels once composited — so instead of guessing constants, this ships the tuning tool itself: a new debug FAB (stacked above "Preserve Snapshot" and the connection status indicator, `bottom-40 right-2`) reveals a small panel with the three numbers plus two guide-box overlays (the reserved strip, and the padded fit-rect), live-persisted to `localStorage` and live-applied to the real camera on every change.
- Also adds a `Cmd/Ctrl+0` hotkey that snaps back to the tuned centre on demand — independent of debug mode, and deliberately independent of Focus Mode too (Focus Mode toggles a side panel that changes the usable canvas width, so the debug tooling has to keep working whichever way that's toggled — it's mounted as a sibling of that panel, not nested inside it).
- Defaults are all `0`, so an untuned install behaves like the old dead-centre-of-viewport camera until the debug panel is actually opened and used.

## How to use it

Open a diagram in the playground, click the new slider-icon FAB above the existing two, and drag the three numbers until the diagram sits nicely clear of your face-cam. Values persist automatically (they're global, not per-diagram, since they describe your recording rig). `Cmd/Ctrl+0` recentres on demand any time; the debug FAB just toggles whether the tuning UI is visible.

## Test plan

- [x] `pnpm typecheck` (via the repo's pre-commit hook, ran across all 4 packages) — clean
- [x] `pnpm lint:boundaries` — clean
- [x] `apps/local` diagram-feature test suite (135 tests, including 5 new/rewritten `centreCameraOnContent` cases covering: dead-centre with no reserved space, face-cam strip reservation, X/Y padding inset, the 100%-zoom cap, and the empty-page no-op) — all passing
- [ ] Manual: open the diagram playground, tune the debug panel against a real recording setup, confirm the guide boxes line up with reality

🤖 Generated with [Claude Code](https://claude.com/claude-code)