### PR TITLE
Definition Card overlay moves to the dark ground the rest of Overlay uses

### DIFF
--- a/apps/local/public/ai-hero-logo-dark.svg
+++ b/apps/local/public/ai-hero-logo-dark.svg
@@ -5,7 +5,11 @@
 
   The source asset flips fill between black and white with a
   `prefers-color-scheme` media query. An overlay is composited over footage
-  with no page behind it, so the mark is flipped per theme. This is the dark mark, for the light Definition Card.
+  with no page behind it, so the mark is flipped per theme. This is the dark
+  mark, for a light surface — the Definition Card was the last consumer,
+  and has since moved to the dark ground every other Overlay surface uses
+  (see `ai-hero-logo.svg`), so this file is currently unused but kept for
+  the next light surface that needs it.
 -->
 <svg xmlns="http://www.w3.org/2000/svg" width="280" height="280" fill="none" viewBox="0 0 280 280">
   <g clip-path="url(#a)">

--- a/packages/overlay-renderer/remotion/BulletPanel.tsx
+++ b/packages/overlay-renderer/remotion/BulletPanel.tsx
@@ -85,8 +85,8 @@ const GROUND_COLOR = "#101011";
  * The brand mark in the panel's top-left corner, on the same gutter as the
  * words below it, so the corner margin is square.
  *
- * It is the WHITE mark. The Definition Card takes the dark one because its
- * card is white; this panel's ground is not.
+ * It is the WHITE mark — the same one the Definition Card now takes, since
+ * both panels sit on the same dark ground.
  */
 const LOGO_SIZE = 56;
 
@@ -112,10 +112,10 @@ const BULLET_TEXT_COLOR = "#D6D3D1";
 /**
  * The panel carries NO accent bar and no colour of its own.
  *
- * The Definition Card is a white card that needs a brand mark on it; this
- * panel is a dark surface the size of a third of frame, and the only things on
- * it are the AI Hero mark, a heading and its bullets. Weight and space
- * separate them, not colour.
+ * The Definition Card carries an amber accent bar because it is a small card
+ * that needs one visual anchor; this panel is a dark surface the size of a
+ * third of frame, and the only things on it are the AI Hero mark, a heading
+ * and its bullets. Weight and space separate them, not colour.
  */
 
 /**

--- a/packages/overlay-renderer/remotion/DefinitionCard.tsx
+++ b/packages/overlay-renderer/remotion/DefinitionCard.tsx
@@ -44,12 +44,23 @@ const UNDERLINE_ERASE = UNDERLINE_DRAW;
 const UNDERLINE_HEIGHT = 4;
 /** The gap between the title's baseline box and the rule. */
 const UNDERLINE_GAP = 5;
-/** Amber-400. The accent bar's paler amber is invisible on white. */
+/** Amber-400. Reads as the brand accent on the dark panel same as it did on white. */
 const UNDERLINE_COLOR = "#FBBF24";
 
 /** The brand mark, sized against the 36 px title it stands beside. */
 const LOGO_SIZE = 40;
 const LOGO_OFFSET = 3;
+
+/**
+ * The panel's own ground. Tldraw's dark canvas, `hsl(240, 5%, 6.5%)` — the
+ * same near-black the Bullet Panel's ground and the course diagrams use, so
+ * every dark surface in an Overlay shares one colour rather than each
+ * picking a near-black of its own.
+ */
+const PANEL_COLOR = "#101011";
+/** Stone-300: one step back from the title's white, the same pairing the
+ *  Bullet Panel's body text uses against its own dark ground. */
+const DESCRIPTION_COLOR = "#D6D3D1";
 
 /**
  * The AI-Hero-branded term Definition Card: a `title` + `description` pair
@@ -139,8 +150,9 @@ const Card = ({ card }: { card: DefinitionCard }) => {
         }}
       >
         <div
-          className="relative flex items-start overflow-hidden bg-white"
+          className="relative flex items-start overflow-hidden"
           style={{
+            background: PANEL_COLOR,
             gap: 32 * scale,
             padding: 40 * scale,
             paddingLeft: (40 + 8) * scale,
@@ -154,9 +166,11 @@ const Card = ({ card }: { card: DefinitionCard }) => {
         >
           <AccentBar scale={scale} />
           {/* Sized and nudged down so the mark's centre sits on the title's
-              cap height, not on the top of the title's line box. */}
+              cap height, not on the top of the title's line box. The WHITE
+              mark — this panel is dark now, so it takes the same mark the
+              Bullet Panel's dark ground does. */}
           <Img
-            src={staticFile("/ai-hero-logo-dark.svg")}
+            src={staticFile("/ai-hero-logo.svg")}
             style={{
               width: LOGO_SIZE * scale,
               height: LOGO_SIZE * scale,
@@ -169,7 +183,7 @@ const Card = ({ card }: { card: DefinitionCard }) => {
                 text, not as wide as the column. A column-wide rule reads as a
                 divider instead of an underline. */}
             <p
-              className="relative inline-block font-bold leading-tight text-stone-900"
+              className="relative inline-block font-bold leading-tight text-white"
               style={{
                 fontSize: 36 * scale,
                 paddingBottom: UNDERLINE_GAP * scale,
@@ -189,8 +203,8 @@ const Card = ({ card }: { card: DefinitionCard }) => {
               />
             </p>
             <p
-              className="font-normal leading-snug text-stone-600"
-              style={{ fontSize: 26 * scale }}
+              className="font-normal leading-snug"
+              style={{ fontSize: 26 * scale, color: DESCRIPTION_COLOR }}
             >
               {card.description}
             </p>


### PR DESCRIPTION
## Summary
- The Definition Card was the last white surface in the Overlay renderer — the Bullet Panel and the course diagrams already sit on tldraw's dark canvas colour (`#101011`).
- Swaps the card's background to that same dark ground, its title to white and its description to stone-300 (the same pairing the Bullet Panel uses), and its brand mark to the white logo variant.
- The dark logo mark (`ai-hero-logo-dark.svg`) was reserved specifically for this light card; it has no remaining consumer, so its doc comment is updated to say so rather than deleting the asset outright.
- Updated two stale comments in `BulletPanel.tsx` that described the Definition Card as "a white card."

## Test plan
- [x] `pnpm --filter @cvm/overlay-renderer typecheck`
- [x] `pnpm --filter @cvm/overlay-renderer test`
- [x] `pnpm lint:boundaries` (root)
- [x] pre-commit hook (typecheck, lint:boundaries, file-token/dirname checks) passed on commit
- [ ] Visual check in `remotion studio` / the app editor's overlay preview (not run in this environment — no display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)