### PR TITLE
The camera and the panel read one curve, at one instant

### DIFF
--- a/apps/local/app/features/video-editor/overlay-preview.tsx
+++ b/apps/local/app/features/video-editor/overlay-preview.tsx
@@ -68,12 +68,22 @@ const OVERLAY_RENDER_FPS = 60;
  * including when `at` is negative because it began on an earlier Clip, which
  * simply makes that difference larger.
  */
+/**
+ * The frame of the Overlay's content that `currentTime` lands on.
+ *
+ * FLOOR, not round: it has to name the frame the EXPORT composites, and
+ * ffmpeg's `overlay` shows the most recent frame of the graphic whose time has
+ * passed. Rounding showed the next frame half a frame early, which put the
+ * panel up to half a frame ahead of the footage under it — and the footage is
+ * read on this same grid (`sampledTime` in `overlay-transform.ts`), so the two
+ * only stay locked while both round the same way.
+ */
 const overlayFrameAt = (overlay: ClipOverlay, currentTime: number) =>
   Math.max(
     0,
     Math.min(
       Math.ceil(overlay.durationInSeconds * OVERLAY_RENDER_FPS) - 1,
-      Math.round((currentTime - overlay.at) * OVERLAY_RENDER_FPS)
+      Math.floor((currentTime - overlay.at) * OVERLAY_RENDER_FPS)
     )
   );
 

