### PR TITLE
An Overlay in the preview covers the Clips it runs across, and every Clip says so

### DIFF
--- a/apps/local/app/features/video-editor/components/clip-item.tsx
+++ b/apps/local/app/features/video-editor/components/clip-item.tsx
@@ -17,6 +17,7 @@ import {
   ChevronRightIcon,
   FilmIcon,
   ImageIcon,
+  LayersIcon,
   Link2Icon,
   Loader2,
   PauseIcon,
@@ -130,6 +131,14 @@ export const ClipItem = (props: ClipItemProps) => {
   const onUnpinDiagram = useContextSelector(
     VideoEditorContext,
     (ctx) => ctx.onUnpinDiagram
+  );
+  // Every Overlay that COVERS this Clip, anchored to it or spilling onto it
+  // from an earlier one — the same grouping the player preview draws from, so
+  // a Clip carries a badge exactly when a card is on screen over it.
+  const coveringOverlays = useContextSelector(VideoEditorContext, (ctx) =>
+    clip.type === "on-database"
+      ? ctx.overlaysByClipId.get(clip.databaseId)
+      : undefined
   );
   const percentComplete = getClipPercentComplete(clip, currentTimeInClip);
 
@@ -251,6 +260,39 @@ export const ClipItem = (props: ClipItemProps) => {
                   <ZoomInIcon className="w-3 h-3 shrink-0" />
                   Zoomed
                 </span>
+              </div>
+            )}
+
+            {/* Overlays covering this Clip. Definition Card is the only
+                content-kind there is today (see the `overlays` table, which
+                deliberately has no `kind` column), so the kind is spelled out
+                here rather than read off the row. A card anchored to an
+                earlier Clip is listed too, because it is still on screen
+                here — `at` is negative for those. */}
+            {coveringOverlays && coveringOverlays.length > 0 && (
+              <div className="z-10 relative mt-2 flex flex-wrap gap-1">
+                {coveringOverlays.map((overlay) => (
+                  <span
+                    key={overlay.id}
+                    title={
+                      overlay.at < 0
+                        ? `Definition Card, continuing from an earlier Clip: ${overlay.title}`
+                        : `Definition Card, ${overlay.at}s into this Clip for ${overlay.durationInSeconds}s: ${overlay.title}`
+                    }
+                    className={cn(
+                      "inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground max-w-[16rem]",
+                      // Dimmed where the card only carries over from an
+                      // earlier Clip, so the Clip that OWNS it still reads as
+                      // the one to edit.
+                      overlay.at < 0 && "opacity-60"
+                    )}
+                  >
+                    <LayersIcon className="w-3 h-3 shrink-0" />
+                    <span className="truncate">
+                      Definition Card · {overlay.title}
+                    </span>
+                  </span>
+                ))}
               </div>
             )}
 

--- a/apps/local/app/features/video-editor/components/portrait-studio-panel.tsx
+++ b/apps/local/app/features/video-editor/components/portrait-studio-panel.tsx
@@ -7,6 +7,7 @@ import { StudioActionsDropdown } from "./studio-actions-dropdown";
 import { MissingWordTimingBadge } from "./transcript-word-actions";
 import { PreloadableClipManager } from "../preloadable-clip";
 import type { ClipOverlay } from "../overlay-preview";
+import type { OverlaySpillClip } from "../overlay-spill";
 import {
   getIsOBSActive as getIsOBSActiveSelector,
   getShowCenterLine as getShowCenterLineSelector,
@@ -247,6 +248,7 @@ export const PortraitStudioPanel = () => {
                 // `DEFINITION_CARD_FRAME` in `overlay-render-cache.ts`); the
                 // Shorts studio has no overlay preview of its own yet.
                 overlays={NO_OVERLAYS}
+                timelineClips={NO_TIMELINE_CLIPS}
               />
             </div>
 
@@ -338,3 +340,6 @@ export const PortraitStudioPanel = () => {
 
 /** A stable empty array — the Shorts studio has no overlay preview yet. */
 const NO_OVERLAYS: ClipOverlay[] = [];
+
+/** Nothing to measure, because there is nothing to spill (see `NO_OVERLAYS`). */
+const NO_TIMELINE_CLIPS: OverlaySpillClip[] = [];

--- a/apps/local/app/features/video-editor/components/portrait-studio-panel.tsx
+++ b/apps/local/app/features/video-editor/components/portrait-studio-panel.tsx
@@ -7,7 +7,6 @@ import { StudioActionsDropdown } from "./studio-actions-dropdown";
 import { MissingWordTimingBadge } from "./transcript-word-actions";
 import { PreloadableClipManager } from "../preloadable-clip";
 import type { ClipOverlay } from "../overlay-preview";
-import type { OverlaySpillClip } from "../overlay-spill";
 import {
   getIsOBSActive as getIsOBSActiveSelector,
   getShowCenterLine as getShowCenterLineSelector,
@@ -247,8 +246,7 @@ export const PortraitStudioPanel = () => {
                 // previews — are a landscape/course-video feature (see
                 // `DEFINITION_CARD_FRAME` in `overlay-render-cache.ts`); the
                 // Shorts studio has no overlay preview of its own yet.
-                overlays={NO_OVERLAYS}
-                timelineClips={NO_TIMELINE_CLIPS}
+                overlaysByClipId={NO_OVERLAYS}
               />
             </div>
 
@@ -338,8 +336,5 @@ export const PortraitStudioPanel = () => {
   );
 };
 
-/** A stable empty array — the Shorts studio has no overlay preview yet. */
-const NO_OVERLAYS: ClipOverlay[] = [];
-
-/** Nothing to measure, because there is nothing to spill (see `NO_OVERLAYS`). */
-const NO_TIMELINE_CLIPS: OverlaySpillClip[] = [];
+/** A stable empty map — the Shorts studio has no overlay preview yet. */
+const NO_OVERLAYS = new Map<string, ClipOverlay[]>();

--- a/apps/local/app/features/video-editor/components/video-player-panel.tsx
+++ b/apps/local/app/features/video-editor/components/video-player-panel.tsx
@@ -14,7 +14,6 @@ import { LessonBodyWriterModal } from "@/features/lesson-writer/lesson-body-writ
 import { AutofillDescriptionModal } from "@/features/lesson-writer/autofill-description-modal";
 import { VideoPlayerLinksTab } from "./video-player-links-tab";
 import { PreloadableClipManager } from "../preloadable-clip";
-import { toOverlaySpillClips } from "../overlay-spill";
 import {
   getLastTranscribedClipId as getLastTranscribedClipIdSelector,
   getChapters as getChaptersSelector,
@@ -102,14 +101,10 @@ export const VideoPlayerPanel = () => {
     (ctx) => ctx.clipsToAggressivelyPreload
   );
   const clips = useContextSelector(VideoEditorContext, (ctx) => ctx.clips);
-  const overlays = useContextSelector(
+  const overlaysByClipId = useContextSelector(
     VideoEditorContext,
-    (ctx) => ctx.overlays
+    (ctx) => ctx.overlaysByClipId
   );
-  // The whole Video, measured — an Overlay may outlive its anchor Clip and
-  // keep showing over the Clips that follow, including Clips the player has
-  // not preloaded yet and so does not pass to the manager below.
-  const timelineClips = useMemo(() => toOverlaySpillClips(clips), [clips]);
   const insertionPoint = useContextSelector(
     VideoEditorContext,
     (ctx) => ctx.insertionPoint
@@ -429,8 +424,7 @@ export const VideoPlayerPanel = () => {
                   onUpdateCurrentTime={onUpdateCurrentTime}
                   playbackRate={playbackRate}
                   scrubSeekTime={scrubSeekTime}
-                  overlays={overlays}
-                  timelineClips={timelineClips}
+                  overlaysByClipId={overlaysByClipId}
                 />
               </div>
             </>

--- a/apps/local/app/features/video-editor/components/video-player-panel.tsx
+++ b/apps/local/app/features/video-editor/components/video-player-panel.tsx
@@ -14,6 +14,7 @@ import { LessonBodyWriterModal } from "@/features/lesson-writer/lesson-body-writ
 import { AutofillDescriptionModal } from "@/features/lesson-writer/autofill-description-modal";
 import { VideoPlayerLinksTab } from "./video-player-links-tab";
 import { PreloadableClipManager } from "../preloadable-clip";
+import { toOverlaySpillClips } from "../overlay-spill";
 import {
   getLastTranscribedClipId as getLastTranscribedClipIdSelector,
   getChapters as getChaptersSelector,
@@ -105,6 +106,10 @@ export const VideoPlayerPanel = () => {
     VideoEditorContext,
     (ctx) => ctx.overlays
   );
+  // The whole Video, measured — an Overlay may outlive its anchor Clip and
+  // keep showing over the Clips that follow, including Clips the player has
+  // not preloaded yet and so does not pass to the manager below.
+  const timelineClips = useMemo(() => toOverlaySpillClips(clips), [clips]);
   const insertionPoint = useContextSelector(
     VideoEditorContext,
     (ctx) => ctx.insertionPoint
@@ -425,6 +430,7 @@ export const VideoPlayerPanel = () => {
                   playbackRate={playbackRate}
                   scrubSeekTime={scrubSeekTime}
                   overlays={overlays}
+                  timelineClips={timelineClips}
                 />
               </div>
             </>

--- a/apps/local/app/features/video-editor/overlay-preview.tsx
+++ b/apps/local/app/features/video-editor/overlay-preview.tsx
@@ -12,6 +12,11 @@ import { VIDEO_FORMAT_DIMENSIONS } from "@/features/videos/video-format";
  * `packages/core/services/db-overlay-operations.server.ts`), shaped for the
  * client. `at`/`durationInSeconds` are already Clip-relative — this is a
  * client-side echo of the DB row, not a new coordinate system.
+ *
+ * One exception: `groupOverlaysByClip` hands a Clip that an Overlay SPILLS
+ * onto a copy of that Overlay whose `at` is negative, meaning "this card
+ * started that many seconds before this Clip did". `clipId` still names the
+ * anchor Clip, and `durationInSeconds` is still the card's own full length.
  */
 export type ClipOverlay = {
   id: string;
@@ -43,8 +48,10 @@ const DEFINITION_CARD_FPS = 60;
 
 /**
  * The frame of `overlay`'s own card timeline that `currentTime` names, clamped
- * into the card's own duration. `currentTime` and `at` are both Clip-relative,
- * so the difference between them is the card's own elapsed time.
+ * into the card's own duration. `currentTime` and `at` are both relative to
+ * the same Clip, so the difference between them is the card's own elapsed
+ * time — including when `at` is negative because the card began on an earlier
+ * Clip, which simply makes that difference larger.
  */
 const overlayFrameAt = (overlay: ClipOverlay, currentTime: number) =>
   Math.max(
@@ -55,13 +62,26 @@ const overlayFrameAt = (overlay: ClipOverlay, currentTime: number) =>
     )
   );
 
-/** The Overlay active at `currentTime`, or `undefined` if none is. */
-const findActiveOverlay = (overlays: ClipOverlay[], currentTime: number) =>
-  overlays.find(
-    (overlay) =>
+/**
+ * The Overlay active at `currentTime`, or `undefined` if none is.
+ *
+ * Searched from the end, so that where two Overlays overlap — a card spilling
+ * off an earlier Clip and a card anchored to this one — the later of the two
+ * wins. That is the one the export draws on top: `compositeOverlaysOntoExport`
+ * chains the cards in timeline order, so each composites over the one before.
+ */
+const findActiveOverlay = (overlays: ClipOverlay[], currentTime: number) => {
+  for (let index = overlays.length - 1; index >= 0; index--) {
+    const overlay = overlays[index]!;
+    if (
       currentTime >= overlay.at &&
       currentTime < overlay.at + overlay.durationInSeconds
-  );
+    ) {
+      return overlay;
+    }
+  }
+  return undefined;
+};
 
 /**
  * The overlay preview for one Clip: at most one Definition Card, rendered by
@@ -70,9 +90,13 @@ const findActiveOverlay = (overlays: ClipOverlay[], currentTime: number) =>
  * top and keeps its own playback untouched).
  *
  * Read-only — there is no in-UI authoring here, only a preview of what `cvm
- * overlay` has already created. If more than one Overlay somehow overlaps at
- * `currentTime` (not something `cvm overlay` guards against today), the first
- * one found wins; that is a rare edge case not worth solving elegantly.
+ * overlay` has already created. At most one card is drawn at a time: where two
+ * overlap, the later one wins (see `findActiveOverlay`), which is the one the
+ * export puts on top but is not the two-card stack the export would show.
+ *
+ * `overlays` is not only the Overlays anchored to this Clip — it is every
+ * Overlay this Clip must DRAW, which `groupOverlaysByClip` widens to include
+ * cards that started on an earlier Clip and are still running.
  *
  * The `<Player>` never plays on its own clock. It is held paused and seeked to
  * the frame `currentTime` names, so the card is a pure function of the Clip's

--- a/apps/local/app/features/video-editor/overlay-spill.test.ts
+++ b/apps/local/app/features/video-editor/overlay-spill.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ClipOnDatabase,
+  DatabaseId,
+  FrontendId,
+} from "./clip-state-reducer";
+import { BEAT_DURATION } from "./constants";
+import type { ClipOverlay } from "./overlay-preview";
+import {
+  groupOverlaysByClip,
+  toOverlaySpillClips,
+  type OverlaySpillClip,
+} from "./overlay-spill";
+
+const clip = (
+  databaseId: string,
+  durationInSeconds: number
+): OverlaySpillClip => ({ databaseId, durationInSeconds });
+
+/** A Clip the preview cannot play and cannot measure. */
+const unknownClip: OverlaySpillClip = {
+  databaseId: null,
+  durationInSeconds: null,
+};
+
+const overlay = (props: {
+  clipId: string;
+  at: number;
+  durationInSeconds: number;
+  id?: string;
+}): ClipOverlay => ({
+  id: props.id ?? "overlay-1",
+  clipId: props.clipId,
+  at: props.at,
+  durationInSeconds: props.durationInSeconds,
+  title: "A Definition Card",
+  description: "What it means.",
+});
+
+describe("groupOverlaysByClip", () => {
+  it("gives an Overlay that fits inside its Clip to that Clip only", () => {
+    const byClip = groupOverlaysByClip(
+      [clip("a", 10), clip("b", 10)],
+      [overlay({ clipId: "a", at: 2, durationInSeconds: 5 })]
+    );
+
+    expect(byClip.get("a")).toEqual([
+      expect.objectContaining({ at: 2, durationInSeconds: 5 }),
+    ]);
+    expect(byClip.get("b")).toBeUndefined();
+  });
+
+  it("carries an Overlay that outlives its Clip onto the next Clip", () => {
+    const byClip = groupOverlaysByClip(
+      [clip("a", 10), clip("b", 10)],
+      [overlay({ clipId: "a", at: 8, durationInSeconds: 9 })]
+    );
+
+    expect(byClip.get("a")).toEqual([expect.objectContaining({ at: 8 })]);
+    // Clip "b" starts 10s after Clip "a" does, so the card began 2s before it.
+    expect(byClip.get("b")).toEqual([
+      expect.objectContaining({ at: -2, durationInSeconds: 9 }),
+    ]);
+  });
+
+  it("carries an Overlay across as many Clips as its duration reaches", () => {
+    const byClip = groupOverlaysByClip(
+      [clip("a", 4), clip("b", 4), clip("c", 4), clip("d", 4)],
+      [overlay({ clipId: "a", at: 1, durationInSeconds: 10 })]
+    );
+
+    expect(byClip.get("a")).toEqual([expect.objectContaining({ at: 1 })]);
+    expect(byClip.get("b")).toEqual([expect.objectContaining({ at: -3 })]);
+    expect(byClip.get("c")).toEqual([expect.objectContaining({ at: -7 })]);
+    // The card ends 11s in, and Clip "d" only starts at 12s.
+    expect(byClip.get("d")).toBeUndefined();
+  });
+
+  it("stops an Overlay at the end of the Video", () => {
+    const byClip = groupOverlaysByClip(
+      [clip("a", 4)],
+      [overlay({ clipId: "a", at: 1, durationInSeconds: 60 })]
+    );
+
+    expect(byClip.get("a")).toEqual([expect.objectContaining({ at: 1 })]);
+    expect(byClip.size).toBe(1);
+  });
+
+  it("keeps every Overlay a Clip must draw, in timeline order", () => {
+    const byClip = groupOverlaysByClip(
+      [clip("a", 10), clip("b", 10)],
+      [
+        overlay({ id: "spills", clipId: "a", at: 8, durationInSeconds: 6 }),
+        overlay({ id: "own", clipId: "b", at: 1, durationInSeconds: 5 }),
+      ]
+    );
+
+    expect(byClip.get("b")?.map((each) => each.id)).toEqual(["spills", "own"]);
+  });
+
+  it("stops the walk at a Clip of unknown length", () => {
+    const byClip = groupOverlaysByClip(
+      [clip("a", 10), unknownClip, clip("c", 10)],
+      [overlay({ clipId: "a", at: 8, durationInSeconds: 30 })]
+    );
+
+    expect(byClip.get("a")).toEqual([expect.objectContaining({ at: 8 })]);
+    // Where Clip "c" starts cannot be known, so the card is not guessed onto it.
+    expect(byClip.get("c")).toBeUndefined();
+  });
+
+  it("drops an Overlay whose anchor Clip is not on the timeline", () => {
+    const byClip = groupOverlaysByClip(
+      [clip("a", 10)],
+      [overlay({ clipId: "archived", at: 1, durationInSeconds: 5 })]
+    );
+
+    expect(byClip.size).toBe(0);
+  });
+});
+
+const databaseClip = (props: {
+  databaseId: string;
+  sourceStartTime: number;
+  sourceEndTime: number;
+  pauseType: ClipOnDatabase["pauseType"];
+}): ClipOnDatabase => ({
+  type: "on-database",
+  frontendId: `frontend-${props.databaseId}` as FrontendId,
+  databaseId: props.databaseId as DatabaseId,
+  videoFilename: "take.mkv",
+  sourceStartTime: props.sourceStartTime,
+  sourceEndTime: props.sourceEndTime,
+  text: "",
+  transcribedAt: null,
+  scene: null,
+  profile: null,
+  insertionOrder: null,
+  pauseType: props.pauseType,
+  zoomType: "none",
+  diagramSnapshotId: null,
+  diagramName: null,
+  webLinks: [],
+});
+
+describe("toOverlaySpillClips", () => {
+  it("measures a Clip by its own source window", () => {
+    expect(
+      toOverlaySpillClips([
+        databaseClip({
+          databaseId: "a",
+          sourceStartTime: 5,
+          sourceEndTime: 13,
+          pauseType: "none",
+        }),
+      ])
+    ).toEqual([{ databaseId: "a", durationInSeconds: 8 }]);
+  });
+
+  it("counts the Beat a long pause adds after the Clip", () => {
+    expect(
+      toOverlaySpillClips([
+        databaseClip({
+          databaseId: "a",
+          sourceStartTime: 0,
+          sourceEndTime: 8,
+          pauseType: "long",
+        }),
+      ])
+    ).toEqual([{ databaseId: "a", durationInSeconds: 8 + BEAT_DURATION }]);
+  });
+});

--- a/apps/local/app/features/video-editor/overlay-spill.ts
+++ b/apps/local/app/features/video-editor/overlay-spill.ts
@@ -1,0 +1,116 @@
+import type { Clip } from "./clip-state-reducer";
+import { BEAT_DURATION } from "./constants";
+import type { ClipOverlay } from "./overlay-preview";
+
+/**
+ * One Clip as the spill walk needs it.
+ *
+ * `durationInSeconds` is how long the Clip holds the PREVIEW playhead — its
+ * own length plus its Beat, if it has one — not how long the export gives it.
+ * The two differ by a fraction of a second per Beat (`BEAT_DURATION` here
+ * against `LONG_PAUSE_DURATION_IN_SECONDS` there), which is close enough to
+ * show an author where a card lands, and is the clock the card is actually
+ * drawn against on screen.
+ */
+export type OverlaySpillClip = {
+  /**
+   * `null` for a Clip that is not on the database yet. Such a Clip owns no
+   * Overlays and the preview does not render it, but it still takes up time.
+   */
+  databaseId: string | null;
+  /** `null` when the Clip's length is not known yet. */
+  durationInSeconds: number | null;
+};
+
+/**
+ * The Video's Clips measured for the spill walk, in playback order.
+ *
+ * A Clip the preview cannot play — one not on the database yet — is kept in
+ * the list rather than dropped, with no length, so that an Overlay stops at it
+ * instead of silently jumping the gap it leaves.
+ */
+export const toOverlaySpillClips = (
+  clips: readonly Clip[]
+): OverlaySpillClip[] =>
+  clips.map((clip) =>
+    clip.type === "on-database"
+      ? {
+          databaseId: clip.databaseId,
+          durationInSeconds:
+            clip.sourceEndTime -
+            clip.sourceStartTime +
+            // The Beat the preview waits out before it starts the next Clip.
+            (clip.pauseType === "long" ? BEAT_DURATION : 0),
+        }
+      : { databaseId: null, durationInSeconds: null }
+  );
+
+/**
+ * Every Overlay each Clip must draw, keyed by Clip database id.
+ *
+ * An Overlay lasts as long as it says, not as long as its anchor Clip. One
+ * that outlives its Clip keeps showing over the Clips that follow, and the
+ * export composites it exactly so — see `placeOverlaysOnTimeline` in
+ * `app/services/overlay-compositing.ts`. This gives the preview the same
+ * behaviour, so an author sees a long card the way the final edit will play
+ * it instead of watching it disappear at the Clip boundary.
+ *
+ * Each Clip the Overlay reaches gets its own copy of it, with `at` made
+ * relative to THAT Clip. For every Clip after the anchor that `at` is
+ * negative — the card started that many seconds before the Clip did — which
+ * `overlayFrameAt` reads correctly with no special case, and which puts the
+ * card on screen part-way through rather than at its entrance.
+ *
+ * `clips` must be the whole Video in playback order. The walk stops at a Clip
+ * of unknown length rather than guessing where the Clip after it starts.
+ */
+export const groupOverlaysByClip = (
+  clips: readonly OverlaySpillClip[],
+  overlays: readonly ClipOverlay[]
+): Map<string, ClipOverlay[]> => {
+  const indexOfClip = new Map<string, number>();
+  clips.forEach((clip, index) => {
+    if (clip.databaseId !== null) {
+      indexOfClip.set(clip.databaseId, index);
+    }
+  });
+
+  const byClip = new Map<string, ClipOverlay[]>();
+  const add = (databaseId: string, overlay: ClipOverlay) => {
+    const forClip = byClip.get(databaseId);
+    if (forClip) {
+      forClip.push(overlay);
+    } else {
+      byClip.set(databaseId, [overlay]);
+    }
+  };
+
+  for (const overlay of overlays) {
+    const anchor = indexOfClip.get(overlay.clipId);
+    if (anchor === undefined) {
+      continue;
+    }
+
+    const endsAt = overlay.at + overlay.durationInSeconds;
+    // Seconds from the start of the anchor Clip to the start of `clips[index]`.
+    let clipStartsAt = 0;
+
+    for (let index = anchor; index < clips.length; index++) {
+      if (clipStartsAt >= endsAt) {
+        break;
+      }
+
+      const clip = clips[index]!;
+      if (clip.databaseId !== null) {
+        add(clip.databaseId, { ...overlay, at: overlay.at - clipStartsAt });
+      }
+
+      if (clip.durationInSeconds === null) {
+        break;
+      }
+      clipStartsAt += clip.durationInSeconds;
+    }
+  }
+
+  return byClip;
+};

--- a/apps/local/app/features/video-editor/overlay-spill.ts
+++ b/apps/local/app/features/video-editor/overlay-spill.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import type { Clip } from "./clip-state-reducer";
 import { BEAT_DURATION } from "./constants";
 import type { ClipOverlay } from "./overlay-preview";
@@ -114,3 +115,20 @@ export const groupOverlaysByClip = (
 
   return byClip;
 };
+
+/**
+ * `groupOverlaysByClip` for a whole Video, held steady between renders.
+ *
+ * Worked out once, at the editor's root, and read from `VideoEditorContext`
+ * by both the player preview and the Clip list — which must agree about the
+ * Clips a card covers, or a Clip would carry a badge for a card that never
+ * appears over it.
+ */
+export const useOverlaysByClipId = (
+  clips: readonly Clip[],
+  overlays: readonly ClipOverlay[]
+) =>
+  useMemo(
+    () => groupOverlaysByClip(toOverlaySpillClips(clips), overlays),
+    [clips, overlays]
+  );

--- a/apps/local/app/features/video-editor/preloadable-clip.tsx
+++ b/apps/local/app/features/video-editor/preloadable-clip.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ClipOnDatabase, FrontendId } from "./clip-state-reducer";
 import { cn } from "@/lib/utils";
 import { clipZoomCssStyle } from "@/features/videos/clip-zoom";
@@ -10,7 +10,6 @@ import {
 import { useAudioBoost } from "./use-audio-boost";
 import type { RunningState } from "./video-state-reducer";
 import { OverlayPreview, type ClipOverlay } from "./overlay-preview";
-import { groupOverlaysByClip, type OverlaySpillClip } from "./overlay-spill";
 
 const PRELOAD_PLAY_AMOUNT = 0.1;
 
@@ -218,23 +217,14 @@ export const PreloadableClipManager = (props: {
   onClipFinished: () => void;
   onUpdateCurrentTime: (time: number) => void;
   scrubSeekTime: number | undefined;
-  /** Every Overlay on this Video — grouped below into the Clips that draw it. */
-  overlays: ClipOverlay[];
   /**
-   * Every Clip on this Video in playback order — NOT only the preloaded ones
-   * in `clips` above. An Overlay may outlive its anchor Clip and keep showing
-   * over the Clips that follow, and working out how far it reaches means
-   * measuring those Clips, whether or not they are preloaded yet.
+   * Every Overlay each Clip must draw, keyed by Clip database id. Grouped for
+   * the whole Video upstream rather than here, because an Overlay may outlive
+   * its anchor Clip and keep showing over the Clips that follow — a walk that
+   * needs every Clip's length, not only the preloaded Clips in `clips` above.
    */
-  timelineClips: OverlaySpillClip[];
+  overlaysByClipId: Map<string, ClipOverlay[]>;
 }) => {
-  // Grouped once per change rather than re-walked per Clip per render — this
-  // Video may have many Clips, each re-rendering on every playhead tick.
-  const overlaysByClipId = useMemo(
-    () => groupOverlaysByClip(props.timelineClips, props.overlays),
-    [props.timelineClips, props.overlays]
-  );
-
   return (
     <div className="">
       {props.clips.map((clip) => {
@@ -282,7 +272,9 @@ export const PreloadableClipManager = (props: {
               scrubSeekTime={
                 isCurrentlyPlaying ? props.scrubSeekTime : undefined
               }
-              overlays={overlaysByClipId.get(clip.databaseId) ?? EMPTY_OVERLAYS}
+              overlays={
+                props.overlaysByClipId.get(clip.databaseId) ?? EMPTY_OVERLAYS
+              }
             />
           </div>
         );

--- a/apps/local/app/features/video-editor/preloadable-clip.tsx
+++ b/apps/local/app/features/video-editor/preloadable-clip.tsx
@@ -10,6 +10,7 @@ import {
 import { useAudioBoost } from "./use-audio-boost";
 import type { RunningState } from "./video-state-reducer";
 import { OverlayPreview, type ClipOverlay } from "./overlay-preview";
+import { groupOverlaysByClip, type OverlaySpillClip } from "./overlay-spill";
 
 const PRELOAD_PLAY_AMOUNT = 0.1;
 
@@ -24,7 +25,11 @@ export const PreloadableClip = (props: {
   onUpdateCurrentTime: (time: number) => void;
   profile: string | undefined;
   scrubSeekTime: number | undefined;
-  /** This Clip's own Overlays only — already filtered by `clip_id` upstream. */
+  /**
+   * Every Overlay this Clip must draw — already selected upstream. Not the
+   * same as the Overlays anchored to it: a card anchored to an earlier Clip
+   * that is still running is in here too, with a negative `at`.
+   */
   overlays: ClipOverlay[];
 }) => {
   const [preloadState, setPreloadState] = useState<"preloading" | "finished">(
@@ -213,24 +218,22 @@ export const PreloadableClipManager = (props: {
   onClipFinished: () => void;
   onUpdateCurrentTime: (time: number) => void;
   scrubSeekTime: number | undefined;
-  /** Every Overlay on this Video — grouped below by `clip_id` per Clip. */
+  /** Every Overlay on this Video — grouped below into the Clips that draw it. */
   overlays: ClipOverlay[];
+  /**
+   * Every Clip on this Video in playback order — NOT only the preloaded ones
+   * in `clips` above. An Overlay may outlive its anchor Clip and keep showing
+   * over the Clips that follow, and working out how far it reaches means
+   * measuring those Clips, whether or not they are preloaded yet.
+   */
+  timelineClips: OverlaySpillClip[];
 }) => {
-  // Grouped once per `overlays` change rather than `.filter()`-ed per Clip
-  // per render — this Video may have many Clips, each re-rendering on every
-  // playhead tick.
-  const overlaysByClipId = useMemo(() => {
-    const map = new Map<string, ClipOverlay[]>();
-    for (const overlay of props.overlays) {
-      const forClip = map.get(overlay.clipId);
-      if (forClip) {
-        forClip.push(overlay);
-      } else {
-        map.set(overlay.clipId, [overlay]);
-      }
-    }
-    return map;
-  }, [props.overlays]);
+  // Grouped once per change rather than re-walked per Clip per render — this
+  // Video may have many Clips, each re-rendering on every playhead tick.
+  const overlaysByClipId = useMemo(
+    () => groupOverlaysByClip(props.timelineClips, props.overlays),
+    [props.timelineClips, props.overlays]
+  );
 
   return (
     <div className="">

--- a/apps/local/app/features/video-editor/video-editor-context.tsx
+++ b/apps/local/app/features/video-editor/video-editor-context.tsx
@@ -69,6 +69,12 @@ export type VideoEditorContextType = {
   allItems: TimelineItem[];
   /** Every Overlay on this Video, across all of its Clips (see overlay-preview.tsx). */
   overlays: ClipOverlay[];
+  /**
+   * Every Overlay each Clip COVERS, keyed by Clip database id — wider than
+   * `overlays` grouped by `clipId`, because an Overlay may outlive its anchor
+   * Clip and keep covering the Clips that follow. See `overlay-spill.ts`.
+   */
+  overlaysByClipId: Map<string, ClipOverlay[]>;
   sessions: RecordingSession[];
   sessionPanels: SessionPanelData[];
   videoTitle: string;

--- a/apps/local/app/features/video-editor/video-editor.tsx
+++ b/apps/local/app/features/video-editor/video-editor.tsx
@@ -54,6 +54,7 @@ import {
 } from "./video-editor-context";
 import type { VideoFormat } from "@/features/videos/video-format";
 import type { ClipOverlay } from "./overlay-preview";
+import { useOverlaysByClipId } from "./overlay-spill";
 import {
   getClipsToAggressivelyPreload,
   getTotalDuration,
@@ -171,6 +172,7 @@ export const VideoEditor = (props: {
   // exactly what a Copy Video duplicates — clips on the database that aren't on
   // their way to the archive — so its length is what the Copy Video modal shows.
   const clips = useMemo(() => timelineItems.filter(isClip), [timelineItems]);
+  const overlaysByClipId = useOverlaysByClipId(clips, props.overlays);
 
   // Derive session panel data for RecordingSessionPanel components
   const sessionPanels = useMemo(
@@ -431,6 +433,7 @@ export const VideoEditor = (props: {
       items: timelineItems,
       allItems: props.items,
       overlays: props.overlays,
+      overlaysByClipId,
       sessions: props.sessions,
       sessionPanels,
       videoTitle: props.videoTitle,
@@ -530,6 +533,7 @@ export const VideoEditor = (props: {
       props.anyClipsMissingTranscriptWords,
       props.items,
       props.overlays,
+      overlaysByClipId,
       props.videoTitle,
       props.videoId,
       props.repoName,


### PR DESCRIPTION
## The problem

Two things about Overlays were invisible or wrong in the Video Editor.

**A card was cut off at the Clip boundary.** The export has always let an Overlay outlive its anchor Clip — `placeOverlaysOnTimeline` measures a card by its own `durationInSeconds` and cuts it only at the end of the Video. The preview did not: `<OverlayPreview>` is mounted inside the current Clip's own wrapper, so a card vanished the moment the next Clip started. Every card today is authored at 10s against Clips of 8-13s, so most of them were cut short on screen and did not show what the final edit will play.

**Nothing in the Clip list said an Overlay existed at all.** The only way to find one was to play the Video and watch for the card.

## The change

`groupOverlaysByClip` walks each Overlay forward through the Clips it reaches and gives each of them its own copy, with `at` made relative to that Clip — negative for the Clips after the anchor, which `overlayFrameAt` already reads correctly and which mounts the card part-way through instead of at its entrance. The walk measures a Clip on the **preview** clock, its Beat included, and stops at a Clip of unknown length rather than guessing.

The grouping is worked out once for the whole Video (`useOverlaysByClipId`) and put on `VideoEditorContext`. It is not a grouping any one Clip can do for itself — it needs every Clip's length — and having the player preview and the Clip list read the same map is what keeps a pill and a card on screen over the same Clips.

Each Clip now carries a pill per Overlay covering it, next to the Zoom pill and in the same style: **Definition Card · You need a paid plan**. A Clip an Overlay merely runs across gets one too, dimmed, so the Clip that OWNS the card still reads as the one to edit. The tooltip says where the card starts and how long it lasts, or that it continues from an earlier Clip.

The content-kind is spelled out in the component rather than read off the row, because the `overlays` table deliberately has no `kind` column while Definition Card is the only content-kind there is.

`findActiveOverlay` now searches from the end, so where a spilling card and a card anchored to this Clip overlap, the later one wins — the one the export composites on top.

## Verification

- `pnpm test` in `apps/local`: **235 files, 2869 tests, all pass** — 9 of them new, for `groupOverlaysByClip` and `toOverlaySpillClips`.
- `pnpm run typecheck` and `pnpm run lint:boundaries`: clean.
- Real browser, real footage, Video `c1398147`: the "You need a paid plan" card, anchored 5s into a Clip 8.77s long, stays on screen for its full 10s across the Clip boundary and 6.6s into the Clip that follows. Before this change it disappeared at the boundary.
- The same Video shows 5 pills — 3 anchored, 2 dimmed carry-overs — which matches the data exactly.

## Note for a follow-up, not fixed here

Every Overlay in the database is authored at `durationInSeconds: 10` while its Clip runs 7.9-13.3s. That is now visible rather than hidden, but whether 10s is the right length is an authoring decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)