### PR TITLE
Fix diagram centering QA: sidebar-independent strip, working hotkey, palette entry

### DIFF
--- a/apps/local/app/features/diagrams/centre-camera-on-content.test.ts
+++ b/apps/local/app/features/diagrams/centre-camera-on-content.test.ts
@@ -86,10 +86,11 @@ describe("centreCameraOnContent", () => {
     });
     centreCameraOnContent(editor);
     expect(calls).toHaveLength(1);
-    // zoom = min(1000/400, 800/300) = 2.5, capped at baseZoom 1
-    // x = -100 + (0 + (1000 - 400*1)/2)/1 = 200
-    // y = -200 + (0 + (800 - 300*1)/2)/1 = 50
-    expect(calls[0]!.point).toMatchObject({ x: 200, y: 50, z: 1 });
+    // zoom = min(1000/400, 800/300) = 2.5 — width is the constraining axis,
+    // so it fills exactly; height has 50px of slack split above and below.
+    // x = -100 + (0 + (1000 - 400*2.5)/2)/2.5 = -100
+    // y = -200 + (0 + (800 - 300*2.5)/2)/2.5 = -190
+    expect(calls[0]!.point).toMatchObject({ x: -100, y: -190, z: 2.5 });
     expect(calls[0]!.opts).toMatchObject({ immediate: true });
   });
 
@@ -100,36 +101,40 @@ describe("centreCameraOnContent", () => {
     });
     centreCameraOnContent(editor);
     // safeWidth = 1000 - 200 = 800, safeHeight = 800 (full height, unaffected)
-    // fit zoom = min(800/100, 800/100) = 8, capped at baseZoom 1
-    // x = -0 + (0 + (800 - 100*1)/2)/1 = 350
-    // y = -0 + (0 + (800 - 100*1)/2)/1 = 350
-    expect(calls[0]!.point).toMatchObject({ x: 350, y: 350, z: 1 });
+    // fit zoom = min(800/100, 800/100) = 8 — both axes fill exactly.
+    // x = -0 + (0 + (800 - 100*8)/2)/8 = 0
+    // y = -0 + (0 + (800 - 100*8)/2)/8 = 0
+    expect(calls[0]!.point).toMatchObject({ x: 0, y: 0, z: 8 });
   });
 
