### PR TITLE
A Bullet Panel slides the footage by half its ground, not all of it

### DIFF
--- a/apps/local/app/services/overlay-compositing.test.ts
+++ b/apps/local/app/services/overlay-compositing.test.ts
@@ -356,14 +356,14 @@ describe("buildOverlayCompositeFilterGraph — the camera Transform", () => {
   it("slides to the kind's own default Transform, which nobody authored", () => {
     const graph = buildOverlayCompositeFilterGraph([panel()])!;
 
-    // Unmoved (offset 0) to the panel's own ground width, 812 of 1920.
-    expect(graph).toContain("st(3,lerp(0.000000,0.422917,ld(2)))");
+    // Unmoved (offset 0) to half the panel's own ground, 406 of 1920.
+    expect(graph).toContain("st(3,lerp(0.000000,0.211458,ld(2)))");
     // The canvas is widened by exactly that travel, on the left, and the
     // picture is taken back out of it at its own size — so the source is
     // never magnified.
-    expect(graph).toContain("pad=w='iw*1.422917':h='ih':x='iw*0.422917':y='0'");
-    expect(graph).toContain("crop=w='iw/1.422917':h='ih'");
-    expect(graph).toContain("(iw/1.422917)*(0.422917-ld(3))");
+    expect(graph).toContain("pad=w='iw*1.211458':h='ih':x='iw*0.211458':y='0'");
+    expect(graph).toContain("crop=w='iw/1.211458':h='ih'");
+    expect(graph).toContain("(iw/1.211458)*(0.211458-ld(3))");
     // Nothing divides a dimension by the progress slot any more — that
     // division WAS the zoom.
     expect(graph).not.toContain("iw/ld(3)");

--- a/packages/core/features/videos/overlay-transform.test.ts
+++ b/packages/core/features/videos/overlay-transform.test.ts
@@ -118,8 +118,11 @@ const panelWindow: OverlayTransformWindow & { kind: string } = {
   endInSeconds: 20,
 };
 
-/** The arrived offset, as a fraction of frame width: the panel's own ground. */
-const PANEL_OFFSET = 812 / 1920;
+/**
+ * The arrived offset, as a fraction of frame width: HALF the panel's own ground,
+ * which is what puts the presenter in the middle of the block the panel leaves.
+ */
+const PANEL_OFFSET = 812 / 2 / 1920;
 
 describe("overlay transform", () => {
   describe("which kinds move the camera", () => {

--- a/packages/core/features/videos/overlay-transform.ts
+++ b/packages/core/features/videos/overlay-transform.ts
@@ -53,17 +53,27 @@ export type OverlayTransform = {
 const CENTERED: OverlayFraming = { offsetX: 0 };
 
 /**
- * How far a Bullet Panel slides the footage right: the exact width of the
- * panel's own opaque ground, 812 of 1920 (`GROUND_WIDTH` in the renderer's
- * `BulletPanel.tsx`).
+ * How far a Bullet Panel slides the footage right: HALF the width of the panel's
+ * own opaque ground, 406 of 1920 (the ground is 812 — `GROUND_WIDTH` in the
+ * renderer's `BulletPanel.tsx`).
  *
- * It is that width and not a rounder number because the two edges are meant to
- * meet. The footage's left edge arrives exactly where the panel's right edge
- * is, so the panel covers empty frame rather than the presenter, and no part of
- * the shot is hidden behind it. Slide less and the panel eats into the face;
- * slide more and a band of dead frame opens between the two.
+ * Half, because the thing that must end up centred is the PRESENTER, in the
+ * block of frame the panel leaves. Slide by half of what you cover and the
+ * source's own middle lands in the middle of what is left, at any panel width:
+ * the block runs from the panel's right edge to the frame's, so its centre sits
+ * half a panel to the right of the frame's centre, which is exactly how far the
+ * footage has come.
+ *
+ * So the panel DOES stand on the footage rather than beside it, and that is
+ * intended. Sliding the whole 812 makes the two edges meet and hides no pixel
+ * of the shot, but it throws the face out to the right of the space it has —
+ * the earlier framing, and the one this replaces. The ground is opaque, so what
+ * it stands on costs nothing.
+ *
+ * TUNING: by eye, against the Studio. It went from the full ground width to
+ * half of it.
  */
-const BULLET_PANEL_OFFSET_X = 812 / 1920;
+const BULLET_PANEL_OFFSET_X = 812 / 2 / 1920;
 
 /**
  * The move each content-kind asks for, or `null` for a kind that draws over


### PR DESCRIPTION
The full-ground slide put the two edges exactly together — the footage's left
edge landing on the panel's right edge — so the panel hid no pixel of the shot.
That was the wrong thing to optimise. It left the presenter's face out at the
right of the block it had, rather than in the middle of it.

**Slide by HALF the ground and the source's own centre lands in the centre of
what is left.** It is half at any panel width: the visible block runs from the
panel's right edge to the frame's, so its centre sits half a panel right of the
frame's centre, which is exactly how far the footage has come.

For today's numbers: the ground is 812 of 1920, so the block is 1108 wide and
its middle is at 1366. The source's middle starts at 960. It must travel 406 —
half of 812.

The panel now stands ON the footage. That is intended and costs nothing: the
ground is opaque.

## What changed

One constant, so the preview and the export move together:

- `BULLET_PANEL_OFFSET_X`: `812 / 1920` -> `812 / 2 / 1920`
- the ffmpeg literals in the compositing test follow — `0.422917` becomes
  `0.211458`, `1.422917` becomes `1.211458`

`CONTEXT.md` names no pixel figure for the **Transform**, so it needs no edit.

## Note for the author

`EXPORT_VERSION` is deliberately NOT bumped. This DOES change exported pixels
for a Video carrying a **Bullet Panel**, so it needs one if such a Video is
already exported. That is your call, not this PR's.

## Checks

- `packages/core` `features/videos` — 63 tests pass
- `apps/local` overlay services — 85 tests pass
- pre-commit in full: typecheck 7/7, `lint:boundaries` 4/4, file-token,
  no-dirname

🤖 Generated with [Claude Code](https://claude.com/claude-code)
