### PR TITLE
The overlay preview follows the Clip's playhead

### DIFF
--- a/apps/local/app/features/video-editor/overlay-preview.tsx
+++ b/apps/local/app/features/video-editor/overlay-preview.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
-import { Player } from "@remotion/player";
+import { useEffect, useMemo, useRef } from "react";
+import { Player, type PlayerRef } from "@remotion/player";
 import {
   DefinitionCardPreview,
   type DefinitionCard as DefinitionCardInputProps,
@@ -41,6 +41,20 @@ const { width: COMPOSITION_WIDTH, height: COMPOSITION_HEIGHT } =
  */
 const DEFINITION_CARD_FPS = 60;
 
+/**
+ * The frame of `overlay`'s own card timeline that `currentTime` names, clamped
+ * into the card's own duration. `currentTime` and `at` are both Clip-relative,
+ * so the difference between them is the card's own elapsed time.
+ */
+const overlayFrameAt = (overlay: ClipOverlay, currentTime: number) =>
+  Math.max(
+    0,
+    Math.min(
+      Math.ceil(overlay.durationInSeconds * DEFINITION_CARD_FPS) - 1,
+      Math.round((currentTime - overlay.at) * DEFINITION_CARD_FPS)
+    )
+  );
+
 /** The Overlay active at `currentTime`, or `undefined` if none is. */
 const findActiveOverlay = (overlays: ClipOverlay[], currentTime: number) =>
   overlays.find(
@@ -60,21 +74,41 @@ const findActiveOverlay = (overlays: ClipOverlay[], currentTime: number) =>
  * `currentTime` (not something `cvm overlay` guards against today), the first
  * one found wins; that is a rare edge case not worth solving elegantly.
  *
+ * The `<Player>` never plays on its own clock. It is held paused and seeked to
+ * the frame `currentTime` names, so the card is a pure function of the Clip's
+ * playhead — exactly as the export composites it. A free-running `<Player>`
+ * would show nothing at all until playback happened to cross the Overlay's
+ * `at`, and would then drift away from the footage on pause, on scrub and at
+ * any playback rate other than 1x.
+ *
  * Keyed by the active Overlay's `id` so switching from one Overlay to another
- * remounts the `<Player>` — a fresh render from frame 0 — rather than trying
- * to seek an existing one to a new composition.
+ * remounts the `<Player>` on the new card, rather than trying to reuse a
+ * `<Player>` that is already mounted on a different composition.
  */
 export const OverlayPreview = (props: {
   overlays: ClipOverlay[];
   /** This Clip's own current playback position, in seconds. */
   currentTime: number;
 }) => {
+  const playerRef = useRef<PlayerRef>(null);
   const active = useMemo(
     () => findActiveOverlay(props.overlays, props.currentTime),
     [props.overlays, props.currentTime]
   );
 
-  if (!active) {
+  // The frame of the card that `currentTime` names. `undefined` when no
+  // Overlay covers the playhead — computed before the early return below so
+  // the seek effect keeps a stable hook order.
+  const frame = active ? overlayFrameAt(active, props.currentTime) : undefined;
+
+  useEffect(() => {
+    if (frame === undefined) {
+      return;
+    }
+    playerRef.current?.seekTo(frame);
+  }, [frame]);
+
+  if (!active || frame === undefined) {
     return null;
   }
 
@@ -93,6 +127,7 @@ export const OverlayPreview = (props: {
     <div className="absolute inset-0" style={{ pointerEvents: "none" }}>
       <Player
         key={active.id}
+        ref={playerRef}
         component={DefinitionCardPreview}
         inputProps={inputProps}
         fps={DEFINITION_CARD_FPS}
@@ -100,7 +135,9 @@ export const OverlayPreview = (props: {
         compositionWidth={COMPOSITION_WIDTH}
         compositionHeight={COMPOSITION_HEIGHT}
         style={{ width: "100%", height: "100%" }}
-        autoPlay
+        // Mounted on the frame the playhead already sits on, so a card the
+        // playhead lands in the middle of does not flash its entrance.
+        initialFrame={frame}
         loop={false}
         controls={false}
       />

--- a/apps/local/app/features/video-editor/preloadable-clip.tsx
+++ b/apps/local/app/features/video-editor/preloadable-clip.tsx
@@ -45,6 +45,34 @@ export const PreloadableClip = (props: {
 
   const isPlaying = !props.hidden && props.state === "playing";
 
+  // Keeps the overlay playhead in step with the `<video>` while it is NOT
+  // playing. The rAF loop below stops on pause and never runs before the first
+  // play, so on its own it leaves `overlayCurrentTime` at 0 — a paused or
+  // scrubbed Clip would show no Definition Card at all, however far into an
+  // Overlay the playhead sits.
+  useEffect(() => {
+    const video = ref.current;
+    if (!video || props.hidden || props.overlays.length === 0) {
+      return;
+    }
+
+    const sync = () =>
+      setOverlayCurrentTime(video.currentTime - props.clip.sourceStartTime);
+
+    sync();
+    video.addEventListener("seeked", sync);
+    video.addEventListener("timeupdate", sync);
+    return () => {
+      video.removeEventListener("seeked", sync);
+      video.removeEventListener("timeupdate", sync);
+    };
+  }, [
+    ref.current,
+    props.hidden,
+    props.overlays.length,
+    props.clip.sourceStartTime,
+  ]);
+
   useEffect(() => {
     if (!ref.current) {
       return;


### PR DESCRIPTION
## Why you could not see any Overlays

The in-editor Definition Card preview from #1581 is wired correctly end to end — the loader reads the Overlays, they reach `PreloadableClip`, and the `<Player>` mounts. But it only ever drew a card **if playback happened to run across the Overlay's `at` while that Clip was playing**.

Scrub to a card you just authored, or open the Video and look at it, and nothing appears. That is how you check a card, so the feature reads as "Overlays do not work at all".

## The two causes

**`preloadable-clip.tsx`** fed `overlayCurrentTime` only from the rAF loop, and that loop returns early when the Clip is not playing:

```ts
if (!isPlaying && preloadState === "finished") {
  return;
}
```

So on a paused or freshly-loaded Clip the overlay playhead stayed at `0`, `findActiveOverlay` never matched, and `OverlayPreview` returned `null`. A `seeked`/`timeupdate` listener now keeps it in step with the `<video>` whenever the Clip is on screen.

**`overlay-preview.tsx`** let the `<Player>` `autoPlay` on its own wall clock. Once mounted, the card drifted away from the footage: it kept animating through a pause, and lagged at any playback rate other than 1x. The `<Player>` is now held paused and seeked to the frame the playhead names, mounted at that frame via `initialFrame` so a card entered mid-way does not flash its entrance.

The card is now a pure function of the Clip's playhead — the same relation the export composites.

## Verification

Driven in a real browser against real footage, on this build and on `main`, using Video `c1398147` (which has three authored Overlays):

| Playhead | Meaning | `main` | This branch |
|---|---|---|---|
| 29.99s, paused | before the Overlay's `at` | no card | no card |
| 31.77s, paused | 5.7s into Clip a1, inside the 5s..13.7s window | **no card** | **card drawn** |
| 31.25s, playing | playback crosses `at` | card drawn | card drawn |

`typecheck`, `lint:boundaries` and the 351 `apps/local` video-editor tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)