### PR TITLE
fix(cli): let piped output drain before exit

### DIFF
--- a/apps/local/app/cli/bin.mjs
+++ b/apps/local/app/cli/bin.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 /**
- * The outermost bin edge for the globally-linked `cvm` command. This is the
- * ONLY place process.exit is allowed.
+ * The outermost bin edge for the globally-linked `cvm` command.
  *
  * It is a PLAIN Node launcher (not TypeScript) on purpose: it must run before
  * tsx is initialised so it can pin tsx to THIS project's tsconfig. tsx resolves
@@ -24,13 +23,15 @@ const { tsImport } = await import("tsx/esm/api");
 const { runCli } = await tsImport("./main.ts", import.meta.url);
 
 runCli(process.argv.slice(2)).then(
-  (code) => process.exit(code),
+  (code) => {
+    process.exitCode = code;
+  },
   (cause) => {
     // Last-resort guard: runCli is designed never to reject, but if something
     // escapes, render a clean DatabaseError (never a raw stack) and exit 4.
     process.stderr.write(
       JSON.stringify({ _tag: "DatabaseError", message: String(cause) }) + "\n"
     );
-    process.exit(4);
+    process.exitCode = 4;
   }
 );

--- a/apps/local/app/cli/bin.test.ts
+++ b/apps/local/app/cli/bin.test.ts
@@ -1,0 +1,71 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true }))
+  );
+});
+
+const runLauncherThroughSlowPipe = async (launcher: string) => {
+  const child = spawn(process.execPath, [launcher], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+
+  child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+  child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+  child.stdout.pause();
+
+  const closed = new Promise<number | null>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", resolve);
+  });
+
+  // Keep the pipe blocked until the launcher has attempted its entire write.
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  child.stdout.resume();
+
+  const exitCode = await closed;
+
+  return {
+    exitCode,
+    stdout: Buffer.concat(stdout),
+    stderr: Buffer.concat(stderr).toString(),
+  };
+};
+
+describe("the cvm bin launcher", () => {
+  it("lets stdout drain before exiting through a slow pipe", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "cvm-bin-"));
+    temporaryDirectories.push(directory);
+
+    const binPath = fileURLToPath(new URL("./bin.mjs", import.meta.url));
+    const source = await readFile(binPath, "utf8");
+    const byteCount = 4 * 1024 * 1024;
+    const fixture = source.replace(
+      /const \{ tsImport \}[\s\S]*?const \{ runCli \} = await tsImport\([^;]+;/,
+      `const runCli = async () => { process.stdout.write("x".repeat(${byteCount})); return 0; };`
+    );
+    expect(fixture).not.toBe(source);
+
+    const launcher = join(directory, "bin.mjs");
+    await writeFile(launcher, fixture);
+
+    const result = await runLauncherThroughSlowPipe(launcher);
+
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toHaveLength(byteCount);
+    expect(result.stdout.every((byte) => byte === 120)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- replace immediate `process.exit()` calls at the `cvm` bin edge with `process.exitCode`
- let Node drain stdout and stderr naturally before terminating
- add a deterministic slow-pipe regression that verifies a 4 MiB CLI payload arrives intact

Closes #1467

## Testing

- `pnpm --filter @cvm/local exec vitest run app/cli/bin.test.ts`
- `pnpm --filter @cvm/local run test` (2,723 passed)
- `pnpm --filter @cvm/local run typecheck`
- repository pre-commit typecheck and boundary checks
- `pnpm exec prettier --check apps/local/app/cli/bin.mjs apps/local/app/cli/bin.test.ts`

## Regression proof

With the previous `process.exit(code)` behavior restored, the new test fails because the slow pipe receives only part of the 4 MiB payload. With this change, the complete payload is received before the process exits.