-  it("insets the diagram by paddingX/paddingY on every side", () => {
-    seedSettings({ paddingX: 50, paddingY: 20 });
+  it("insets the diagram by paddingX/paddingY on every side — the fitted edge lands exactly on the padding line", () => {
+    seedSettings({ paddingX: 100, paddingY: 100 });
     const { editor, calls } = fakeEditor({
-      bounds: { x: 0, y: 0, w: 100, h: 100 },
+      bounds: { x: 0, y: 0, w: 200, h: 100 },
     });
     centreCameraOnContent(editor);
-    // safeWidth = 1000 - 100 = 900, safeHeight = 800 - 40 = 760
-    // fit zoom = min(900/100, 760/100) = 7.6, capped at baseZoom 1
-    // x = -0 + (50 + (900 - 100*1)/2)/1 = 450
-    // y = -0 + (20 + (760 - 100*1)/2)/1 = 350
-    expect(calls[0]!.point).toMatchObject({ x: 450, y: 350, z: 1 });
+    // safeWidth = 1000 - 200 = 800, safeHeight = 800 - 200 = 600
+    // fit zoom = min(800/200, 600/100) = 4 — width is the constraining axis.
+    // x = -0 + (100 + (800 - 200*4)/2)/4 = 25 — and 25 * 4 = 100 = paddingX
+    //     exactly: the left edge of the content lands ON the padding line,
+    //     not floating somewhere inside it (the bug this test used to hide,
+    //     back when zoom capped at 100% and left a diagram this small just
+    //     sitting in the middle of a much bigger gap).
+    // y = -0 + (100 + (600 - 100*4)/2)/4 = 50
+    expect(calls[0]!.point).toMatchObject({ x: 25, y: 50, z: 4 });
   });
 
-  it("never zooms in past the editor's own 100%", () => {
-    // `targetZoom` is a cap in tldraw, not a target: a big diagram still zooms
-    // out to fit, but a single small shape does not fill the screen at 8x. The
-    // cap is whatever this editor calls 100% — not a hardcoded 1, which camera
-    // constraints can move.
+  it("zooms in past 100% to fill the safe area, clamped only by the camera's own zoom ceiling", () => {
+    // No cap at the editor's "100%" (`baseZoom`) any more: a diagram this
+    // small would ask for 80x (min(1000/10, 800/10)) to fill the frame, which
+    // is past even this editor's own zoom ceiling (zoomSteps top * baseZoom =
+    // 8 * 2 = 16) — so the ceiling is what actually stops it, not 100%.
     const { editor, calls } = fakeEditor({
       bounds: { x: 0, y: 0, w: 10, h: 10 },
       baseZoom: 2,
     });
     centreCameraOnContent(editor);
-    expect(calls[0]!.point).toMatchObject({ z: 2 });
+    expect(calls[0]!.point).toMatchObject({ z: 16 });
   });
 
   it("leaves the camera alone when the page is empty", () => {
@@ -153,13 +158,9 @@ describe("centreCameraOnContent", () => {
       });
       withWindowWidth(1000, () => centreCameraOnContent(withSidebar));
       // safeWidth = 800 - 0 = 800, safeHeight = 800
-      // fit zoom = min(800/100, 800/100) = 8, capped at baseZoom 1
-      // x = -0 + (0 + (800 - 100)/2)/1 = 350
-      expect(withSidebarCalls[0]!.point).toMatchObject({
-        x: 350,
-        y: 350,
-        z: 1,
-      });
+      // fit zoom = min(800/100, 800/100) = 8 — both axes fill exactly.
+      // x = -0 + (0 + (800 - 100*8)/2)/8 = 0
+      expect(withSidebarCalls[0]!.point).toMatchObject({ x: 0, y: 0, z: 8 });
 
       // No sidebar (Focus Mode, or Playground Home): same window, same
       // content, the canvas now spans it and reserves the strip itself.
@@ -169,7 +170,7 @@ describe("centreCameraOnContent", () => {
       });
       withWindowWidth(1000, () => centreCameraOnContent(noSidebar));
       // safeWidth = 1000 - 200 = 800, safeHeight = 800 — identical to above.
-      expect(noSidebarCalls[0]!.point).toMatchObject({ x: 350, y: 350, z: 1 });
+      expect(noSidebarCalls[0]!.point).toMatchObject({ x: 0, y: 0, z: 8 });
     });
 
     it("still reserves whatever the sidebar doesn't already cover", () => {
@@ -183,9 +184,9 @@ describe("centreCameraOnContent", () => {
       withWindowWidth(1000, () => centreCameraOnContent(editor));
       // right inset = max(200 - 100, 0) = 100
       // safeWidth = 900 - 100 = 800, safeHeight = 800
-      // fit zoom = min(800/100, 800/100) = 8, capped at baseZoom 1
-      // x = -0 + (0 + (800 - 100)/2)/1 = 350
-      expect(calls[0]!.point).toMatchObject({ x: 350, y: 350, z: 1 });
+      // fit zoom = min(800/100, 800/100) = 8 — both axes fill exactly.
+      // x = -0 + (0 + (800 - 100*8)/2)/8 = 0
+      expect(calls[0]!.point).toMatchObject({ x: 0, y: 0, z: 8 });
     });
 
     it("falls back to reserving the full strip from the viewport's own edge without a window (SSR/tests)", () => {
@@ -193,14 +194,14 @@ describe("centreCameraOnContent", () => {
       // and it used to be the only way this function ran at all.
       seedSettings({ faceCamWidth: 200 });
       const { editor, calls } = fakeEditor({
-        bounds: { x: 0, y: 0, w: 100, h: 100 },
+        bounds: { x: 0, y: 0, w: 75, h: 100 },
         viewport: { x: 0, y: 0, w: 800, h: 800 },
       });
       centreCameraOnContent(editor);
       // safeWidth = 800 - 200 = 600, safeHeight = 800
-      // fit zoom = min(600/100, 800/100) = 6, capped at baseZoom 1
-      // x = -0 + (0 + (600 - 100)/2)/1 = 250
-      expect(calls[0]!.point).toMatchObject({ x: 250, y: 350, z: 1 });
+      // fit zoom = min(600/75, 800/100) = 8 — both axes fill exactly.
+      // x = -0 + (0 + (600 - 75*8)/2)/8 = 0
+      expect(calls[0]!.point).toMatchObject({ x: 0, y: 0, z: 8 });
     });
   });
 });

--- a/apps/local/app/features/diagrams/centre-camera-on-content.test.ts
+++ b/apps/local/app/features/diagrams/centre-camera-on-content.test.ts
@@ -81,6 +81,14 @@ function fakeEditor(opts: {
 
 describe("centreCameraOnContent", () => {
   it("frames the page's content dead-centre when no face-cam room is reserved", () => {
+    // Explicit, not implicit: CENTERING_DEFAULTS ships non-zero (Matt's own
+    // rig), so "nothing reserved" has to be seeded rather than assumed.
+    seedSettings({
+      faceCamWidth: 0,
+      paddingX: 0,
+      paddingY: 0,
+      maxZoomPercent: 800,
+    });
     const { editor, calls } = fakeEditor({
       bounds: { x: 100, y: 200, w: 400, h: 300 },
     });
@@ -95,10 +103,15 @@ describe("centreCameraOnContent", () => {
   });
 
   it("reserves a full-height strip on the right for the face-cam", () => {
-    // maxZoomPercent set high to isolate this test from the default 300%
-    // cap below — this test is about the face-cam reservation, not the
-    // zoom ceiling.
-    seedSettings({ faceCamWidth: 200, maxZoomPercent: 800 });
+    // paddingX/paddingY zeroed and maxZoomPercent set high to isolate this
+    // from CENTERING_DEFAULTS' own non-zero padding and zoom cap — this
+    // test is about the face-cam reservation alone.
+    seedSettings({
+      faceCamWidth: 200,
+      paddingX: 0,
+      paddingY: 0,
+      maxZoomPercent: 800,
+    });
     const { editor, calls } = fakeEditor({
       bounds: { x: 0, y: 0, w: 100, h: 100 },
     });
@@ -111,7 +124,12 @@ describe("centreCameraOnContent", () => {
   });
 
   it("insets the diagram by paddingX/paddingY on every side — the fitted edge lands exactly on the padding line", () => {
-    seedSettings({ paddingX: 100, paddingY: 100, maxZoomPercent: 800 });
+    seedSettings({
+      faceCamWidth: 0,
+      paddingX: 100,
+      paddingY: 100,
+      maxZoomPercent: 800,
+    });
     const { editor, calls } = fakeEditor({
       bounds: { x: 0, y: 0, w: 200, h: 100 },
     });
@@ -128,9 +146,14 @@ describe("centreCameraOnContent", () => {
   });
 
   it("zooms in past 100% to fill the safe area, clamped only by the camera's own zoom ceiling", () => {
-    // maxZoomPercent set effectively unlimited, so zoomSteps is the only
-    // thing left to demonstrate here.
-    seedSettings({ maxZoomPercent: 100_000 });
+    // Spatial settings zeroed and maxZoomPercent set effectively unlimited,
+    // so zoomSteps is the only thing left to demonstrate here.
+    seedSettings({
+      faceCamWidth: 0,
+      paddingX: 0,
+      paddingY: 0,
+      maxZoomPercent: 100_000,
+    });
     // No cap at the editor's "100%" (`baseZoom`) any more: a diagram this
     // small would ask for 80x (min(1000/10, 800/10)) to fill the frame, which
     // is past even this editor's own zoom ceiling (zoomSteps top * baseZoom =
@@ -152,16 +175,21 @@ describe("centreCameraOnContent", () => {
   });
 
   describe("maxZoomPercent", () => {
-    it("defaults to capping the fit zoom at 300% of the editor's own 100%", () => {
-      // Nothing seeded: CENTERING_DEFAULTS.maxZoomPercent is 300.
+    it("applies the real production defaults end to end when nothing has been tuned", () => {
+      // Nothing seeded: this is what a fresh install — or CENTERING_DEFAULTS
+      // itself, unedited — actually produces. A regression here means either
+      // the shipped numbers moved or the four of them stopped composing the
+      // way they're documented to.
       const { editor, calls } = fakeEditor({
         bounds: { x: 0, y: 0, w: 10, h: 10 },
       });
       centreCameraOnContent(editor);
-      // fit zoom would be min(1000/10, 800/10) = 80 — far past both the
-      // default cap (3 * baseZoom 1 = 3) and zoomSteps' own max (8), and the
-      // cap is the more restrictive of the two, so it wins.
-      expect(calls[0]!.point).toMatchObject({ z: 3 });
+      // insets: left 150, right 492 + 150 = 642, top/bottom 120.
+      // safeWidth = 1000 - 150 - 642 = 208, safeHeight = 800 - 120 - 120 = 560
+      // fit zoom = min(208/10, 560/10) = 20.8 — far past the default 225%
+      // cap (2.25 * baseZoom 1), which is the more restrictive of it and
+      // zoomSteps' own max (8), and wins.
+      expect(calls[0]!.point).toMatchObject({ z: 2.25 });
     });
 
     it("honours a configured value in place of the default", () => {
@@ -189,10 +217,15 @@ describe("centreCameraOnContent", () => {
       // The sidebar (800px of canvas left, out of a 1000px window) happens to
       // be exactly as wide as the reserved face-cam strip: the canvas can't
       // reach any of the strip, so nothing extra needs reserving from ITS
-      // edge — the sidebar is already doing that job. maxZoomPercent is set
-      // high to isolate this from the default 300% cap — this test is about
-      // the sidebar, not the zoom ceiling.
-      seedSettings({ faceCamWidth: 200, maxZoomPercent: 800 });
+      // edge — the sidebar is already doing that job. Padding zeroed and
+      // maxZoomPercent set high to isolate this from CENTERING_DEFAULTS'
+      // own non-zero padding and zoom cap — this test is about the sidebar.
+      seedSettings({
+        faceCamWidth: 200,
+        paddingX: 0,
+        paddingY: 0,
+        maxZoomPercent: 800,
+      });
       const { editor: withSidebar, calls: withSidebarCalls } = fakeEditor({
         bounds: { x: 0, y: 0, w: 100, h: 100 },
         viewport: { x: 0, y: 0, w: 800, h: 800 },
@@ -217,7 +250,12 @@ describe("centreCameraOnContent", () => {
     it("still reserves whatever the sidebar doesn't already cover", () => {
       // The sidebar only eats 100px of a 200px strip — the canvas has to
       // leave the other 100px clear itself.
-      seedSettings({ faceCamWidth: 200, maxZoomPercent: 800 });
+      seedSettings({
+        faceCamWidth: 200,
+        paddingX: 0,
+        paddingY: 0,
+        maxZoomPercent: 800,
+      });
       const { editor, calls } = fakeEditor({
         bounds: { x: 0, y: 0, w: 100, h: 100 },
         viewport: { x: 0, y: 0, w: 900, h: 800 },
@@ -233,7 +271,12 @@ describe("centreCameraOnContent", () => {
     it("falls back to reserving the full strip from the viewport's own edge without a window (SSR/tests)", () => {
       // No `window` stubbed — every other test in this file runs this way,
       // and it used to be the only way this function ran at all.
-      seedSettings({ faceCamWidth: 200, maxZoomPercent: 800 });
+      seedSettings({
+        faceCamWidth: 200,
+        paddingX: 0,
+        paddingY: 0,
+        maxZoomPercent: 800,
+      });
       const { editor, calls } = fakeEditor({
         bounds: { x: 0, y: 0, w: 75, h: 100 },
         viewport: { x: 0, y: 0, w: 800, h: 800 },

--- a/apps/local/app/features/diagrams/centre-camera-on-content.test.ts
+++ b/apps/local/app/features/diagrams/centre-camera-on-content.test.ts
@@ -36,6 +36,21 @@ function seedSettings(settings: Partial<CenteringSettings>) {
 }
 
 /**
+ * `window` is a system boundary too, same rule as `localStorage` above —
+ * stubbed the same way `recent-icons.test.ts` stubs it, and always torn back
+ * down so a test that forgets to call this still runs in the no-window
+ * environment every other test in this file relies on.
+ */
+function withWindowWidth<T>(innerWidth: number, fn: () => T): T {
+  (globalThis as { window?: unknown }).window = { innerWidth };
+  try {
+    return fn();
+  } finally {
+    delete (globalThis as { window?: unknown }).window;
+  }
+}
+
+/**
  * A stand-in for tldraw's `Editor` — a third-party boundary. Only the camera
  * call matters here, so the fake records it rather than simulating it.
  */
@@ -123,5 +138,69 @@ describe("centreCameraOnContent", () => {
     const { editor, calls } = fakeEditor({ bounds: undefined });
     centreCameraOnContent(editor);
     expect(calls).toHaveLength(0);
+  });
+
+  describe("sidebar independence", () => {
+    it("lands the diagram in exactly the same spot whether or not the Snapshot Timeline / Diagram Rail sidebar is eating the reserved strip", () => {
+      // The sidebar (800px of canvas left, out of a 1000px window) happens to
+      // be exactly as wide as the reserved face-cam strip: the canvas can't
+      // reach any of the strip, so nothing extra needs reserving from ITS
+      // edge — the sidebar is already doing that job.
+      seedSettings({ faceCamWidth: 200 });
+      const { editor: withSidebar, calls: withSidebarCalls } = fakeEditor({
+        bounds: { x: 0, y: 0, w: 100, h: 100 },
+        viewport: { x: 0, y: 0, w: 800, h: 800 },
+      });
+      withWindowWidth(1000, () => centreCameraOnContent(withSidebar));
+      // safeWidth = 800 - 0 = 800, safeHeight = 800
+      // fit zoom = min(800/100, 800/100) = 8, capped at baseZoom 1
+      // x = -0 + (0 + (800 - 100)/2)/1 = 350
+      expect(withSidebarCalls[0]!.point).toMatchObject({
+        x: 350,
+        y: 350,
+        z: 1,
+      });
+
+      // No sidebar (Focus Mode, or Playground Home): same window, same
+      // content, the canvas now spans it and reserves the strip itself.
+      const { editor: noSidebar, calls: noSidebarCalls } = fakeEditor({
+        bounds: { x: 0, y: 0, w: 100, h: 100 },
+        viewport: { x: 0, y: 0, w: 1000, h: 800 },
+      });
+      withWindowWidth(1000, () => centreCameraOnContent(noSidebar));
+      // safeWidth = 1000 - 200 = 800, safeHeight = 800 — identical to above.
+      expect(noSidebarCalls[0]!.point).toMatchObject({ x: 350, y: 350, z: 1 });
+    });
+
+    it("still reserves whatever the sidebar doesn't already cover", () => {
+      // The sidebar only eats 100px of a 200px strip — the canvas has to
+      // leave the other 100px clear itself.
+      seedSettings({ faceCamWidth: 200 });
+      const { editor, calls } = fakeEditor({
+        bounds: { x: 0, y: 0, w: 100, h: 100 },
+        viewport: { x: 0, y: 0, w: 900, h: 800 },
+      });
+      withWindowWidth(1000, () => centreCameraOnContent(editor));
+      // right inset = max(200 - 100, 0) = 100
+      // safeWidth = 900 - 100 = 800, safeHeight = 800
+      // fit zoom = min(800/100, 800/100) = 8, capped at baseZoom 1
+      // x = -0 + (0 + (800 - 100)/2)/1 = 350
+      expect(calls[0]!.point).toMatchObject({ x: 350, y: 350, z: 1 });
+    });
+
+    it("falls back to reserving the full strip from the viewport's own edge without a window (SSR/tests)", () => {
+      // No `window` stubbed — every other test in this file runs this way,
+      // and it used to be the only way this function ran at all.
+      seedSettings({ faceCamWidth: 200 });
+      const { editor, calls } = fakeEditor({
+        bounds: { x: 0, y: 0, w: 100, h: 100 },
+        viewport: { x: 0, y: 0, w: 800, h: 800 },
+      });
+      centreCameraOnContent(editor);
+      // safeWidth = 800 - 200 = 600, safeHeight = 800
+      // fit zoom = min(600/100, 800/100) = 6, capped at baseZoom 1
+      // x = -0 + (0 + (600 - 100)/2)/1 = 250
+      expect(calls[0]!.point).toMatchObject({ x: 250, y: 350, z: 1 });
+    });
   });
 });

--- a/apps/local/app/features/diagrams/centre-camera-on-content.test.ts
+++ b/apps/local/app/features/diagrams/centre-camera-on-content.test.ts
@@ -95,7 +95,10 @@ describe("centreCameraOnContent", () => {
   });
 
   it("reserves a full-height strip on the right for the face-cam", () => {
-    seedSettings({ faceCamWidth: 200 });
+    // maxZoomPercent set high to isolate this test from the default 300%
+    // cap below — this test is about the face-cam reservation, not the
+    // zoom ceiling.
+    seedSettings({ faceCamWidth: 200, maxZoomPercent: 800 });
     const { editor, calls } = fakeEditor({
       bounds: { x: 0, y: 0, w: 100, h: 100 },
     });
@@ -108,7 +111,7 @@ describe("centreCameraOnContent", () => {
   });
 
   it("insets the diagram by paddingX/paddingY on every side — the fitted edge lands exactly on the padding line", () => {
-    seedSettings({ paddingX: 100, paddingY: 100 });
+    seedSettings({ paddingX: 100, paddingY: 100, maxZoomPercent: 800 });
     const { editor, calls } = fakeEditor({
       bounds: { x: 0, y: 0, w: 200, h: 100 },
     });
@@ -125,6 +128,9 @@ describe("centreCameraOnContent", () => {
   });
 
   it("zooms in past 100% to fill the safe area, clamped only by the camera's own zoom ceiling", () => {
+    // maxZoomPercent set effectively unlimited, so zoomSteps is the only
+    // thing left to demonstrate here.
+    seedSettings({ maxZoomPercent: 100_000 });
     // No cap at the editor's "100%" (`baseZoom`) any more: a diagram this
     // small would ask for 80x (min(1000/10, 800/10)) to fill the frame, which
     // is past even this editor's own zoom ceiling (zoomSteps top * baseZoom =
@@ -145,13 +151,48 @@ describe("centreCameraOnContent", () => {
     expect(calls).toHaveLength(0);
   });
 
+  describe("maxZoomPercent", () => {
+    it("defaults to capping the fit zoom at 300% of the editor's own 100%", () => {
+      // Nothing seeded: CENTERING_DEFAULTS.maxZoomPercent is 300.
+      const { editor, calls } = fakeEditor({
+        bounds: { x: 0, y: 0, w: 10, h: 10 },
+      });
+      centreCameraOnContent(editor);
+      // fit zoom would be min(1000/10, 800/10) = 80 — far past both the
+      // default cap (3 * baseZoom 1 = 3) and zoomSteps' own max (8), and the
+      // cap is the more restrictive of the two, so it wins.
+      expect(calls[0]!.point).toMatchObject({ z: 3 });
+    });
+
+    it("honours a configured value in place of the default", () => {
+      seedSettings({ maxZoomPercent: 150 });
+      const { editor, calls } = fakeEditor({
+        bounds: { x: 0, y: 0, w: 10, h: 10 },
+      });
+      centreCameraOnContent(editor);
+      expect(calls[0]!.point).toMatchObject({ z: 1.5 });
+    });
+
+    it("still yields to zoomSteps' own max when that's the more restrictive of the two", () => {
+      seedSettings({ maxZoomPercent: 100_000 });
+      const { editor, calls } = fakeEditor({
+        bounds: { x: 0, y: 0, w: 10, h: 10 },
+        zoomSteps: [0.1, 2],
+      });
+      centreCameraOnContent(editor);
+      expect(calls[0]!.point).toMatchObject({ z: 2 });
+    });
+  });
+
   describe("sidebar independence", () => {
     it("lands the diagram in exactly the same spot whether or not the Snapshot Timeline / Diagram Rail sidebar is eating the reserved strip", () => {
       // The sidebar (800px of canvas left, out of a 1000px window) happens to
       // be exactly as wide as the reserved face-cam strip: the canvas can't
       // reach any of the strip, so nothing extra needs reserving from ITS
-      // edge — the sidebar is already doing that job.
-      seedSettings({ faceCamWidth: 200 });
+      // edge — the sidebar is already doing that job. maxZoomPercent is set
+      // high to isolate this from the default 300% cap — this test is about
+      // the sidebar, not the zoom ceiling.
+      seedSettings({ faceCamWidth: 200, maxZoomPercent: 800 });
       const { editor: withSidebar, calls: withSidebarCalls } = fakeEditor({
         bounds: { x: 0, y: 0, w: 100, h: 100 },
         viewport: { x: 0, y: 0, w: 800, h: 800 },
@@ -176,7 +217,7 @@ describe("centreCameraOnContent", () => {
     it("still reserves whatever the sidebar doesn't already cover", () => {
       // The sidebar only eats 100px of a 200px strip — the canvas has to
       // leave the other 100px clear itself.
-      seedSettings({ faceCamWidth: 200 });
+      seedSettings({ faceCamWidth: 200, maxZoomPercent: 800 });
       const { editor, calls } = fakeEditor({
         bounds: { x: 0, y: 0, w: 100, h: 100 },
         viewport: { x: 0, y: 0, w: 900, h: 800 },
@@ -192,7 +233,7 @@ describe("centreCameraOnContent", () => {
     it("falls back to reserving the full strip from the viewport's own edge without a window (SSR/tests)", () => {
       // No `window` stubbed — every other test in this file runs this way,
       // and it used to be the only way this function ran at all.
-      seedSettings({ faceCamWidth: 200 });
+      seedSettings({ faceCamWidth: 200, maxZoomPercent: 800 });
       const { editor, calls } = fakeEditor({
         bounds: { x: 0, y: 0, w: 75, h: 100 },
         viewport: { x: 0, y: 0, w: 800, h: 800 },

--- a/apps/local/app/features/diagrams/centre-camera-on-content.ts
+++ b/apps/local/app/features/diagrams/centre-camera-on-content.ts
@@ -1,6 +1,7 @@
 import type { Editor } from "tldraw";
 import {
   getCenteringSettings,
+  getRightOffscreenWidth,
   getSafeAreaInsets,
 } from "./diagram-centering-settings";
 
@@ -25,6 +26,15 @@ import {
  * restore, palette search, the manual recentre hotkey, and the debug panel's
  * live preview) agrees on where "centred" means.
  *
+ * The strip is pinned to the *window's* right edge, not the tldraw
+ * viewport's: `getViewportScreenBounds()` shrinks whenever the Snapshot
+ * Timeline / Diagram Rail sidebar is showing, and reserving `faceCamWidth`
+ * from ITS edge would double-reserve — once for the sidebar, again for the
+ * strip — so the diagram's "centred" position would jump every time the
+ * sidebar opened or closed, or Focus Mode toggled it away. Subtracting
+ * `getRightOffscreenWidth` before insetting keeps that position fixed to the
+ * window regardless.
+ *
  * `targetZoom` is a *cap*, not a target: a large diagram still zooms out to
  * fit, while a single small shape is centred at 100% instead of being blown
  * up past it. This mirrors tldraw's own `zoomToBounds`, whose fit-and-clamp
@@ -36,8 +46,16 @@ export function centreCameraOnContent(editor: Editor): void {
   if (!bounds) return;
 
   const settings = getCenteringSettings();
-  const insets = getSafeAreaInsets(settings);
   const viewport = editor.getViewportScreenBounds();
+  // No `window` in SSR/tests — falls back to the viewport's own width, i.e.
+  // "nothing is off-canvas", the same as this function's behaviour before
+  // the sidebar was accounted for.
+  const windowWidth =
+    typeof window !== "undefined" ? window.innerWidth : viewport.x + viewport.w;
+  const insets = getSafeAreaInsets(
+    settings,
+    getRightOffscreenWidth(viewport, windowWidth)
+  );
 
   // The rectangle (in screen pixels) the diagram is allowed to occupy: the
   // viewport, inset on every side by `insets` — the same insets the debug

--- a/apps/local/app/features/diagrams/centre-camera-on-content.ts
+++ b/apps/local/app/features/diagrams/centre-camera-on-content.ts
@@ -35,19 +35,25 @@ import {
  * `getRightOffscreenWidth` before insetting keeps that position fixed to the
  * window regardless.
  *
- * The fit always exactly fills the padded box on its constraining axis — a
- * small diagram is zoomed IN past 100% rather than left floating in the
- * middle of a mostly-empty frame, because the whole point of tuning padding
- * by eye is that the diagram's edge then sits exactly on the line that was
- * tuned. (Earlier this capped at the editor's own 100% — `baseZoom` — the
- * same way tldraw's `zoomToBounds` does. That reads as "never blow up a tiny
- * shape", but in practice it meant the fit only ever engaged for diagrams
- * already bigger than the safe area, and everything else just sat centred
- * in whatever gap was left, ignoring the padding entirely.) The only clamp
- * left is `zoomSteps` — the editor's own min/max zoom — same as
- * `zoomToBounds`, whose fit-and-clamp math this reimplements by hand because
- * it only fits into the full viewport, centred, and can't target an
- * off-centre sub-region of it.
+ * The fit fills the padded box on its constraining axis — a small diagram is
+ * zoomed IN past 100% rather than left floating in the middle of a
+ * mostly-empty frame, because the whole point of tuning padding by eye is
+ * that the diagram's edge then sits exactly on the line that was tuned.
+ * (Earlier this capped at the editor's own 100% — `baseZoom` — the same way
+ * tldraw's `zoomToBounds` does. That reads as "never blow up a tiny shape",
+ * but in practice it meant the fit only ever engaged for diagrams already
+ * bigger than the safe area, and everything else just sat centred in
+ * whatever gap was left, ignoring the padding entirely.) `zoomSteps` — the
+ * editor's own min/max zoom, same as `zoomToBounds` — still floors it, and
+ * `maxZoomPercent` (tuned the same way as the insets, watched live via the
+ * debug panel's zoom readout) now ceilings it: past that percentage, a
+ * small enough diagram stops filling the box and is centred within it
+ * instead, the same "don't blow it up further" idea `baseZoom` used to
+ * enforce unconditionally, just at wherever the author decided actually
+ * looks right rather than hardcoded to 100%. `zoomToBounds`'s own
+ * fit-and-clamp math is reimplemented by hand here because it only fits
+ * into the full viewport, centred, and can't target an off-centre
+ * sub-region of it.
  */
 export function centreCameraOnContent(editor: Editor): void {
   const bounds = editor.getCurrentPageBounds();
@@ -74,7 +80,13 @@ export function centreCameraOnContent(editor: Editor): void {
   const { zoomSteps } = editor.getCameraOptions();
   const baseZoom = editor.getBaseZoom();
   const zoomMin = (zoomSteps?.[0] ?? 1) * baseZoom;
-  const zoomMax = (zoomSteps?.[zoomSteps.length - 1] ?? 1) * baseZoom;
+  // The lower of the camera's own zoom ceiling and the tuned `maxZoomPercent`
+  // — whichever is more restrictive wins, so a low `zoomSteps` max still
+  // applies even if `maxZoomPercent` is set higher than it.
+  const zoomMax = Math.min(
+    (zoomSteps?.[zoomSteps.length - 1] ?? 1) * baseZoom,
+    (settings.maxZoomPercent / 100) * baseZoom
+  );
 
   const fitZoom = Math.min(safeWidth / bounds.w, safeHeight / bounds.h);
   const zoom = Math.min(Math.max(fitZoom, zoomMin), zoomMax);

--- a/apps/local/app/features/diagrams/centre-camera-on-content.ts
+++ b/apps/local/app/features/diagrams/centre-camera-on-content.ts
@@ -35,11 +35,19 @@ import {
  * `getRightOffscreenWidth` before insetting keeps that position fixed to the
  * window regardless.
  *
- * `targetZoom` is a *cap*, not a target: a large diagram still zooms out to
- * fit, while a single small shape is centred at 100% instead of being blown
- * up past it. This mirrors tldraw's own `zoomToBounds`, whose fit-and-clamp
- * math this reimplements by hand — `zoomToBounds` only fits into the full
- * viewport, centred, and can't target an off-centre sub-region of it.
+ * The fit always exactly fills the padded box on its constraining axis — a
+ * small diagram is zoomed IN past 100% rather than left floating in the
+ * middle of a mostly-empty frame, because the whole point of tuning padding
+ * by eye is that the diagram's edge then sits exactly on the line that was
+ * tuned. (Earlier this capped at the editor's own 100% — `baseZoom` — the
+ * same way tldraw's `zoomToBounds` does. That reads as "never blow up a tiny
+ * shape", but in practice it meant the fit only ever engaged for diagrams
+ * already bigger than the safe area, and everything else just sat centred
+ * in whatever gap was left, ignoring the padding entirely.) The only clamp
+ * left is `zoomSteps` — the editor's own min/max zoom — same as
+ * `zoomToBounds`, whose fit-and-clamp math this reimplements by hand because
+ * it only fits into the full viewport, centred, and can't target an
+ * off-centre sub-region of it.
  */
 export function centreCameraOnContent(editor: Editor): void {
   const bounds = editor.getCurrentPageBounds();
@@ -69,8 +77,7 @@ export function centreCameraOnContent(editor: Editor): void {
   const zoomMax = (zoomSteps?.[zoomSteps.length - 1] ?? 1) * baseZoom;
 
   const fitZoom = Math.min(safeWidth / bounds.w, safeHeight / bounds.h);
-  const clampedZoom = Math.min(Math.max(fitZoom, zoomMin), zoomMax);
-  const zoom = Math.min(baseZoom, clampedZoom);
+  const zoom = Math.min(Math.max(fitZoom, zoomMin), zoomMax);
 
   editor.setCamera(
     {

--- a/apps/local/app/features/diagrams/diagram-centering-debug.tsx
+++ b/apps/local/app/features/diagrams/diagram-centering-debug.tsx
@@ -4,6 +4,7 @@ import { SlidersHorizontal } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { centreCameraOnContent } from "./centre-camera-on-content";
 import {
+  getRightOffscreenWidth,
   getSafeAreaInsets,
   useCenteringSetting,
 } from "./diagram-centering-settings";
@@ -33,8 +34,22 @@ export function DiagramCenteringDebug({
   const [paddingY, setPaddingY] = useCenteringSetting("paddingY");
   // Same insets `centreCameraOnContent` computes the camera move from — the
   // guide boxes below render them directly as CSS, so they can't drift from
-  // where the diagram actually lands.
-  const insets = getSafeAreaInsets({ faceCamWidth, paddingX, paddingY });
+  // where the diagram actually lands. Read fresh on every render (rather than
+  // cached in state) so a sidebar/Focus Mode toggle — which re-renders this
+  // component as a side effect of its parent's own re-render — recomputes it
+  // too; see `getRightOffscreenWidth` for why the sidebar matters here at all.
+  const viewport = editorRef.current?.getViewportScreenBounds();
+  const windowWidth =
+    typeof window !== "undefined"
+      ? window.innerWidth
+      : (viewport?.x ?? 0) + (viewport?.w ?? 0);
+  const rightOffscreen = viewport
+    ? getRightOffscreenWidth(viewport, windowWidth)
+    : 0;
+  const insets = getSafeAreaInsets(
+    { faceCamWidth, paddingX, paddingY },
+    rightOffscreen
+  );
 
   // Live-update: every persisted change re-runs the same recentre the rest
   // of the app uses, so the debug panel never drifts from real behaviour.
@@ -61,10 +76,13 @@ export function DiagramCenteringDebug({
       {open && (
         <>
           {/* Reserved face-cam strip — a full-height zone on the right the
-              diagram is kept clear of. */}
+              diagram is kept clear of. Drawn at whatever's left of it after
+              the sidebar's own width: the strip is pinned to the window's
+              edge, so a sidebar wide enough to cover it needs no red shown
+              here at all. */}
           <div
             className="pointer-events-none absolute right-0 top-0 z-40 h-full border-l-2 border-red-500/70 bg-red-500/10"
-            style={{ width: Math.max(faceCamWidth, 0) }}
+            style={{ width: Math.max(faceCamWidth - rightOffscreen, 0) }}
           />
           {/* The padded safe rect the diagram is actually fit-and-centred
               into — the same `getSafeAreaInsets` `centreCameraOnContent`

--- a/apps/local/app/features/diagrams/diagram-centering-debug.tsx
+++ b/apps/local/app/features/diagrams/diagram-centering-debug.tsx
@@ -12,10 +12,11 @@ import {
 /**
  * A prototype tuning UI (see `docs/adr` — none written yet on purpose: this
  * is deliberately a debug tool, not a finished setting screen). It's how the
- * three numbers `centreCameraOnContent` reads get found in the first place:
- * open it, drag the values until the guide boxes and the diagram look right
- * against your actual camera setup, close it. Nothing here needs to be
- * pretty — it needs to be legible enough to tune live while sat in frame.
+ * four numbers `centreCameraOnContent` reads get found in the first place:
+ * open it, drag the values until the guide boxes, the zoom readout, and the
+ * diagram itself all look right against your actual camera setup, close it.
+ * Nothing here needs to be pretty — it needs to be legible enough to tune
+ * live while sat in frame.
  *
  * Deliberately independent of Focus Mode: Focus Mode hides the Snapshot
  * Timeline / Diagram Rail panel on the right, and tuning has to work with
@@ -32,6 +33,8 @@ export function DiagramCenteringDebug({
   const [faceCamWidth, setFaceCamWidth] = useCenteringSetting("faceCamWidth");
   const [paddingX, setPaddingX] = useCenteringSetting("paddingX");
   const [paddingY, setPaddingY] = useCenteringSetting("paddingY");
+  const [maxZoomPercent, setMaxZoomPercent] =
+    useCenteringSetting("maxZoomPercent");
   // Same insets `centreCameraOnContent` computes the camera move from — the
   // guide boxes below render them directly as CSS, so they can't drift from
   // where the diagram actually lands. Read fresh on every render (rather than
@@ -56,14 +59,12 @@ export function DiagramCenteringDebug({
   useEffect(() => {
     const ed = editorRef.current;
     if (ed) centreCameraOnContent(ed);
-  }, [faceCamWidth, paddingX, paddingY, editorRef]);
+  }, [faceCamWidth, paddingX, paddingY, maxZoomPercent, editorRef]);
 
-  // centreCameraOnContent has no ceiling of its own any more — past the
-  // padded edges, the only thing stopping a small diagram from zooming in
-  // arbitrarily far is the camera's own `zoomSteps` range (see its history).
-  // Nothing here picks a saner cap yet; this is how "how far does it
-  // actually go" gets watched live while tuning, the same way the guide
-  // boxes above are, before that number gets chosen.
+  // The live counterpart to `maxZoomPercent` above: past the padded edges,
+  // this is what a small diagram's fit zoom actually comes out to, tuned
+  // against in real time rather than guessed at — drag the field, watch
+  // this move, stop where it looks right.
   //
   // `[editorRef.current]` (not `[editorRef]`) is deliberate: `useValue`
   // builds its reactive subscription once per identity in the deps array,
@@ -141,6 +142,12 @@ export function DiagramCenteringDebug({
               value={paddingY}
               onChange={setPaddingY}
             />
+            <NumberField
+              label="Max zoom %"
+              value={maxZoomPercent}
+              onChange={setMaxZoomPercent}
+              step={25}
+            />
           </div>
         </>
       )}
@@ -152,17 +159,21 @@ function NumberField({
   label,
   value,
   onChange,
+  step = 4,
 }: {
   label: string;
   value: number;
   onChange: (next: number) => void;
+  /** Pixel-sized fields (padding, face-cam width) move in fine steps; a
+   * percentage field wants coarser ones. */
+  step?: number;
 }) {
   return (
     <label className="mb-2 flex items-center justify-between gap-2 text-xs text-zinc-400 last:mb-0">
       <span>{label}</span>
       <Input
         type="number"
-        step={4}
+        step={step}
         value={value}
         onChange={(e) => {
           const next = Number(e.target.value);

--- a/apps/local/app/features/diagrams/diagram-centering-debug.tsx
+++ b/apps/local/app/features/diagrams/diagram-centering-debug.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type RefObject } from "react";
-import type { Editor } from "tldraw";
+import { useValue, type Editor } from "tldraw";
 import { SlidersHorizontal } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { centreCameraOnContent } from "./centre-camera-on-content";
@@ -58,6 +58,25 @@ export function DiagramCenteringDebug({
     if (ed) centreCameraOnContent(ed);
   }, [faceCamWidth, paddingX, paddingY, editorRef]);
 
+  // centreCameraOnContent has no ceiling of its own any more — past the
+  // padded edges, the only thing stopping a small diagram from zooming in
+  // arbitrarily far is the camera's own `zoomSteps` range (see its history).
+  // Nothing here picks a saner cap yet; this is how "how far does it
+  // actually go" gets watched live while tuning, the same way the guide
+  // boxes above are, before that number gets chosen.
+  //
+  // `[editorRef.current]` (not `[editorRef]`) is deliberate: `useValue`
+  // builds its reactive subscription once per identity in the deps array,
+  // and the ref OBJECT never changes, only what it points at. Keying on the
+  // object would leave this watching a `computed` built before the editor
+  // ever mounted, permanently stuck reading `null` off a signal it never
+  // wired up.
+  const zoom = useValue(
+    "centering-debug-zoom",
+    () => editorRef.current?.getZoomLevel() ?? null,
+    [editorRef.current]
+  );
+
   return (
     <>
       <button
@@ -100,6 +119,12 @@ export function DiagramCenteringDebug({
           <div className="absolute bottom-52 right-2 z-50 w-56 rounded-md border border-zinc-700 bg-zinc-900/95 p-3 shadow-lg">
             <div className="mb-2 text-xs font-semibold text-zinc-300">
               Diagram centering (debug)
+            </div>
+            <div className="mb-2 flex items-center justify-between text-xs text-zinc-400">
+              <span>Zoom</span>
+              <span className="font-mono text-zinc-100">
+                {zoom === null ? "—" : `${Math.round(zoom * 100)}%`}
+              </span>
             </div>
             <NumberField
               label="Face-cam width"

--- a/apps/local/app/features/diagrams/diagram-centering-settings.test.ts
+++ b/apps/local/app/features/diagrams/diagram-centering-settings.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  getRightOffscreenWidth,
+  getSafeAreaInsets,
+} from "./diagram-centering-settings";
+
+describe("getRightOffscreenWidth", () => {
+  it("is zero when the canvas already spans the whole window", () => {
+    expect(getRightOffscreenWidth({ x: 0, w: 1000 }, 1000)).toBe(0);
+  });
+
+  it("is the gap between the canvas's right edge and the window's", () => {
+    // A 256px sidebar eating the right of a 1000px window.
+    expect(getRightOffscreenWidth({ x: 0, w: 744 }, 1000)).toBe(256);
+  });
+
+  it("accounts for the canvas not starting at the window's left edge either", () => {
+    expect(getRightOffscreenWidth({ x: 50, w: 700 }, 1000)).toBe(250);
+  });
+
+  it("never goes negative", () => {
+    // A canvas that (somehow) already exceeds the window is fully on-screen.
+    expect(getRightOffscreenWidth({ x: 0, w: 1200 }, 1000)).toBe(0);
+  });
+});
+
+describe("getSafeAreaInsets", () => {
+  it("defaults rightOffscreenWidth to zero — the pre-sidebar-aware behaviour", () => {
+    expect(
+      getSafeAreaInsets({ faceCamWidth: 200, paddingX: 10, paddingY: 5 })
+    ).toEqual({ left: 10, right: 210, top: 5, bottom: 5 });
+  });
+
+  it("subtracts what the sidebar already covers from the reserved strip", () => {
+    expect(
+      getSafeAreaInsets({ faceCamWidth: 200, paddingX: 10, paddingY: 5 }, 150)
+    ).toEqual({ left: 10, right: 60, top: 5, bottom: 5 });
+  });
+
+  it("floors the strip at zero once the sidebar covers all of it — padding still applies", () => {
+    expect(
+      getSafeAreaInsets({ faceCamWidth: 200, paddingX: 10, paddingY: 5 }, 500)
+    ).toEqual({ left: 10, right: 10, top: 5, bottom: 5 });
+  });
+
+  it("left/top/bottom are untouched by rightOffscreenWidth — only the strip is pinned to the window", () => {
+    const noSidebar = getSafeAreaInsets({
+      faceCamWidth: 0,
+      paddingX: 10,
+      paddingY: 5,
+    });
+    const withSidebar = getSafeAreaInsets(
+      { faceCamWidth: 0, paddingX: 10, paddingY: 5 },
+      256
+    );
+    expect(withSidebar).toEqual(noSidebar);
+  });
+});

--- a/apps/local/app/features/diagrams/diagram-centering-settings.ts
+++ b/apps/local/app/features/diagrams/diagram-centering-settings.ts
@@ -81,16 +81,47 @@ export interface SafeAreaInsets {
 }
 
 /**
+ * How much of the *window's* right edge the visible tldraw canvas does not
+ * reach right now — e.g. because the Snapshot Timeline / Diagram Rail
+ * sidebar is open (Focus Mode hides it, which is when this is zero).
+ *
+ * The face-cam is composited by OBS onto the window (ADR 0004), not onto
+ * whatever fraction of it tldraw happens to be rendering into — so the strip
+ * reserved for it has to be measured from the window's edge, and this is the
+ * piece of that measurement `getViewportScreenBounds()` alone can't give,
+ * because it only describes the canvas.
+ */
+export function getRightOffscreenWidth(
+  viewport: { x: number; w: number },
+  windowWidth: number
+): number {
+  return Math.max(windowWidth - (viewport.x + viewport.w), 0);
+}
+
+/**
  * The single definition of "the area the diagram is allowed to occupy":
  * padding on the left/top/bottom, and the reserved face-cam strip plus
  * padding on the right. `centreCameraOnContent` turns this into a camera
  * move; the debug panel's guide-box overlay renders it directly as CSS
  * insets — both read the same four numbers, so they can't drift apart.
+ *
+ * `rightOffscreenWidth` (see `getRightOffscreenWidth`) is subtracted from
+ * `faceCamWidth` before padding is added, so a sidebar that already covers
+ * part — or all — of the reserved strip doesn't make the canvas reserve it a
+ * second time on top. That's what pins the diagram's centred position to the
+ * same spot on the window whether the sidebar is open or Focus Mode has
+ * hidden it: the strip's own position never moves, only how much of it the
+ * *canvas* still has to leave clear does.
  */
-export function getSafeAreaInsets(settings: CenteringSettings): SafeAreaInsets {
+export function getSafeAreaInsets(
+  settings: CenteringSettings,
+  rightOffscreenWidth = 0
+): SafeAreaInsets {
   return {
     left: settings.paddingX,
-    right: settings.faceCamWidth + settings.paddingX,
+    right:
+      Math.max(settings.faceCamWidth - rightOffscreenWidth, 0) +
+      settings.paddingX,
     top: settings.paddingY,
     bottom: settings.paddingY,
   };

--- a/apps/local/app/features/diagrams/diagram-centering-settings.ts
+++ b/apps/local/app/features/diagrams/diagram-centering-settings.ts
@@ -9,43 +9,53 @@ import { hasLocalStorage, useLocalStorage } from "@/hooks/use-local-storage";
  * The first three of these four numbers are how `centreCameraOnContent`
  * knows how much room to leave for it: a full-height strip reserved on the
  * right, plus breathing room (padding) around the diagram within whatever's
- * left. There's no way to derive them — they depend on the physical size of
- * the author's camera bubble and how it feels once composited — so they're
- * tuned by eye via the debug panel (`diagram-centering-debug.tsx`) rather
- * than computed.
- *
- * `maxZoomPercent` is a different kind of number: with no ceiling of its
- * own, a small enough diagram would zoom in to fill the padded box no
+ * left. `maxZoomPercent` is a different kind of number: with no ceiling of
+ * its own, a small enough diagram would zoom in to fill the padded box no
  * matter how far that takes it — fine geometrically, but past some point it
- * just looks wrong (blown-up strokes, a page-filling icon). There's no way
- * to derive a "correct" value here either, so it's tuned the same way, and
- * the debug panel's live zoom readout is what it gets tuned against.
+ * just looks wrong (blown-up strokes, a page-filling icon).
+ *
+ * All four were tuned by eye against the actual recording rig, via the debug
+ * panel (`diagram-centering-debug.tsx`) — there's no way to derive any of
+ * them, only watch the guide boxes and the live zoom readout and adjust
+ * until it looks right. `CENTERING_DEFAULTS` below is that answer, shipped
+ * as the starting point for every install; the debug panel stays in the
+ * build so it can be re-tuned if the rig ever changes.
  *
  * Stored globally, not per-diagram: the camera setup is a property of the
  * recording rig, not of any one diagram.
+ *
+ * The key names carry a `:v2` generation marker. Bumping it is how a change
+ * to `CENTERING_DEFAULTS` actually reaches an install that already has
+ * something written under the old keys — `localStorage` always wins over a
+ * default (see `readStoredNumber`), so changing the constant alone would
+ * leave anyone who ever opened the debug panel before this pinned to
+ * whatever they'd last poked it to, forever. A version bump orphans the old
+ * keys (dead, harmless, never read again) and starts every install fresh
+ * from the new numbers — future re-tuning through the debug panel still
+ * works exactly as before, it just writes under the new name.
  */
 export const CENTERING_STORAGE_KEYS = {
-  faceCamWidth: "diagram-centering:face-cam-width",
-  paddingX: "diagram-centering:padding-x",
-  paddingY: "diagram-centering:padding-y",
-  maxZoomPercent: "diagram-centering:max-zoom-percent",
+  faceCamWidth: "diagram-centering:face-cam-width:v2",
+  paddingX: "diagram-centering:padding-x:v2",
+  paddingY: "diagram-centering:padding-y:v2",
+  maxZoomPercent: "diagram-centering:max-zoom-percent:v2",
 } as const;
 
 export type CenteringSettingKey = keyof typeof CENTERING_STORAGE_KEYS;
 
 /**
- * The spatial three default to zero so an untuned install behaves like the
- * old dead-centre-of-the-whole-viewport camera: no reserved strip, no
- * padding. `maxZoomPercent` can't default to zero the same way — that would
- * cap every diagram at no zoom at all — so it defaults to 300%, a starting
- * guess at "past here a small diagram looks blown up rather than fitted".
- * The debug panel is where all four actually get tuned.
+ * Matt's actual recording rig, as of the last time these were tuned: a
+ * face-cam bubble reserving 492px on the right, 150/120px of breathing room
+ * around the diagram within what's left, and a diagram never zoomed in past
+ * 225% to fill it. Not derived from anything — see the module doc above —
+ * so if the rig changes, these are the numbers to re-tune via the debug
+ * panel, not guess at again from scratch.
  */
 export const CENTERING_DEFAULTS: Record<CenteringSettingKey, number> = {
-  faceCamWidth: 0,
-  paddingX: 0,
-  paddingY: 0,
-  maxZoomPercent: 300,
+  faceCamWidth: 492,
+  paddingX: 150,
+  paddingY: 120,
+  maxZoomPercent: 225,
 };
 
 export interface CenteringSettings {

--- a/apps/local/app/features/diagrams/diagram-centering-settings.ts
+++ b/apps/local/app/features/diagrams/diagram-centering-settings.ts
@@ -6,12 +6,20 @@ import { hasLocalStorage, useLocalStorage } from "@/hooks/use-local-storage";
  * no visibility into it at all (ADR 0004: the diagram playground doubles as
  * the recording surface, but the camera itself lives outside tldraw/CVM).
  *
- * These three numbers are how `centreCameraOnContent` knows how much room to
- * leave for it: a full-height strip reserved on the right, plus breathing
- * room (padding) around the diagram within whatever's left. There's no way
- * to derive them — they depend on the physical size of the author's camera
- * bubble and how it feels once composited — so they're tuned by eye via the
- * debug panel (`diagram-centering-debug.tsx`) rather than computed.
+ * The first three of these four numbers are how `centreCameraOnContent`
+ * knows how much room to leave for it: a full-height strip reserved on the
+ * right, plus breathing room (padding) around the diagram within whatever's
+ * left. There's no way to derive them — they depend on the physical size of
+ * the author's camera bubble and how it feels once composited — so they're
+ * tuned by eye via the debug panel (`diagram-centering-debug.tsx`) rather
+ * than computed.
+ *
+ * `maxZoomPercent` is a different kind of number: with no ceiling of its
+ * own, a small enough diagram would zoom in to fill the padded box no
+ * matter how far that takes it — fine geometrically, but past some point it
+ * just looks wrong (blown-up strokes, a page-filling icon). There's no way
+ * to derive a "correct" value here either, so it's tuned the same way, and
+ * the debug panel's live zoom readout is what it gets tuned against.
  *
  * Stored globally, not per-diagram: the camera setup is a property of the
  * recording rig, not of any one diagram.
@@ -20,25 +28,33 @@ export const CENTERING_STORAGE_KEYS = {
   faceCamWidth: "diagram-centering:face-cam-width",
   paddingX: "diagram-centering:padding-x",
   paddingY: "diagram-centering:padding-y",
+  maxZoomPercent: "diagram-centering:max-zoom-percent",
 } as const;
 
 export type CenteringSettingKey = keyof typeof CENTERING_STORAGE_KEYS;
 
 /**
- * Defaults to zero so an untuned install behaves like the old
- * dead-centre-of-the-whole-viewport camera: no reserved strip, no padding.
- * The debug panel is where these actually become non-zero.
+ * The spatial three default to zero so an untuned install behaves like the
+ * old dead-centre-of-the-whole-viewport camera: no reserved strip, no
+ * padding. `maxZoomPercent` can't default to zero the same way — that would
+ * cap every diagram at no zoom at all — so it defaults to 300%, a starting
+ * guess at "past here a small diagram looks blown up rather than fitted".
+ * The debug panel is where all four actually get tuned.
  */
 export const CENTERING_DEFAULTS: Record<CenteringSettingKey, number> = {
   faceCamWidth: 0,
   paddingX: 0,
   paddingY: 0,
+  maxZoomPercent: 300,
 };
 
 export interface CenteringSettings {
   faceCamWidth: number;
   paddingX: number;
   paddingY: number;
+  /** A cap on `centreCameraOnContent`'s fit zoom, as a percent of the
+   * editor's own 100% (`baseZoom`) — see `CENTERING_DEFAULTS`. */
+  maxZoomPercent: number;
 }
 
 function readStoredNumber(key: string, fallback: number): number {
@@ -68,6 +84,10 @@ export function getCenteringSettings(): CenteringSettings {
     paddingY: readStoredNumber(
       CENTERING_STORAGE_KEYS.paddingY,
       CENTERING_DEFAULTS.paddingY
+    ),
+    maxZoomPercent: readStoredNumber(
+      CENTERING_STORAGE_KEYS.maxZoomPercent,
+      CENTERING_DEFAULTS.maxZoomPercent
     ),
   };
 }
@@ -112,9 +132,15 @@ export function getRightOffscreenWidth(
  * same spot on the window whether the sidebar is open or Focus Mode has
  * hidden it: the strip's own position never moves, only how much of it the
  * *canvas* still has to leave clear does.
+ *
+ * Takes only the spatial three settings, not the full {@link CenteringSettings}
+ * — `maxZoomPercent` has nothing to do with "the area the diagram occupies",
+ * only with how far it gets zoomed once fitted into it, so callers that only
+ * have those three (the debug panel's live guide-box render, this file's own
+ * tests) don't need to fake a fourth field just to satisfy the type.
  */
 export function getSafeAreaInsets(
-  settings: CenteringSettings,
+  settings: Pick<CenteringSettings, "faceCamWidth" | "paddingX" | "paddingY">,
   rightOffscreenWidth = 0
 ): SafeAreaInsets {
   return {

--- a/apps/local/app/features/diagrams/palette/diagram-command-palette.tsx
+++ b/apps/local/app/features/diagrams/palette/diagram-command-palette.tsx
@@ -19,7 +19,7 @@ export function DiagramCommandPalette(props: {
   handleCopyDiagramContents: (id: string) => Promise<void>;
   handleCreateDiagram: () => Promise<void>;
   reloadScene: (id: string) => Promise<void>;
-  /** The same camera move the manual Cmd/Ctrl+Home shortcut runs. */
+  /** The same camera move the manual Cmd/Ctrl+0 shortcut runs. */
   recentreDiagram: () => void;
 }) {
   const handlers = usePaletteHandlers(props);

--- a/apps/local/app/features/diagrams/palette/diagram-command-palette.tsx
+++ b/apps/local/app/features/diagrams/palette/diagram-command-palette.tsx
@@ -19,6 +19,8 @@ export function DiagramCommandPalette(props: {
   handleCopyDiagramContents: (id: string) => Promise<void>;
   handleCreateDiagram: () => Promise<void>;
   reloadScene: (id: string) => Promise<void>;
+  /** The same camera move the manual Cmd/Ctrl+Home shortcut runs. */
+  recentreDiagram: () => void;
 }) {
   const handlers = usePaletteHandlers(props);
   return <CommandPalette editorRef={props.editorRef} handlers={handlers} />;

--- a/apps/local/app/features/diagrams/palette/palette-model.ts
+++ b/apps/local/app/features/diagrams/palette/palette-model.ts
@@ -84,7 +84,7 @@ export const ROOT_ACTIONS: RootAction[] = [
   {
     id: "recentre-diagram",
     label: "Recentre diagram",
-    hint: "Snap the camera back to the tuned, face-cam-aware centre (Cmd/Ctrl+Home)",
+    hint: "Snap the camera back to the tuned, face-cam-aware centre (Cmd/Ctrl+0)",
     group: "Navigate",
     icon: "crosshair",
   },

--- a/apps/local/app/features/diagrams/palette/palette-model.ts
+++ b/apps/local/app/features/diagrams/palette/palette-model.ts
@@ -82,6 +82,13 @@ export const ROOT_ACTIONS: RootAction[] = [
     opens: "diagrams",
   },
   {
+    id: "recentre-diagram",
+    label: "Recentre diagram",
+    hint: "Snap the camera back to the tuned, face-cam-aware centre (Cmd/Ctrl+Home)",
+    group: "Navigate",
+    icon: "crosshair",
+  },
+  {
     id: "preserve-snapshot",
     label: "Preserve current as snapshot",
     hint: "Pin this state to the timeline",

--- a/apps/local/app/features/diagrams/palette/use-palette-handlers.ts
+++ b/apps/local/app/features/diagrams/palette/use-palette-handlers.ts
@@ -26,6 +26,8 @@ export function usePaletteHandlers(opts: {
   handleCreateDiagram: () => Promise<void>;
   /** Re-reads head from the server and loads it into the editor. */
   reloadScene: (id: string) => Promise<void>;
+  /** The same camera move the manual Cmd/Ctrl+Home shortcut runs. */
+  recentreDiagram: () => void;
 }): PaletteHandlers {
   const {
     diagramId,
@@ -35,6 +37,7 @@ export function usePaletteHandlers(opts: {
     handleCopyDiagramContents,
     handleCreateDiagram,
     reloadScene,
+    recentreDiagram,
   } = opts;
 
   const navigate = useNavigate();
@@ -43,6 +46,8 @@ export function usePaletteHandlers(opts: {
   return useMemo(
     () => ({
       onPreserveSnapshot: preserveSnapshot,
+
+      onRecentreDiagram: recentreDiagram,
 
       onRestoreToHead: async () => {
         // "Discard changes since the last snapshot" — the same restore the
@@ -132,6 +137,7 @@ export function usePaletteHandlers(opts: {
       handleCopyDiagramContents,
       handleCreateDiagram,
       reloadScene,
+      recentreDiagram,
       navigate,
       revalidator,
     ]

--- a/apps/local/app/features/diagrams/palette/use-palette-handlers.ts
+++ b/apps/local/app/features/diagrams/palette/use-palette-handlers.ts
@@ -26,7 +26,7 @@ export function usePaletteHandlers(opts: {
   handleCreateDiagram: () => Promise<void>;
   /** Re-reads head from the server and loads it into the editor. */
   reloadScene: (id: string) => Promise<void>;
-  /** The same camera move the manual Cmd/Ctrl+Home shortcut runs. */
+  /** The same camera move the manual Cmd/Ctrl+0 shortcut runs. */
   recentreDiagram: () => void;
 }): PaletteHandlers {
   const {

--- a/apps/local/app/features/diagrams/palette/use-palette.ts
+++ b/apps/local/app/features/diagrams/palette/use-palette.ts
@@ -63,7 +63,7 @@ export type PaletteHandlers = {
   onCopyContents: () => void | Promise<void>;
   onRenameDiagram: (name: string) => void | Promise<void>;
   onNewDiagram: () => void | Promise<void>;
-  /** The same camera move the manual Cmd/Ctrl+Home shortcut runs. */
+  /** The same camera move the manual Cmd/Ctrl+0 shortcut runs. */
   onRecentreDiagram: () => void;
   /**
    * Navigating away flushes the pending save first — see the call site. A

--- a/apps/local/app/features/diagrams/palette/use-palette.ts
+++ b/apps/local/app/features/diagrams/palette/use-palette.ts
@@ -63,6 +63,8 @@ export type PaletteHandlers = {
   onCopyContents: () => void | Promise<void>;
   onRenameDiagram: (name: string) => void | Promise<void>;
   onNewDiagram: () => void | Promise<void>;
+  /** The same camera move the manual Cmd/Ctrl+Home shortcut runs. */
+  onRecentreDiagram: () => void;
   /**
    * Navigating away flushes the pending save first — see the call site. A
    * snapshot hit is restored on the way, so the author arrives at the state
@@ -186,6 +188,9 @@ export function usePalette(opts: {
           break;
         case "new-diagram":
           void handlers.onNewDiagram();
+          break;
+        case "recentre-diagram":
+          handlers.onRecentreDiagram();
           break;
       }
       setOpen(false);

--- a/apps/local/app/features/diagrams/use-recentre-diagram-shortcut.test.ts
+++ b/apps/local/app/features/diagrams/use-recentre-diagram-shortcut.test.ts
@@ -9,24 +9,17 @@ function key(
   return { key: k, metaKey: false, ctrlKey: false, ...mods };
 }
 
-describe("Cmd/Ctrl+Home", () => {
+describe("Cmd/Ctrl+0", () => {
   it("matches with either modifier", () => {
-    expect(isRecentreShortcut(key("Home", { metaKey: true }))).toBe(true);
-    expect(isRecentreShortcut(key("Home", { ctrlKey: true }))).toBe(true);
+    expect(isRecentreShortcut(key("0", { metaKey: true }))).toBe(true);
+    expect(isRecentreShortcut(key("0", { ctrlKey: true }))).toBe(true);
   });
 
-  it("ignores a bare Home — that's the page's own scroll-to-top", () => {
-    expect(isRecentreShortcut(key("Home"))).toBe(false);
-  });
-
-  it("does not match Cmd/Ctrl+0 — the browser's own reserved reset-zoom shortcut", () => {
-    // The whole point of not using it: preventDefault() can't stop the
-    // browser's handling of it, so binding to it would be a dead keypress.
-    expect(isRecentreShortcut(key("0", { metaKey: true }))).toBe(false);
-    expect(isRecentreShortcut(key("0", { ctrlKey: true }))).toBe(false);
+  it("ignores a bare 0 — that's just a digit", () => {
+    expect(isRecentreShortcut(key("0"))).toBe(false);
   });
 
   it("ignores other modified keys", () => {
-    expect(isRecentreShortcut(key("End", { metaKey: true }))).toBe(false);
+    expect(isRecentreShortcut(key("1", { metaKey: true }))).toBe(false);
   });
 });

--- a/apps/local/app/features/diagrams/use-recentre-diagram-shortcut.test.ts
+++ b/apps/local/app/features/diagrams/use-recentre-diagram-shortcut.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { isRecentreShortcut } from "./use-recentre-diagram-shortcut";
+
+/** The bits of a KeyboardEvent the matcher actually reads. */
+function key(
+  k: string,
+  mods: { metaKey?: boolean; ctrlKey?: boolean } = {}
+): { key: string; metaKey: boolean; ctrlKey: boolean } {
+  return { key: k, metaKey: false, ctrlKey: false, ...mods };
+}
+
+describe("Cmd/Ctrl+Home", () => {
+  it("matches with either modifier", () => {
+    expect(isRecentreShortcut(key("Home", { metaKey: true }))).toBe(true);
+    expect(isRecentreShortcut(key("Home", { ctrlKey: true }))).toBe(true);
+  });
+
+  it("ignores a bare Home — that's the page's own scroll-to-top", () => {
+    expect(isRecentreShortcut(key("Home"))).toBe(false);
+  });
+
+  it("does not match Cmd/Ctrl+0 — the browser's own reserved reset-zoom shortcut", () => {
+    // The whole point of not using it: preventDefault() can't stop the
+    // browser's handling of it, so binding to it would be a dead keypress.
+    expect(isRecentreShortcut(key("0", { metaKey: true }))).toBe(false);
+    expect(isRecentreShortcut(key("0", { ctrlKey: true }))).toBe(false);
+  });
+
+  it("ignores other modified keys", () => {
+    expect(isRecentreShortcut(key("End", { metaKey: true }))).toBe(false);
+  });
+});

--- a/apps/local/app/features/diagrams/use-recentre-diagram-shortcut.ts
+++ b/apps/local/app/features/diagrams/use-recentre-diagram-shortcut.ts
@@ -2,26 +2,25 @@ import { useEffect } from "react";
 import { isTextEntryTarget, type ShortcutTarget } from "./snapshot-navigation";
 
 /**
- * NOT Cmd/Ctrl+0. That reads as the common "reset view" convention, but it's
- * also Chrome/Firefox/Safari's own "reset zoom level to 100%" shortcut,
- * reserved at the browser-chrome level — `preventDefault()` on the keydown
- * event cannot stop it (unlike, say, Cmd/Ctrl+F, which this route also
- * rebinds and which the browser lets a page override). A handler bound to it
- * simply never runs; the browser changes its own zoom instead, and the
- * camera — which was never touched — looks like it "ignored" the tuned
- * padding, when really it was never asked to move at all.
+ * Cmd/Ctrl+0 — the common "reset view" convention (browsers, maps apps).
+ * Free in tldraw's own keymap (which binds `shift+0`/`shift+1`/`shift+2` for
+ * zoom, never a bare 0) and in this route's other shortcuts
+ * (Cmd/Ctrl+S/K/F/[/]).
  *
- * Cmd/Ctrl+Home keeps the "back to the start" convention without landing on
- * a combo the browser owns. Free in tldraw's own keymap (which binds
- * `shift+0`/`shift+1`/`shift+2` for zoom, never Home) and in this route's
- * other shortcuts (Cmd/Ctrl+S/K/F/[/]).
+ * Turned out NOT to be a dead binding — swapping it for Cmd/Ctrl+Home
+ * changed nothing, which ruled out the browser's reserved "reset zoom"
+ * shortcut as the cause of "recentre doesn't respect the padding I've
+ * chosen". The actual bug was in `centreCameraOnContent`'s fit math (it
+ * capped zoom at 100%, so a small diagram never reached the padding edges
+ * regardless of which key triggered the recentre) — see its history. This
+ * stays on the conventional key.
  */
 export function isRecentreShortcut(e: {
   ctrlKey: boolean;
   metaKey: boolean;
   key: string;
 }): boolean {
-  return (e.ctrlKey || e.metaKey) && e.key === "Home";
+  return (e.ctrlKey || e.metaKey) && e.key === "0";
 }
 
 /**

--- a/apps/local/app/features/diagrams/use-recentre-diagram-shortcut.ts
+++ b/apps/local/app/features/diagrams/use-recentre-diagram-shortcut.ts
@@ -1,15 +1,27 @@
 import { useEffect } from "react";
 import { isTextEntryTarget, type ShortcutTarget } from "./snapshot-navigation";
 
-function isRecentreShortcut(e: {
+/**
+ * NOT Cmd/Ctrl+0. That reads as the common "reset view" convention, but it's
+ * also Chrome/Firefox/Safari's own "reset zoom level to 100%" shortcut,
+ * reserved at the browser-chrome level — `preventDefault()` on the keydown
+ * event cannot stop it (unlike, say, Cmd/Ctrl+F, which this route also
+ * rebinds and which the browser lets a page override). A handler bound to it
+ * simply never runs; the browser changes its own zoom instead, and the
+ * camera — which was never touched — looks like it "ignored" the tuned
+ * padding, when really it was never asked to move at all.
+ *
+ * Cmd/Ctrl+Home keeps the "back to the start" convention without landing on
+ * a combo the browser owns. Free in tldraw's own keymap (which binds
+ * `shift+0`/`shift+1`/`shift+2` for zoom, never Home) and in this route's
+ * other shortcuts (Cmd/Ctrl+S/K/F/[/]).
+ */
+export function isRecentreShortcut(e: {
   ctrlKey: boolean;
   metaKey: boolean;
   key: string;
 }): boolean {
-  // Cmd/Ctrl+0 — the common "reset view" convention (browsers, maps apps).
-  // Free in both tldraw's own keymap and this route's other shortcuts
-  // (Cmd/Ctrl+S/K/F/[/]).
-  return (e.ctrlKey || e.metaKey) && e.key === "0";
+  return (e.ctrlKey || e.metaKey) && e.key === "Home";
 }
 
 /**

--- a/apps/local/app/routes/diagram-playground.$diagramId.tsx
+++ b/apps/local/app/routes/diagram-playground.$diagramId.tsx
@@ -527,6 +527,7 @@ export default function DiagramPlaygroundActive({
             handleCopyDiagramContents={handleCopyDiagramContents}
             handleCreateDiagram={handleCreateDiagram}
             reloadScene={loadDiagramScene}
+            recentreDiagram={recentreDiagram}
           />
         )}
         <ConnectionStatusIndicator


### PR DESCRIPTION
## Summary

QA follow-up on #1555 (the face-cam centering feature):

- **Sidebar-dependent centering.** The reserved face-cam strip was measured from `editor.getViewportScreenBounds()`'s right edge, which shrinks whenever the Snapshot Timeline / Diagram Rail sidebar is showing — so the diagram centred in a different spot depending on whether the sidebar was open. `getRightOffscreenWidth` now measures how much of the *window's* right edge the sidebar is covering, and `getSafeAreaInsets` subtracts that from `faceCamWidth` before applying it — the strip stays pinned to the window's edge (and so does the debug panel's guide-box overlay) regardless of sidebar/Focus Mode state.

- **Recentre didn't respect the tuned padding.** Initially suspected the Cmd/Ctrl+0 hotkey was colliding with the browser's reserved "reset zoom" shortcut, and rebound it to Cmd/Ctrl+Home — but that changed nothing, which disproved it. The real cause: `centreCameraOnContent` capped its fit zoom at the editor's own 100% (`baseZoom`), mirroring tldraw's `zoomToBounds`. In practice that meant the fit-to-safe-area math only ever engaged for diagrams already bigger than the padded box — anything smaller just sat centred at 100% inside whatever gap was left, ignoring the padding entirely, no matter which key triggered the recentre. Removed the 100% clamp. The hotkey itself is back on the conventional Cmd/Ctrl+0.

- **Command palette entry.** Added "Recentre diagram" to the Cmd+K palette's Navigate group, wired to the same handler the hotkey and every automatic recentre (scene load, restore, palette search) already call.

- **Configurable, tuned max zoom.** With the 100% cap gone, a small enough diagram would zoom in as far as the camera's own `zoomSteps` range allowed, which can look wrong well before it gets there. Added `maxZoomPercent` as a fourth tunable setting alongside face-cam width and the two paddings (same storage/debug-panel pattern). `centreCameraOnContent` clamps the fit zoom to whichever is more restrictive of `maxZoomPercent` and the camera's own `zoomSteps` max. The debug panel shows the live zoom % (`editor.getZoomLevel()`, tldraw's own `useValue` idiom) so it can be tuned against real diagrams.

- **Shipped defaults, not placeholders.** `CENTERING_DEFAULTS` now ships Matt's actual tuned rig — face-cam width 492, padding 150×120, max zoom 225% — instead of the earlier zero/300 placeholders, so a fresh install is correctly framed without ever opening the debug panel. Every centering storage key got a `:v2` suffix so this actually reaches machines that already have something written under the old keys (`localStorage` always wins over a default) — the debug panel keeps working exactly as before for future re-tuning, it just writes under the new name.

## Test plan
- [x] `pnpm --filter @cvm/local test -- app/features/diagrams` — 152/152 passing: `getRightOffscreenWidth`/`getSafeAreaInsets`, sidebar-independence end-to-end in `centreCameraOnContent`, the hotkey matcher, the fit-past-100% behaviour, the `maxZoomPercent` cap (default, override, and zoomSteps still winning when tighter), and the shipped defaults composing correctly end to end
- [x] `pnpm --filter @cvm/local run typecheck` / `lint:boundaries` — clean
- [x] Pre-commit hooks (typecheck + lint:boundaries across the monorepo) passed on every commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)