### PR TITLE
The Overlay Transform drops a crop option ffmpeg no longer has

### DIFF
--- a/apps/local/app/services/overlay-composite-ffmpeg-graph.test.ts
+++ b/apps/local/app/services/overlay-composite-ffmpeg-graph.test.ts
@@ -1,0 +1,91 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { buildOverlayCompositeFilterGraph } from "@/services/overlay-compositing";
+
+/**
+ * The one test that asks ffmpeg itself whether the compositing pass can run.
+ *
+ * Every other test of this graph reads the string, or evaluates the camera's
+ * expressions with an evaluator of its own. None of them can tell a node ffmpeg
+ * accepts from one it refuses, so a `crop` option that a newer ffmpeg had
+ * dropped passed every test and failed every export instead — the pass died at
+ * `export:composite-overlays` and the Video stayed an Unexported Video.
+ *
+ * So this test hands the REAL graph to the REAL ffmpeg over synthetic inputs
+ * and asks only that it parse and run. It says nothing about the picture; the
+ * arithmetic of the move is proved in `overlay-transform.test.ts`.
+ *
+ * Skipped where there is no ffmpeg. Exporting is a local-only command anyway,
+ * so the only machine that can be hurt by this failing is the only machine that
+ * can run it.
+ */
+const hasFfmpeg = (() => {
+  try {
+    execFileSync("ffmpeg", ["-version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+/** Runs the graph over one synthetic input per label it reads, for a moment. */
+const runGraph = (graph: string, inputCount: number) => {
+  const inputs = Array.from({ length: inputCount }, () => [
+    "-f",
+    "lavfi",
+    "-i",
+    "testsrc=size=320x180:rate=25",
+  ]).flat();
+
+  return execFileSync(
+    "ffmpeg",
+    [
+      "-hide_banner",
+      ...inputs,
+      "-filter_complex",
+      graph,
+      "-map",
+      "[outv]",
+      "-t",
+      "0.2",
+      "-f",
+      "null",
+      "-",
+    ],
+    { encoding: "utf8", stdio: ["ignore", "ignore", "pipe"] }
+  );
+};
+
+describe.skipIf(!hasFfmpeg)(
+  "the overlay compositing graph runs in ffmpeg",
+  () => {
+    it("runs a Bullet Panel, whose Kind carries a camera move", () => {
+      const graph = buildOverlayCompositeFilterGraph([
+        { startInSeconds: 0.5, endInSeconds: 16.5, kind: "bulletPanel" },
+      ]);
+
+      expect(graph).not.toBeNull();
+      expect(() => runGraph(graph!, 2)).not.toThrow();
+    });
+
+    it("runs a Definition Card, which carries none", () => {
+      const graph = buildOverlayCompositeFilterGraph([
+        { startInSeconds: 1, endInSeconds: 5, kind: "definitionCard" },
+      ]);
+
+      expect(graph).not.toBeNull();
+      expect(() => runGraph(graph!, 2)).not.toThrow();
+    });
+
+    it("runs several Overlays of both Kinds on one timeline", () => {
+      const graph = buildOverlayCompositeFilterGraph([
+        { startInSeconds: 0.5, endInSeconds: 16.5, kind: "bulletPanel" },
+        { startInSeconds: 20, endInSeconds: 24, kind: "definitionCard" },
+        { startInSeconds: 30, endInSeconds: 40, kind: "bulletPanel" },
+      ]);
+
+      expect(graph).not.toBeNull();
+      expect(() => runGraph(graph!, 4)).not.toThrow();
+    });
+  }
+);

--- a/packages/core/features/videos/overlay-transform.ts
+++ b/packages/core/features/videos/overlay-transform.ts
@@ -428,12 +428,14 @@ export const overlayTransformVideoFilter = (
     `color=${SLIDE_BACKGROUND_COLOR}`,
   ].join(":");
 
+  // NO `eval=` OPTION. ffmpeg 6.0 removed it from `crop` and evaluates `x`
+  // and `y` on every frame instead, so asking for `eval=frame` is not merely
+  // needless — it is refused, and the whole compositing pass dies with it.
   const crop = [
     `crop=w='${sourceWidth}'`,
     `h='ih'`,
     `x='${prelude}(${sourceWidth})*(${fmt(padLeft)}-ld(3))'`,
     `y='0'`,
-    `eval=frame`,
   ].join(":");
 
   return `${pad},${crop}`;


### PR DESCRIPTION
## What failed

The newest export — video `8cdbe2da-07f9-4a69-b76b-462bdadfd563`, 2026-08-23 16:48 — stopped at stage `export:composite-overlays` with exit code 8:

```
Error applying option 'eval' to filter 'crop': Option not found
```

## Why

`overlayTransformVideoFilter` ended the animated `crop` of the Overlay Transform with `eval=frame`. ffmpeg 6.0 removed that option from `crop` (this machine runs 6.1.1, whose `crop` takes only `w`, `h`, `x`, `y`, `keep_aspect`, `exact`). ffmpeg refuses the whole `filter_complex`, so the compositing pass dies and the Video stays an **Unexported Video**. Every Video carrying a **Bullet Panel** was affected — every Definition Card-only Video was not, because it asks for no camera move.

## The fix

Drop the option. It was needless as well as refused: ffmpeg now evaluates a crop's `x` and `y` on every frame, so the camera still slides. Verified on frames rendered by the real ffmpeg.

The **Export Hash** does not cover the filter text, so no address moves and no other export is invalidated.

## The test

The graph is only a string until ffmpeg reads it, and no test read it the way ffmpeg does — `overlay-transform.test.ts` evaluates the move's expressions with an evaluator of its own, so it passed throughout. This adds one smoke test that hands the REAL graph to the REAL ffmpeg over synthetic inputs and asks only that it run. Put back `eval=frame` and it fails with the exact message from the export log.

It skips where there is no ffmpeg, because exporting is a **Local-Only Command** anyway.

## Known limit

On ffmpeg below 6.0, `crop` defaults to `eval=init`, where this graph would freeze the camera silently rather than fail. If that matters, the place for it is a version check at the front of the Publish, not a branch inside the filter builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