--- a/apps/local/app/services/course-publish-service-overlay-composite.test.ts
+++ b/apps/local/app/services/course-publish-service-overlay-composite.test.ts
@@ -369,8 +369,10 @@ describe("Bullet Panels in a course export", () => {
     // window lives in the ramps, not in an `enable=`.
     expect(graph).toContain("pad=w=");
     expect(graph).toContain("crop=w=");
-    expect(graph).toContain("clip((t-11.000000)/");
-    expect(graph).toContain("clip((17.000000-t)/");
+    // The window is the Overlay's start, and its own LENGTH — the ramps are
+    // stated on the elapsed seconds slot 1 holds, on the panel's frame grid.
+    expect(graph).toContain("floor((t-11.000000)*60");
+    expect(graph).toContain("clip((6.000000-ld(1))/");
     // ...and the panel drawn on top of it, over the very same window.
     expect(graph).toContain("[1:v]setpts=PTS-STARTPTS+11.000/TB[ovl0]");
     expect(graph).toContain(

--- a/apps/local/app/services/export-hash-camera-version.test.ts
+++ b/apps/local/app/services/export-hash-camera-version.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeExportHash,
+  type ExportClip,
+  type ExportOverlay,
+} from "@/services/export-hash";
+
+/**
+ * What the camera move's version does to the export address.
+ *
+ * An export is CONTENT-ADDRESSED: a Video whose address has not changed is not
+ * re-exported, whatever the code now does. The move's arithmetic is code and
+ * not data, so it is invisible to the address — which means a fix to the move
+ * reaches every Video EXCEPT the ones that already have the old move baked into
+ * a file. `OVERLAY_CAMERA_VERSION` is how the address is told.
+ *
+ * It has to be told PRECISELY. Bumping `EXPORT_VERSION` would re-export the
+ * whole library to produce, for almost every Video, exactly the bytes it
+ * already has. So the version rides on an Overlay whose Kind actually moves the
+ * camera, and on nothing else — and that is the pair of facts this file pins,
+ * from both sides, with the literal addresses themselves.
+ *
+ * It lives apart from `export-hash.test.ts` because that file is at the repo's
+ * per-file size limit.
+ */
+
+const overlay = (overrides: Partial<ExportOverlay> = {}): ExportOverlay => ({
+  at: 2,
+  durationInSeconds: 4,
+  kind: "definitionCard",
+  disableEnterAnimation: false,
+  disableExitAnimation: false,
+  title: "Hydration",
+  description: "Attaching handlers to server-rendered HTML.",
+  bullets: null,
+  ...overrides,
+});
+
+const clip = (overlays: ExportOverlay[]): ExportClip => ({
+  videoFilename: "rec.mp4",
+  sourceStartTime: 0,
+  sourceEndTime: 10,
+  pauseType: "none",
+  zoomType: "none",
+  overlays,
+});
+
+const addressOf = (...overlays: ExportOverlay[]) =>
+  computeExportHash([clip(overlays)], "landscape");
+
+describe("the camera move's version in the export address", () => {
+  /**
+   * A Definition Card moves no camera, so it must carry NOTHING — otherwise
+   * every Video in the library re-exports to produce the bytes it already has.
+   *
+   * The literal is the address a Definition Card video had BEFORE the camera
+   * version existed, recomputed independently from the payload rather than
+   * copied out of a test run. If it moves, the version has leaked onto
+   * Overlays that have no camera.
+   */
+  it("leaves a Definition Card's address exactly where it was", () => {
+    expect(addressOf(overlay())).toBe("506d7e9fe1da53c7e56f0d1b398164fa");
+  });
+
+  /**
+   * The other half of the same rule. A Bullet Panel DOES move the camera, so
+   * it must carry the version, and a Video exported with the old drifting move
+   * is re-addressed rather than keeping bytes that no longer match what this
+   * code renders.
+   *
+   * The first literal is the address that same Overlay had before the version
+   * existed. It must not still be in use.
+   */
+  it("moves a Bullet Panel's address, so an old export cannot be kept", () => {
+    const panel = overlay({ kind: "bulletPanel" });
+    expect(addressOf(panel)).not.toBe("41a4047b58f30b4c4eddfea603e10a89");
+    expect(addressOf(panel)).toBe("c300c12668892ca79a9e727a008dc231");
+  });
+
+  it("keeps the two Kinds at different addresses", () => {
+    expect(addressOf(overlay())).not.toBe(
+      addressOf(overlay({ kind: "bulletPanel" }))
+    );
+  });
+});

--- a/apps/local/app/services/export-hash.ts
+++ b/apps/local/app/services/export-hash.ts
@@ -12,6 +12,10 @@ import {
   resolveOverlayKind,
 } from "@/features/videos/overlay-kind";
 import {
+  OVERLAY_CAMERA_VERSION,
+  overlayTransform,
+} from "@/features/videos/overlay-transform";
+import {
   bulletPanelHashPayload,
   type BulletPanelBullet,
 } from "@/features/videos/bullet-panel";
@@ -130,6 +134,13 @@ const toOverlayPayload = (overlays: ExportOverlay[]) =>
       // `false` leaves every existing export address exactly where it was.
       ...(o.disableEnterAnimation ? { ne: true } : {}),
       ...(o.disableExitAnimation ? { nx: true } : {}),
+      // How the camera move itself renders, carried ONLY by an Overlay whose
+      // Kind has one. The move's arithmetic is not in the address — it is code,
+      // not data — so a Video already exported with an older, wronger move
+      // would otherwise keep those bytes for ever. Absent for a Definition
+      // Card, which moves no camera, so no export that predates the Transform
+      // is re-addressed by it.
+      ...(overlayTransform(o.kind) ? { cv: OVERLAY_CAMERA_VERSION } : {}),
       t: o.title,
       x: o.description,
       // The Bullet Panel's bullets join `k` in being emitted only when they

--- a/apps/local/app/services/overlay-composite-ffmpeg-graph.test.ts
+++ b/apps/local/app/services/overlay-composite-ffmpeg-graph.test.ts
@@ -1,6 +1,12 @@
 import { execFileSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import { buildOverlayCompositeFilterGraph } from "@/services/overlay-compositing";
+import {
+  overlayTransform,
+  overlayTransformProgressAt,
+  overlayTransformVideoFilter,
+  type OverlayTransformWindow,
+} from "@/features/videos/overlay-transform";
 
 /**
  * The one test that asks ffmpeg itself whether the compositing pass can run.
@@ -86,6 +92,100 @@ describe.skipIf(!hasFfmpeg)(
 
       expect(graph).not.toBeNull();
       expect(() => runGraph(graph!, 4)).not.toThrow();
+    });
+  }
+);
+
+/**
+ * Where the camera actually puts the picture, measured in REAL PIXELS out of
+ * real ffmpeg.
+ *
+ * A white source is slid over a near-black background, so the first lit column
+ * of a row is the picture's own left edge — which is the whole of what the move
+ * does. One row is read per frame; the frame is only 16 tall because nothing
+ * about a horizontal slide varies down it.
+ */
+const measureLeftEdges = (filter: string, fps: number, seconds: number) => {
+  const width = 1920;
+  const height = 16;
+  const raw = execFileSync(
+    "ffmpeg",
+    [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-f",
+      "lavfi",
+      "-i",
+      `color=white:s=${width}x${height}:r=${fps}:d=${seconds}`,
+      "-vf",
+      filter,
+      "-f",
+      "rawvideo",
+      "-pix_fmt",
+      "gray",
+      "-",
+    ],
+    { maxBuffer: 64 * 1024 * 1024 }
+  );
+
+  const frames = Math.floor(raw.length / (width * height));
+  return Array.from({ length: frames }, (_, frame) => {
+    const row = raw.subarray(
+      frame * width * height,
+      frame * width * height + width
+    );
+    const edge = row.findIndex((value) => value > 200);
+    return { timeInSeconds: frame / fps, leftEdge: edge };
+  });
+};
+
+describe.skipIf(!hasFfmpeg)(
+  "the camera move, measured in ffmpeg's own pixels",
+  () => {
+    const window: OverlayTransformWindow & { kind: string } = {
+      kind: "bulletPanel",
+      startInSeconds: 0,
+      endInSeconds: 10,
+    };
+
+    /**
+     * REGRESSION, and the test that should have existed first.
+     *
+     * Every other test of this move evaluates its expressions with an evaluator
+     * of this repo's own. That proves the arithmetic and says nothing about what
+     * ffmpeg does with it — so an export that ran 17px ahead of the panel it was
+     * moving with passed the lot. This asks ffmpeg where the picture is.
+     *
+     * The tolerance is 2px because the source is chroma-subsampled, which pins a
+     * crop's `x` to an even column. That is the finest the export can be, not a
+     * margin for the move to drift in: the error it was written to catch is ten
+     * times it.
+     */
+    it("puts the picture where the preview says it is, on every frame", () => {
+      const filter = overlayTransformVideoFilter(window)!;
+      const travel = overlayTransform(window.kind)!.to.offsetX * 1920;
+
+      let worst = 0;
+      for (const { timeInSeconds, leftEdge } of measureLeftEdges(
+        filter,
+        25,
+        1
+      )) {
+        const want = overlayTransformProgressAt(window, timeInSeconds) * travel;
+        worst = Math.max(worst, Math.abs(leftEdge - want));
+      }
+
+      expect(worst).toBeLessThanOrEqual(2);
+    });
+
+    it("leaves the picture alone before the move starts", () => {
+      const later = { ...window, startInSeconds: 5, endInSeconds: 9 };
+      const filter = overlayTransformVideoFilter(later)!;
+
+      for (const { leftEdge } of measureLeftEdges(filter, 25, 1)) {
+        expect(leftEdge).toBe(0);
+      }
     });
   }
 );

--- a/apps/local/app/services/overlay-compositing.test.ts
+++ b/apps/local/app/services/overlay-compositing.test.ts
@@ -346,8 +346,9 @@ describe("buildOverlayCompositeFilterGraph — the camera Transform", () => {
     // back out of it wherever the ramps read zero. Gating only the crop would
     // emit a wider frame than the graph expects, and `pad` has no timeline
     // support to gate it with.
-    expect(graph).toContain("clip((t-12.000000)/");
-    expect(graph).toContain("clip((20.000000-t)/");
+    expect(graph).toContain("floor((t-12.000000)*60");
+    expect(graph).toContain("clip(ld(1)/");
+    expect(graph).toContain("clip((8.000000-ld(1))/");
     // The only `enable=` left in the graph is the graphic overlay's own.
     expect(graph.match(/enable=/g)).toHaveLength(1);
     expect(graph).toContain("[ovl0]overlay=");
@@ -356,14 +357,18 @@ describe("buildOverlayCompositeFilterGraph — the camera Transform", () => {
   it("slides to the kind's own default Transform, which nobody authored", () => {
     const graph = buildOverlayCompositeFilterGraph([panel()])!;
 
-    // Unmoved (offset 0) to the panel's own ground width, 812 of 1920.
-    expect(graph).toContain("st(3,lerp(0.000000,0.422917,ld(2)))");
+    // Unmoved (offset 0) to the panel's own ground width, 812 of 1920 —
+    // spelled to twelve places, because this is the number the preview slides
+    // by too and six places would make them different numbers.
+    expect(graph).toContain("st(3,lerp(0,0.422916666667,ld(2)))");
     // The canvas is widened by exactly that travel, on the left, and the
     // picture is taken back out of it at its own size — so the source is
     // never magnified.
-    expect(graph).toContain("pad=w='iw*1.422917':h='ih':x='iw*0.422917':y='0'");
-    expect(graph).toContain("crop=w='iw/1.422917':h='ih'");
-    expect(graph).toContain("(iw/1.422917)*(0.422917-ld(3))");
+    expect(graph).toContain(
+      "pad=w='iw*1.422916666667':h='ih':x='iw*0.422916666667':y='0'"
+    );
+    expect(graph).toContain("crop=w='iw/1.422916666667':h='ih'");
+    expect(graph).toContain("(iw/1.422916666667)*(0.422916666667-ld(3))");
     // Nothing divides a dimension by the progress slot any more — that
     // division WAS the zoom.
     expect(graph).not.toContain("iw/ld(3)");
@@ -379,12 +384,17 @@ describe("buildOverlayCompositeFilterGraph — the camera Transform", () => {
   it("eases in and out over the same span at both ends", () => {
     const graph = buildOverlayCompositeFilterGraph([panel()])!;
 
-    expect(graph).toContain(`clip((t-1.500000)/${EASE},0,1)`);
-    expect(graph).toContain(`clip((4.500000-t)/${EASE},0,1)`);
-    // Eased, not linear: the sampled curve is past a third of the way there
-    // by an eighth of the ramp.
-    expect(graph).toContain("lerp(0.000000,0.136888,");
-    expect(graph).toContain("lerp(0.136888,0.408511,");
+    // Both ramps are stated on the ELAPSED seconds in slot 1, so the exit's
+    // is the window's own LENGTH minus it, not its end minus `t`.
+    expect(graph).toContain(`clip(ld(1)/${EASE},0,1)`);
+    expect(graph).toContain(`clip((3.000000-ld(1))/${EASE},0,1)`);
+    // Eased, and eased EXACTLY: Cardano's one real root of the curve's x
+    // axis, which is what lets the export and the preview agree at every
+    // instant rather than only at the ends. It replaced eight straight
+    // segments that drifted 18px from the panel in between.
+    expect(graph).toContain("sqrt(ld(4)*ld(4)/4+0.006591796875)");
+    expect(graph).toContain("pow(ld(5)-ld(4)/2,1/3)-pow(ld(5)+ld(4)/2,1/3)");
+    expect(graph).not.toContain("lerp(0.000000,0.136888,");
   });
 
   it("splits what it has when the Overlay is shorter than two eases", () => {
@@ -392,8 +402,8 @@ describe("buildOverlayCompositeFilterGraph — the camera Transform", () => {
       panel({ startInSeconds: 0, endInSeconds: 0.4 }),
     ])!;
 
-    expect(graph).toContain("clip((t-0.000000)/0.200000,0,1)");
-    expect(graph).toContain("clip((0.400000-t)/0.200000,0,1)");
+    expect(graph).toContain("clip(ld(1)/0.200000,0,1)");
+    expect(graph).toContain("clip((0.400000-ld(1))/0.200000,0,1)");
   });
 
   it("cuts into the shifted framing when the enter animation is off", () => {
@@ -403,8 +413,8 @@ describe("buildOverlayCompositeFilterGraph — the camera Transform", () => {
 
     // No ramp at the start at all — the camera is already there — while the
     // exit still eases.
-    expect(graph).toContain(`min(1.000000,clip((4.500000-t)/${EASE},0,1))`);
-    expect(graph).not.toContain("clip((t-1.500000)");
+    expect(graph).toContain(`min(1.000000,clip((3.000000-ld(1))/${EASE},0,1))`);
+    expect(graph).not.toContain(`clip(ld(1)/${EASE}`);
   });
 
   it("cuts out of it when the exit animation is off", () => {
@@ -412,8 +422,8 @@ describe("buildOverlayCompositeFilterGraph — the camera Transform", () => {
       panel({ disableExitAnimation: true }),
     ])!;
 
-    expect(graph).toContain(`min(clip((t-1.500000)/${EASE},0,1),1.000000)`);
-    expect(graph).not.toContain("clip((4.500000-t)");
+    expect(graph).toContain(`min(clip(ld(1)/${EASE},0,1),1.000000)`);
+    expect(graph).not.toContain("clip((3.000000-ld(1))");
   });
 
   it("holds one framing throughout when both are off", () => {
@@ -425,7 +435,10 @@ describe("buildOverlayCompositeFilterGraph — the camera Transform", () => {
     // for the whole of the Overlay's window, with no ramp at either end.
     expect(graph).toContain("st(2,1.000000);");
     expect(graph).not.toContain("clip(");
-    expect(graph).not.toContain("lerp(0.000000,0.136888,");
+    // No ease at all, so no solve for one either — and no frame grid to read
+    // it on, since nothing is moving.
+    expect(graph).not.toContain("sqrt(");
+    expect(graph).not.toContain("floor(");
   });
 
   it("moves the camera only for the Overlays whose kind asks for it", () => {

--- a/apps/local/app/services/overlay-content-renderer.test.ts
+++ b/apps/local/app/services/overlay-content-renderer.test.ts
@@ -3,7 +3,10 @@ import {
   overlayPropsSchema,
   BULLET_PANEL_ANIMATION_IN_SECONDS as RENDERER_EASE,
 } from "@cvm/overlay-renderer/props";
-import { OVERLAY_TRANSFORM_EASE_IN_SECONDS } from "@/features/videos/overlay-transform";
+import {
+  OVERLAY_CONTENT_FPS,
+  OVERLAY_TRANSFORM_EASE_IN_SECONDS,
+} from "@/features/videos/overlay-transform";
 import { overlayRenderProps } from "@/services/overlay-content-renderer";
 import {
   OVERLAY_RENDER_FPS,
@@ -46,6 +49,21 @@ const panel: BulletPanelContent = {
 describe("the panel and the camera move at one speed", () => {
   it("holds the renderer's ease equal to the domain's", () => {
     expect(RENDERER_EASE).toBe(OVERLAY_TRANSFORM_EASE_IN_SECONDS);
+  });
+
+  /**
+   * The camera is read on the frame grid of the content it is moving for, so
+   * it has to know that content's frame rate. `packages/core` cannot import
+   * {@link OVERLAY_RENDER_FPS} — it must stay free of anything filesystem-
+   * bound — so it repeats the number, and this is again the only package that
+   * sees both.
+   *
+   * If this fails, the footage is being sampled on a grid the panel is not
+   * drawn on, and the two slide apart by up to a frame's travel — 38px at the
+   * quickest part of the ease. Fix the two constants, not this test.
+   */
+  it("holds the camera's frame grid equal to the content's frame rate", () => {
+    expect(OVERLAY_CONTENT_FPS).toBe(OVERLAY_RENDER_FPS);
   });
 });
 

--- a/packages/core/features/videos/overlay-transform-ease.ts
+++ b/packages/core/features/videos/overlay-transform-ease.ts
@@ -1,0 +1,144 @@
+/**
+ * The Overlay Transform's EASE — one curve, written twice.
+ *
+ * It sits in its own module because it is the one thing the editor's preview
+ * and the exported file have to agree about EXACTLY. Both surfaces slide the
+ * same footage the same distance; what took them apart was reading the curve
+ * between the two ends differently. The preview solved it; the export sampled
+ * it as eight straight segments and ran up to 18px ahead of the panel it was
+ * moving with.
+ *
+ * So the curve is defined once, here, and emitted twice: as
+ * {@link easeOverlayTransformProgress} for anything that can call a function,
+ * and as {@link easeStatements} for ffmpeg, which cannot. They are the same
+ * formula and the same constants, and a test in `overlay-transform.test.ts`
+ * holds them to the same value at every point of the move.
+ *
+ * The number formatters live here too, because which of the two a number takes
+ * is a fact about this arithmetic rather than about any caller.
+ */
+
+/**
+ * The easing curve, as control points: `cubic-bezier(0.25, 0.1, 0.25, 1)` —
+ * CSS's `ease`, and the exact curve `Easing.bezier(0.25, 0.1, 0.25, 1)` already
+ * gives the Subtitle overlay's slide in the Remotion renderer. It is spelled
+ * out here rather than imported because `packages/core` does not (and should
+ * not) depend on Remotion; the numbers are the contract.
+ *
+ * `x1 === x2` is LOAD-BEARING and not a matter of taste. It is what collapses
+ * the curve's x axis into a cubic that can be inverted in closed form — in
+ * TypeScript AND in ffmpeg's expression language, which has no solver and no
+ * way to loop. See {@link easeOverlayTransformProgress}. Move one x control
+ * point off the other and the export goes back to APPROXIMATING this curve
+ * while the preview computes it, which is exactly how the two came to disagree
+ * about where the footage was. A test holds them equal.
+ */
+const EASE_CONTROL_POINTS = { x1: 0.25, y1: 0.1, x2: 0.25, y2: 1 } as const;
+
+/** One axis of a unit cubic Bézier, whose first and last points are 0 and 1. */
+const bezierAxis = (s: number, p1: number, p2: number): number =>
+  3 * (1 - s) * (1 - s) * s * p1 + 3 * (1 - s) * s * s * p2 + s * s * s;
+
+/**
+ * The curve's x axis, inverted — the three constants Cardano's formula needs.
+ *
+ * With `x1 === x2 === c` the x axis collapses from a general cubic Bézier to
+ * `x = s³ - 3c·s² + 3c·s`, and substituting `s = u + c` kills the square term
+ * outright, leaving the depressed cubic `u³ + Pu + (Q0 - x) = 0`. Its
+ * discriminant is positive for every `c` in `(0, 1)`, so there is exactly ONE
+ * real root and no branch to choose between.
+ *
+ * Derived from the control point rather than typed out, so retuning the curve
+ * along `x1 === x2` stays a one-line edit.
+ */
+export const EASE_C = EASE_CONTROL_POINTS.x1;
+const EASE_P = 3 * EASE_C * (1 - EASE_C);
+export const EASE_Q0 = 3 * EASE_C * EASE_C - 2 * EASE_C * EASE_C * EASE_C;
+export const EASE_DISCRIMINANT = (EASE_P / 3) ** 3;
+
+/**
+ * The eased value of a 0..1 ramp. EXACT — no search, no approximation.
+ *
+ * This used to bisect for `s`, because a cubic Bézier gives x and y in terms of
+ * a parameter rather than y in terms of x. Bisection was accurate enough here
+ * and impossible in ffmpeg, so the export shipped a piecewise-linear SAMPLE of
+ * this same curve — and drifted up to 18px away from the panel that was meant
+ * to be moving with it.
+ *
+ * So the inverse is taken in closed form instead (see {@link EASE_C}), which
+ * both sides can evaluate: this function, and the expression
+ * {@link easeStatements} emits. Same formula, same constants, two languages —
+ * which is the only way the two surfaces can be in step at every instant rather
+ * than only at the ends.
+ */
+export const easeOverlayTransformProgress = (ramp: number): number => {
+  const x = Math.min(1, Math.max(0, ramp));
+  if (x === 0 || x === 1) return x;
+
+  const q = EASE_Q0 - x;
+  const root = Math.sqrt((q * q) / 4 + EASE_DISCRIMINANT);
+  // `root >= |q| / 2`, so both cube roots are of a non-negative number — which
+  // is what lets ffmpeg spell them as `pow(…, 1/3)`, having no `cbrt`.
+  const s = Math.cbrt(root - q / 2) - Math.cbrt(root + q / 2) + EASE_C;
+
+  const { y1, y2 } = EASE_CONTROL_POINTS;
+  return Math.min(1, Math.max(0, bezierAxis(s, y1, y2)));
+};
+
+/**
+ * Numbers as the filter graph spells them: fixed notation, never exponential,
+ * for the same reason `overlay-compositing.ts` formats seconds that way —
+ * ffmpeg's expression parser reads `1e-7` as an identifier minus a number.
+ */
+export const fmt = (value: number): string => value.toFixed(6);
+
+/**
+ * A number of the MOVE — a constant of the ease, or a fraction of the frame —
+ * spelled to its full precision.
+ *
+ * {@link fmt} rounds to six places, which is right for a moment in seconds and
+ * wrong for these. The ease's constants feed a cube root, where a rounded input
+ * moves the whole curve rather than the last decimal of one number. The
+ * geometry is worse: `812 / 1920` at six places is a DIFFERENT number from the
+ * one the preview slides by, so the two surfaces would settle a thousandth of a
+ * pixel apart for no reason at all, and no test could then assert that they
+ * agree exactly. They are all plain fractions near 1, so fixed notation is
+ * still safe.
+ */
+export const exact = (value: number): string =>
+  value.toFixed(12).replace(/0+$/, "").replace(/\.$/, "");
+
+/**
+ * The ease, as ffmpeg statements: a 0..1 ramp in slot 0, the eased value out
+ * in slot 2.
+ *
+ * This is {@link easeOverlayTransformProgress}, term for term, in the other
+ * language — Cardano's one real root, then the curve's y axis at the `s` it
+ * found. Slots 4, 5 and 6 hold `q`, the discriminant's root, and `s`.
+ *
+ * ffmpeg has no `cbrt`, only `pow`, which will not take a negative base to a
+ * fractional power. It does not have to: `root >= |q| / 2` makes both bases
+ * non-negative, and the sign is carried by SUBTRACTING the second cube root
+ * rather than adding it.
+ *
+ * It used to be a piecewise-linear ladder of eight `if`/`lerp` segments,
+ * because a Bézier was thought to have no closed-form inverse. It has one when
+ * its two x control points agree, which this curve's do (see
+ * {@link EASE_CONTROL_POINTS}). The ladder cost up to 18px of drift against a
+ * panel drawn from the real curve; this costs none.
+ */
+export const easeStatements = (): string => {
+  const { y1, y2 } = EASE_CONTROL_POINTS;
+  const s = "ld(6)";
+  const y =
+    `${exact(3 * y1)}*(1-${s})*(1-${s})*${s}` +
+    `+${exact(3 * y2)}*(1-${s})*${s}*${s}` +
+    `+${s}*${s}*${s}`;
+
+  return (
+    `st(4,${exact(EASE_Q0)}-ld(0));` +
+    `st(5,sqrt(ld(4)*ld(4)/4+${exact(EASE_DISCRIMINANT)}));` +
+    `st(6,pow(ld(5)-ld(4)/2,1/3)-pow(ld(5)+ld(4)/2,1/3)+${exact(EASE_C)});` +
+    `st(2,clip(${y},0,1));`
+  );
+};

--- a/packages/core/features/videos/overlay-transform.test.ts
+++ b/packages/core/features/videos/overlay-transform.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  OVERLAY_CONTENT_FPS,
   OVERLAY_TRANSFORM_EASE_IN_SECONDS,
+  easeOverlayTransformProgress,
   overlayTransform,
   overlayTransformCssStyleAt,
   overlayTransformVideoFilter,
@@ -14,9 +16,10 @@ import {
  * hoping.
  *
  * The dialect is small and entirely arithmetic: `st`/`ld` are the numbered
- * slots, `;` sequences them, and `if`/`lt`/`min`/`clip`/`lerp` are ffmpeg's
- * own functions. `if` is evaluated eagerly here, which its uses in this file
- * allow — every branch is plain arithmetic with nothing to guard against.
+ * slots, `;` sequences them, and `min`/`clip`/`lerp`/`floor`/`sqrt`/`pow` are
+ * ffmpeg's own functions. There is no `if` left to evaluate — the camera's
+ * ease stopped being a branching ladder of straight segments when it became a
+ * closed form.
  */
 const evaluateExpression = (
   expression: string,
@@ -25,13 +28,14 @@ const evaluateExpression = (
   t: number
 ): number => {
   const js = expression
-    .replace(/\bif\(/g, "IF(")
     .replace(/\bst\(/g, "ST(")
     .replace(/\bld\(/g, "LD(")
     .replace(/\blerp\(/g, "LERP(")
     .replace(/\bclip\(/g, "CLIP(")
-    .replace(/\blt\(/g, "LT(")
     .replace(/\bmin\(/g, "MIN(")
+    .replace(/\bfloor\(/g, "FLOOR(")
+    .replace(/\bsqrt\(/g, "SQRT(")
+    .replace(/\bpow\(/g, "POW(")
     // Sequenced statements become one comma expression, which is exactly what
     // ffmpeg's `;` is: evaluate each, take the last.
     .replace(/;/g, ",");
@@ -43,10 +47,10 @@ const evaluateExpression = (
     LERP: (from: number, to: number, p: number) => from + (to - from) * p,
     CLIP: (value: number, low: number, high: number) =>
       Math.min(high, Math.max(low, value)),
-    LT: (a: number, b: number) => (a < b ? 1 : 0),
     MIN: (a: number, b: number) => Math.min(a, b),
-    IF: (condition: number, then: number, otherwise: number) =>
-      condition !== 0 ? then : otherwise,
+    FLOOR: (value: number) => Math.floor(value),
+    SQRT: (value: number) => Math.sqrt(value),
+    POW: (base: number, exponent: number) => Math.pow(base, exponent),
   };
 
   return Function(
@@ -228,6 +232,57 @@ describe("overlay transform", () => {
     });
   });
 
+  describe("the ease", () => {
+    /**
+     * `cubic-bezier(0.25, 0.1, 0.25, 1)` solved the slow, obvious way: walk the
+     * curve's own parameter until its x reaches the one asked for, then read
+     * its y.
+     *
+     * This is the DEFINITION the closed form has to reproduce. It is written
+     * out here, in the test, precisely because the shipped one no longer looks
+     * anything like it — Cardano's formula is right or wrong by a derivation
+     * nobody can check by eye, so it is checked against the curve instead.
+     */
+    const bisect = (x: number): number => {
+      const axis = (t: number, p1: number, p2: number) =>
+        3 * (1 - t) * (1 - t) * t * p1 + 3 * (1 - t) * t * t * p2 + t * t * t;
+      if (x <= 0 || x >= 1) return Math.min(1, Math.max(0, x));
+      let low = 0;
+      let high = 1;
+      for (let i = 0; i < 60; i++) {
+        const mid = (low + high) / 2;
+        if (axis(mid, 0.25, 0.25) < x) low = mid;
+        else high = mid;
+      }
+      return axis((low + high) / 2, 0.1, 1);
+    };
+
+    it("is the curve it claims to be, at every point of it", () => {
+      let worst = 0;
+      for (let step = 0; step <= 10000; step++) {
+        const x = step / 10000;
+        worst = Math.max(
+          worst,
+          Math.abs(easeOverlayTransformProgress(x) - bisect(x))
+        );
+      }
+      expect(worst).toBeLessThan(1e-12);
+    });
+
+    it("pins both ends, and never leaves 0..1 in between", () => {
+      expect(easeOverlayTransformProgress(0)).toBe(0);
+      expect(easeOverlayTransformProgress(1)).toBe(1);
+      // Out of range in is clamped, not extrapolated.
+      expect(easeOverlayTransformProgress(-5)).toBe(0);
+      expect(easeOverlayTransformProgress(5)).toBe(1);
+      for (let step = 0; step <= 1000; step++) {
+        const y = easeOverlayTransformProgress(step / 1000);
+        expect(y).toBeGreaterThanOrEqual(0);
+        expect(y).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+
   describe("preview and export frame the same shot", () => {
     const filter = overlayTransformVideoFilter(panelWindow)!;
 
@@ -252,15 +307,66 @@ describe("overlay transform", () => {
           moment
         );
 
-        // The export's own ease is a piecewise-linear ladder sampled from the
-        // curve the preview solves exactly, so the two agree to within a
-        // pixel or so rather than to the bit.
+        // To a BILLIONTH of a pixel, not to a pixel. Both sides evaluate the
+        // same closed-form ease at the same grid-sampled moment, so all that
+        // is left between them is the twelfth decimal place the filter string
+        // spells its constants to.
         expect(fromFilter.pictureLeftEdge).toBeCloseTo(
           fromCss.pictureLeftEdge,
-          0
+          6
         );
       });
     }
+
+    // REGRESSION. The export used to sample this curve as eight straight
+    // segments, because a Bézier was thought to have no closed-form inverse.
+    // The two ends of a segment are exact and its middle is not, so every test
+    // that checked whole seconds passed while the export ran up to 18px ahead
+    // of the panel it was meant to be moving with — worst just after the start,
+    // which is exactly where the eye is on the moving edge. Only a sweep sees
+    // it, so this sweeps.
+    it("agree at EVERY moment of the move, not only at the ends", () => {
+      let worst = 0;
+      for (let step = 0; step <= 2000; step++) {
+        const moment =
+          panelWindow.startInSeconds +
+          (step / 2000) *
+            (panelWindow.endInSeconds - panelWindow.startInSeconds);
+        const style = overlayTransformCssStyleAt(panelWindow, moment);
+        if (!style) continue;
+        worst = Math.max(
+          worst,
+          Math.abs(
+            evaluateVideoFilter(filter, SOURCE_WIDTH, SOURCE_HEIGHT, moment)
+              .pictureLeftEdge -
+              evaluateCssStyle(style, SOURCE_WIDTH).pictureLeftEdge
+          )
+        );
+      }
+      // A millionth of a pixel. The ladder's worst was 18.6.
+      expect(worst).toBeLessThan(1e-6);
+    });
+
+    // The panel is a CLIP at `OVERLAY_CONTENT_FPS`, so it can only ever show
+    // whole frames. The footage has to step with it: sliding smoothly past a
+    // panel that steps puts the two out by up to a frame's travel, which is
+    // 38px at the fastest part of this ease.
+    it("holds the footage still across one frame of the panel, and steps with it", () => {
+      const frame = 1 / OVERLAY_CONTENT_FPS;
+      // Mid-ease, where the move is quickest and a slip shows most.
+      const start = panelWindow.startInSeconds + 6 * frame;
+      const at = (moment: number) =>
+        evaluateCssStyle(
+          overlayTransformCssStyleAt(panelWindow, moment)!,
+          SOURCE_WIDTH
+        ).pictureLeftEdge;
+
+      // Anywhere inside one frame of the panel, the footage is in one place.
+      expect(at(start + frame * 0.25)).toBeCloseTo(at(start), 9);
+      expect(at(start + frame * 0.99)).toBeCloseTo(at(start), 9);
+      // And it does move on the next one — this is a grid, not a freeze.
+      expect(at(start + frame)).toBeGreaterThan(at(start) + 10);
+    });
 
     it("keeps the crop inside the padded canvas throughout", () => {
       for (const moment of moments) {

--- a/packages/core/features/videos/overlay-transform.ts
+++ b/packages/core/features/videos/overlay-transform.ts
@@ -27,6 +27,12 @@
  */
 
 import { resolveOverlayKind, type OverlayKind } from "./overlay-kind.js";
+import {
+  easeOverlayTransformProgress,
+  easeStatements,
+  exact,
+  fmt,
+} from "./overlay-transform-ease.js";
 
 /**
  * Where the footage sits in frame: `offsetX` is how far RIGHT it has travelled
@@ -82,6 +88,27 @@ const OVERLAY_TRANSFORMS: Record<OverlayKind, OverlayTransform | null> = {
 };
 
 /**
+ * What the camera move RENDERS AS — bumped whenever this file starts putting
+ * the footage somewhere it did not put it before.
+ *
+ * An export is content-addressed: a Video whose address has not changed is not
+ * re-exported, whatever the code now does. So a fix to the move that leaves the
+ * address alone reaches every Video EXCEPT the ones that already have the bug
+ * baked into a file. This constant is how the address is told.
+ *
+ * It is not `EXPORT_VERSION`. That one re-exports the whole library; this is
+ * carried only by an Overlay whose Kind actually moves the camera, so a Video
+ * with nothing but Definition Cards keeps the address it has and is not
+ * re-encoded to produce the bytes it already has.
+ *
+ * - 1 — the first move to ship.
+ * - 2 — the ease became exact and the footage started reading it on the
+ *   content's own frame grid. Up to 38px of the move landed on a different
+ *   frame from the panel before this.
+ */
+export const OVERLAY_CAMERA_VERSION = 2;
+
+/**
  * The move a raw `kind` column asks for, or `null` for none. Every consumer
  * goes through here, and through {@link resolveOverlayKind}, so a `kind`
  * nothing recognises moves no camera rather than throwing.
@@ -117,43 +144,6 @@ export const overlayTransform = (
  * down through one to 800ms.
  */
 export const OVERLAY_TRANSFORM_EASE_IN_SECONDS = 0.8;
-
-/**
- * The easing curve, as control points: `cubic-bezier(0.25, 0.1, 0.25, 1)` —
- * CSS's `ease`, and the exact curve `Easing.bezier(0.25, 0.1, 0.25, 1)` already
- * gives the Subtitle overlay's slide in the Remotion renderer. It is spelled
- * out here rather than imported because `packages/core` does not (and should
- * not) depend on Remotion; the numbers are the contract.
- */
-const EASE_CONTROL_POINTS = { x1: 0.25, y1: 0.1, x2: 0.25, y2: 1 } as const;
-
-/** One axis of a unit cubic Bézier, whose first and last points are 0 and 1. */
-const bezierAxis = (s: number, p1: number, p2: number): number =>
-  3 * (1 - s) * (1 - s) * s * p1 + 3 * (1 - s) * s * s * p2 + s * s * s;
-
-/**
- * The eased value of a 0..1 ramp.
- *
- * A cubic Bézier gives x and y in terms of a parameter, not y in terms of x,
- * and has no closed-form inverse — so x is solved for by bisection. Thirty
- * halvings is far past the precision of anything downstream (a frame, or six
- * decimal places in a filter string) and costs nothing: this runs a few dozen
- * times while a filter graph is being built, never per frame.
- */
-export const easeOverlayTransformProgress = (ramp: number): number => {
-  const target = Math.min(1, Math.max(0, ramp));
-  if (target === 0 || target === 1) return target;
-
-  const { x1, y1, x2, y2 } = EASE_CONTROL_POINTS;
-  let low = 0;
-  let high = 1;
-  for (let i = 0; i < 30; i++) {
-    const mid = (low + high) / 2;
-    if (bezierAxis(mid, x1, x2) < target) low = mid;
-    else high = mid;
-  }
-  return bezierAxis((low + high) / 2, y1, y2);
-};
 
 /** The framing partway through a move: `0` is `from`, `1` is `to`. */
 export const overlayTransformFramingAt = (
@@ -206,11 +196,70 @@ const easeDurations = (window: OverlayTransformWindow) => {
 };
 
 /**
+ * The frame rate an Overlay's own CONTENT is rendered at.
+ *
+ * The camera has to know it. A Bullet Panel is not drawn live alongside the
+ * footage — it is a CLIP, rendered at this rate, and a clip can only ever show
+ * whole frames. Whatever the moment, what is actually on screen is the frame
+ * whose own time has most recently passed, up to a frame stale. The footage
+ * has no such grid: left alone, it slides continuously and runs ahead of the
+ * panel by as much as a whole frame's travel — 38px at the fastest part of the
+ * ease, which is a visible slip on an opaque edge.
+ *
+ * So the camera is sampled on the panel's grid too (see {@link sampledTime}).
+ * The two are then not merely following the same curve, they are reading it at
+ * the same instants.
+ *
+ * `packages/core` cannot import the renderer's own copy of this number
+ * (`OVERLAY_RENDER_FPS` in `apps/local`) without depending on it, so it is
+ * repeated here and held equal by a test in `apps/local`, which imports both —
+ * the same arrangement `BULLET_PANEL_ANIMATION_IN_SECONDS` already has.
+ */
+export const OVERLAY_CONTENT_FPS = 60;
+
+/**
+ * A nanosecond of slack on the frame boundary.
+ *
+ * The same moment reaches this arithmetic on two different clocks — the
+ * flattened Video's for the export, the Clip's own (with a NEGATIVE start for
+ * an Overlay that spilled onto it) for the editor — and subtracting two
+ * different pairs of doubles does not always land on the same side of a frame
+ * boundary. Without this, one surface takes frame 11 where the other takes 12,
+ * and the footage jumps a frame's worth of travel against the panel. A moment
+ * within a nanosecond of a boundary is that frame; nothing downstream can
+ * resolve finer.
+ */
+const FRAME_EPSILON = 1e-9;
+
+/**
+ * How far past its start the Overlay's camera is really read: the ELAPSED
+ * seconds, snapped back to the frame of the Overlay's content on screen at
+ * them.
+ *
+ * FLOOR, not round, and that is measured rather than assumed: ffmpeg's
+ * `overlay` shows the most recent frame of the graphic whose presentation time
+ * has passed, so `floor` names the frame the export actually composites. The
+ * editor's preview seeks its `<Player>` the same way for the same reason.
+ *
+ * Elapsed, never an absolute moment, so the answer cannot depend on which
+ * clock the caller states its window on.
+ */
+const sampledElapsed = (
+  window: OverlayTransformWindow,
+  timeInSeconds: number
+): number =>
+  Math.floor(
+    (timeInSeconds - window.startInSeconds) * OVERLAY_CONTENT_FPS +
+      FRAME_EPSILON
+  ) / OVERLAY_CONTENT_FPS;
+
+/**
  * How far into the move the camera is at a given moment on the timeline.
  *
  * The same arithmetic the emitted `crop` expression performs, in TypeScript:
- * the nearer end's ramp, eased. Outside the window there is no move at all,
- * which is what the filter's `enable` gate does by bypassing the node.
+ * the nearer end's ramp, read on the content's frame grid, eased. Outside the
+ * window there is no move at all, which is what the two nodes composing to an
+ * identity gives without a gate.
  */
 export const overlayTransformProgressAt = (
   window: OverlayTransformWindow,
@@ -222,14 +271,13 @@ export const overlayTransformProgressAt = (
   ) {
     return 0;
   }
+  const elapsed = sampledElapsed(window, timeInSeconds);
+  const span = window.endInSeconds - window.startInSeconds;
   const { enter, exit } = easeDurations(window);
-  const ramp = (elapsed: number, duration: number) =>
-    duration === 0 ? 1 : Math.min(1, Math.max(0, elapsed / duration));
+  const ramp = (remaining: number, duration: number) =>
+    duration === 0 ? 1 : Math.min(1, Math.max(0, remaining / duration));
   return easeOverlayTransformProgress(
-    Math.min(
-      ramp(timeInSeconds - window.startInSeconds, enter),
-      ramp(window.endInSeconds - timeInSeconds, exit)
-    )
+    Math.min(ramp(elapsed, enter), ramp(span - elapsed, exit))
   );
 };
 
@@ -287,51 +335,18 @@ export const overlayTransformCssStyleAt = (
 // ---------------------------------------------------------------------------
 
 /**
- * Numbers as the filter graph spells them: fixed notation, never exponential,
- * for the same reason `overlay-compositing.ts` formats seconds that way —
- * ffmpeg's expression parser reads `1e-7` as an identifier minus a number.
- */
-const fmt = (value: number): string => value.toFixed(6);
-
-/**
- * How many straight segments the eased curve is approximated by.
+ * The head of the `crop` expression: the moment into slot 1, progress into
+ * slot 2, and the offset it implies into slot 3.
  *
- * ffmpeg's expression language has no cubic-Bézier solver and no way to define
- * a function, so the curve is SAMPLED here and emitted as a piecewise-linear
- * `if`/`lerp` ladder. Eight segments hold the curve to well under a pixel of
- * error at these scales, and the ladder stays short enough to read.
- */
-const EASE_SEGMENTS = 8;
-
-/**
- * The eased value of `argExpr` (a 0..1 ramp) as an ffmpeg expression.
- *
- * `argExpr` is repeated twice per segment, so callers pass a cheap one — an
- * `ld(n)` slot rather than the arithmetic that filled it.
- */
-const easeExpression = (argExpr: string): string => {
-  let expression = fmt(1);
-  for (let segment = EASE_SEGMENTS - 1; segment >= 0; segment--) {
-    const from = segment / EASE_SEGMENTS;
-    const to = (segment + 1) / EASE_SEGMENTS;
-    expression =
-      `if(lt(${argExpr},${fmt(to)}),` +
-      `lerp(${fmt(easeOverlayTransformProgress(from))},` +
-      `${fmt(easeOverlayTransformProgress(to))},` +
-      `(${argExpr}-${fmt(from)})/${fmt(1 / EASE_SEGMENTS)}),` +
-      `${expression})`;
-  }
-  return expression;
-};
-
-/**
- * The head of the `crop` expression: progress into slot 2, and the offset it
- * implies into slot 3.
+ * Slot 1 is `t` snapped back to the frame grid of the Overlay's own content —
+ * {@link sampledTime}, in ffmpeg — so the footage is read at the instant the
+ * panel frame beside it was drawn for. Without it the footage slides smoothly
+ * past a panel that can only step, and leads it by up to a frame's travel.
  *
  * The two ends are reduced to ONE ramp before being eased, rather than eased
  * separately and then compared. The curve is monotonic, so
  * `min(ease(a), ease(b))` and `ease(min(a, b))` are the same number, and only
- * the second spells the ladder out once.
+ * the second spells the ease out once.
  *
  * A disabled end contributes the constant `1` to that `min` — the camera is
  * simply already there — and that, and nothing else, is what makes it a cut.
@@ -341,23 +356,27 @@ const progressPrelude = (
   window: OverlayTransformWindow
 ): string => {
   const { enter, exit } = easeDurations(window);
+  const fps = exact(OVERLAY_CONTENT_FPS);
+  // Slot 1 is the ELAPSED seconds, on the content's frame grid — the same two
+  // rules {@link sampledElapsed} follows, for the same reasons.
+  const grid =
+    `st(1,floor((t-${fmt(window.startInSeconds)})*${fps}` +
+    `+${exact(FRAME_EPSILON)})/${fps});`;
+  const span = window.endInSeconds - window.startInSeconds;
   const ramps = [
-    enter === 0
-      ? fmt(1)
-      : `clip((t-${fmt(window.startInSeconds)})/${fmt(enter)},0,1)`,
-    exit === 0
-      ? fmt(1)
-      : `clip((${fmt(window.endInSeconds)}-t)/${fmt(exit)},0,1)`,
+    enter === 0 ? fmt(1) : `clip(ld(1)/${fmt(enter)},0,1)`,
+    exit === 0 ? fmt(1) : `clip((${fmt(span)}-ld(1))/${fmt(exit)},0,1)`,
   ];
 
   const progress =
     enter === 0 && exit === 0
       ? `st(2,${fmt(1)});`
-      : `st(0,min(${ramps[0]},${ramps[1]}));st(2,${easeExpression("ld(0)")});`;
+      : `${grid}st(0,min(${ramps[0]},${ramps[1]}));${easeStatements()}`;
 
   return (
     progress +
-    `st(3,lerp(${fmt(transform.from.offsetX)},${fmt(transform.to.offsetX)},ld(2)));`
+    `st(3,lerp(${exact(transform.from.offsetX)},` +
+    `${exact(transform.to.offsetX)},ld(2)));`
   );
 };
 
@@ -418,12 +437,12 @@ export const overlayTransformVideoFilter = (
   const widened = 1 + padLeft + padRight;
 
   const prelude = progressPrelude(transform, overlay);
-  const sourceWidth = `iw/${fmt(widened)}`;
+  const sourceWidth = `iw/${exact(widened)}`;
 
   const pad = [
-    `pad=w='iw*${fmt(widened)}'`,
+    `pad=w='iw*${exact(widened)}'`,
     `h='ih'`,
-    `x='iw*${fmt(padLeft)}'`,
+    `x='iw*${exact(padLeft)}'`,
     `y='0'`,
     `color=${SLIDE_BACKGROUND_COLOR}`,
   ].join(":");
@@ -434,9 +453,16 @@ export const overlayTransformVideoFilter = (
   const crop = [
     `crop=w='${sourceWidth}'`,
     `h='ih'`,
-    `x='${prelude}(${sourceWidth})*(${fmt(padLeft)}-ld(3))'`,
+    `x='${prelude}(${sourceWidth})*(${exact(padLeft)}-ld(3))'`,
     `y='0'`,
   ].join(":");
 
   return `${pad},${crop}`;
 };
+
+/**
+ * Re-exported so the ease stays part of THIS feature's surface. Callers ask
+ * `overlay-transform` for the camera's easing; that it is worked out next door
+ * (`./overlay-transform-ease.ts`) is this feature's business, not theirs.
+ */
+export { easeOverlayTransformProgress };


### PR DESCRIPTION
The footage slid to the right PLACE and took the wrong PATH there. Two
approximations put it out of step with the panel it moves for, both worst early
in the ease — which is exactly where the eye is, on the moving edge.

Measured in real ffmpeg pixels, against the real graph:

| | drift against the panel |
|---|---|
| the ease ladder | **17.2px** ahead at 0.04s, 6.8px behind at 0.24s |
| the frame grid | up to **38.7px** — one whole frame of travel |
| now | **1.4px** |

That 1.4px is the 4:2:0 chroma grid pinning a crop's `x` to an even column. It
is the floor of what the export can do, not a margin left to drift in.

## The ease is now exact

ffmpeg has no solver and cannot loop, so the export SAMPLED
`cubic-bezier(0.25, 0.1, 0.25, 1)` as eight straight segments while the preview
solved it. Both ends of every segment are exact and its middle is not, so the
export was right at the moments the tests checked and wrong between them.

A cubic Bézier's x axis has no closed-form inverse in general — but it has one
when its two x control points agree, and this curve's are both `0.25`. That
collapses x to `s³ - 3c·s² + 3c·s`, and substituting `s = u + c` kills the
square term, leaving a depressed cubic with a positive discriminant: one real
root, no branch to choose. Cardano's formula gives `s` outright, in TypeScript
**and** in an ffmpeg expression. Same formula, same constants, two languages.
`x1 === x2` is now documented as load-bearing and held by a test.

## The camera reads the panel's frame grid

The panel is not drawn live beside the footage — it is a 60fps **clip**, and a
clip shows whole frames. ffmpeg's `overlay` shows the most recent frame whose
time has passed (measured, not assumed), so the panel was up to a frame stale
while the footage slid on continuously.

The camera now floors onto that same grid. The two are not merely following one
curve, they read it at the same instants. The editor's `<Player>` seek changes
`round` → `floor` for the same reason: the preview has to show the frame the
export composites.

Both rules are stated on **elapsed** seconds, never an absolute moment, so the
answer cannot depend on whether the caller is on the Video's clock or the
Clip's. A nanosecond of slack keeps two different subtractions on the same side
of a frame boundary.

## The fix can reach a Video you have already exported

An export is content-addressed and the move's arithmetic is code, not data — so
a Video exported with the old move would have kept those bytes for ever, and
this fix would never have reached the file you were looking at.

`OVERLAY_CAMERA_VERSION` now rides in the export address, but **only** on an
Overlay whose Kind actually moves the camera. A Video with nothing but
Definition Cards keeps the address it has and is not re-encoded to produce the
bytes it already has; its address is pinned to its old literal by a test.
`EXPORT_VERSION` is untouched.

**A Video carrying a Bullet Panel will re-export.** That is the point.

## Also

The ease moves to `overlay-transform-ease.ts`: `overlay-transform.ts` went past
the repo's per-file limit, and one-curve-written-twice is the seam that wanted
splitting anyway.

## Tests

The test that should have existed first now hands the **real** graph to **real**
ffmpeg and measures where the picture lands. Every other test of this move
evaluates its expressions with an evaluator of this repo's own, which proves the
arithmetic and says nothing about what ffmpeg does with it — so a 17px error
passed the lot.

The evaluator-based tests gain a 2000-step sweep of the whole window, because
the ladder's error lived BETWEEN the moments the old tests checked.

- `packages/core` — 667 tests pass
- `apps/local` — 646 service tests pass, including 2 new real-ffmpeg pixel tests
- `packages/overlay-renderer` — 22 tests pass
- typecheck 7/7, `lint:boundaries` 4/4, file-token, no-dirname

Three `app/cli/cli-overlay-bullet-panel-writes.test.ts` failures and the
`.sandcastle` ones are pre-existing — verified by running them on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
