### PR TITLE
commit-maps: support packageManager="npm" on the opening tag

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -351,7 +351,7 @@ A block of questions embedded in a **Video**'s `body`, answered by the reader on
 _Avoid_: Test, Assessment, Question block, Exercise (reserved for the course's practical work)
 
 **Commit Map**:
-The list of commits a lesson uses, at the top of a **Video**'s `body` — `<CommitMap>` wrapping one or more `<Commit id="…">` commit map entries. Each entry's `id` is a slug naming a lesson commit in the course project repo, which the CVM never reads; `main` is the one id that is not a slug. The first entry is where a reader starts the lesson. Stored verbatim and shipped unparsed by **Publish**, like a **Quiz**, but never rewritten for the preview — an `id` is a plain attribute, so the card reads the markup as authored. Authored by hand; the Article Writer writes one only when asked.
+The list of commits a lesson uses, at the top of a **Video**'s `body` — `<CommitMap>` wrapping one or more `<Commit id="…">` commit map entries. Each entry's `id` is a slug naming a lesson commit in the course project repo, which the CVM never reads; `main` is the one id that is not a slug. The first entry is where a reader starts the lesson. The opening tag may carry `packageManager="npm"`, naming the course repo's package manager; omitted, it is `pnpm`. Stored verbatim and shipped unparsed by **Publish**, like a **Quiz**, but never rewritten for the preview — an `id` (and `packageManager`) is a plain attribute, so the card reads the markup as authored. Authored by hand; the Article Writer writes one only when asked.
 _Avoid_: Checkpoint, Commit list, **Course Version** `commitState` (Dropbox publish state, unrelated). "Reset point" names what the first entry is _for_, never an entry in general — a later entry is a cherry-pick target too.
 
 ### Video destinations

--- a/apps/local/app/features/article-writer/commit-map-card.tsx
+++ b/apps/local/app/features/article-writer/commit-map-card.tsx
@@ -5,11 +5,15 @@ import type { ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+/** The package manager a course's project repo uses, `pnpm` unless stated. */
+type PackageManager = "npm" | "pnpm";
+
 /**
  * The preview's stand-in for a commit map on aihero.dev.
  *
  * Deliberately static: the site's card carries a Copy dropdown offering
- * `pnpm reset <slug>` and `pnpm cherry-pick <slug>`, and this one shows those
+ * `pnpm reset <slug>` (or `npm run reset <slug>`, per the map's
+ * `packageManager`) and its cherry-pick equivalent, and this one shows those
  * commands as plain text. The author is proofreading the map, not resetting a
  * repo — and the CVM has no repo to reset.
  */
@@ -41,12 +45,19 @@ export function CommitMapCard({
 export function CommitEntryCard({
   id,
   description,
+  packageManager,
   problems,
 }: {
   id: string | null;
   description: ReactNode;
+  packageManager: PackageManager;
   problems: string[];
 }) {
+  // npm has no bare-script shorthand, so its command carries `run`; pnpm's
+  // does not.
+  const run = (script: string) =>
+    packageManager === "npm" ? `npm run ${script}` : `pnpm ${script}`;
+
   return (
     <div className="relative rounded-md border border-border bg-background p-3">
       <div className="font-mono text-sm font-semibold">
@@ -65,8 +76,14 @@ export function CommitEntryCard({
 
       {id ? (
         <div className="mt-2 space-y-0.5 border-t border-border pt-2 font-mono text-[11px] text-muted-foreground/70">
-          <div>pnpm reset {id}</div>
-          {id === "main" ? null : <div>pnpm cherry-pick {id}</div>}
+          <div>
+            {run("reset")} {id}
+          </div>
+          {id === "main" ? null : (
+            <div>
+              {run("cherry-pick")} {id}
+            </div>
+          )}
         </div>
       ) : null}
 

--- a/apps/local/app/features/article-writer/commit-map-components.test.tsx
+++ b/apps/local/app/features/article-writer/commit-map-components.test.tsx
@@ -36,6 +36,11 @@ const REPEATED = `<CommitMap>
   <Commit id="main">Again</Commit>
 </CommitMap>`;
 
+const NPM = `<CommitMap packageManager="npm">
+  <Commit id="main">The course start</Commit>
+  <Commit id="add-settings-json">See my solution</Commit>
+</CommitMap>`;
+
 describe("commit map card", () => {
   it("draws an entry with its id, description and commands", () => {
     const html = render(CONTIGUOUS);
@@ -51,6 +56,15 @@ describe("commit map card", () => {
 
     expect(html).toContain("pnpm reset main");
     expect(html).not.toContain("pnpm cherry-pick main");
+  });
+
+  it("draws npm commands when the map's packageManager is npm", () => {
+    const html = render(NPM);
+
+    expect(html).toContain("npm run reset add-settings-json");
+    expect(html).toContain("npm run cherry-pick add-settings-json");
+    expect(html).not.toContain("pnpm reset");
+    expect(html).not.toContain("pnpm cherry-pick");
   });
 
   it("reports nothing against a contiguous map", () => {

--- a/apps/local/app/features/article-writer/commit-map-components.tsx
+++ b/apps/local/app/features/article-writer/commit-map-components.tsx
@@ -9,17 +9,29 @@ import { CommitEntryCard, CommitMapCard } from "./commit-map-card";
  * No rewrite: a commit map goes into the preview exactly as authored.
  *
  * Quizzes are rewritten before parsing because `data={{ … }}` is a JS object
- * literal and an HTML attribute cannot hold one. A commit map carries a plain
- * `id="…"` attribute and text children, so the HTML parser takes it as it
- * stands — it only lowercases the tag names, which is why these keys are
- * `commitmap` and `commit`. Nothing here needs a scanner, and adding one for
- * symmetry with the quiz would buy nothing.
+ * literal and an HTML attribute cannot hold one. A commit map carries plain
+ * `id="…"` and `packageManager="…"` attributes and text children, so the HTML
+ * parser takes it as it stands — it lowercases tag *and* attribute names,
+ * which is why these keys are `commitmap`/`commit`, and why the slots below
+ * read `props.packagemanager` rather than `props.packageManager` (the stored
+ * body text, and the real MDX aihero.dev compiles it as, keep the camelCase
+ * spelling — only this raw-HTML preview flattens it). Nothing here needs a
+ * scanner, and adding one for symmetry with the quiz would buy nothing.
  */
 export const COMMIT_MAP_TAG_NAME = "commitmap";
 export const COMMIT_ENTRY_TAG_NAME = "commit";
 
+/** The package manager a course's project repo uses, `pnpm` unless stated. */
+type PackageManager = "npm" | "pnpm";
+const DEFAULT_PACKAGE_MANAGER: PackageManager = "pnpm";
+
 /** Ids the surrounding map uses more than once. */
 const DuplicateIdsContext = createContext<ReadonlySet<string>>(new Set());
+
+/** The map's `packageManager`, read by every entry underneath it. */
+const PackageManagerContext = createContext<PackageManager>(
+  DEFAULT_PACKAGE_MANAGER
+);
 
 type SlotProps = HTMLAttributes<HTMLElement> & Record<string, unknown>;
 
@@ -74,15 +86,23 @@ function CommitMapSlot(props: SlotProps) {
       ]
     : [];
 
+  // Lowercased by the raw-HTML parser along with the tag name — see the file
+  // comment above.
+  const packageManager: PackageManager =
+    props.packagemanager === "npm" ? "npm" : DEFAULT_PACKAGE_MANAGER;
+
   return (
-    <DuplicateIdsContext.Provider value={duplicates}>
-      <CommitMapCard problems={problems}>{children}</CommitMapCard>
-    </DuplicateIdsContext.Provider>
+    <PackageManagerContext.Provider value={packageManager}>
+      <DuplicateIdsContext.Provider value={duplicates}>
+        <CommitMapCard problems={problems}>{children}</CommitMapCard>
+      </DuplicateIdsContext.Provider>
+    </PackageManagerContext.Provider>
   );
 }
 
 function CommitEntrySlot(props: SlotProps) {
   const duplicates = useContext(DuplicateIdsContext);
+  const packageManager = useContext(PackageManagerContext);
   const rawId = props.id;
   const id = typeof rawId === "string" && rawId.length > 0 ? rawId : null;
 
@@ -99,6 +119,7 @@ function CommitEntrySlot(props: SlotProps) {
     <CommitEntryCard
       id={id}
       description={props.children as ReactNode}
+      packageManager={packageManager}
       problems={problems}
     />
   );

--- a/apps/local/app/features/article-writer/commit-map-syntax.test.ts
+++ b/apps/local/app/features/article-writer/commit-map-syntax.test.ts
@@ -64,6 +64,38 @@ describe("parseCommitMaps", () => {
   it("yields no block for an unclosed map", () => {
     expect(parseCommitMaps(`<CommitMap>\n${entry("main")}`)).toEqual([]);
   });
+
+  it("defaults to pnpm when the tag carries no packageManager", () => {
+    const blocks = parseCommitMaps(map(entry("main")));
+
+    expect(blocks[0]!.packageManager).toBe("pnpm");
+  });
+
+  it("reads packageManager off the opening tag", () => {
+    const text = `<CommitMap packageManager="npm">\n${entry("main")}\n</CommitMap>`;
+
+    expect(parseCommitMaps(text)[0]!.packageManager).toBe("npm");
+  });
+
+  it('reads an explicit packageManager="pnpm" the same as omitting it', () => {
+    const text = `<CommitMap packageManager="pnpm">\n${entry("main")}\n</CommitMap>`;
+
+    expect(parseCommitMaps(text)[0]!.packageManager).toBe("pnpm");
+  });
+
+  it("does not recognise a tag with an invalid packageManager", () => {
+    // A malformed attribute is not a `<CommitMap>` at all, the same way any
+    // other malformed tag is not.
+    const text = `<CommitMap packageManager="yarn">\n${entry("main")}\n</CommitMap>`;
+
+    expect(parseCommitMaps(text)).toEqual([]);
+  });
+
+  it("leaves an invalid packageManager's entries adrift", () => {
+    const text = `<CommitMap packageManager="yarn">\n${entry("main")}\n</CommitMap>`;
+
+    expect(findCommitsOutsideCommitMap(text)).toEqual(['<Commit id="main">']);
+  });
 });
 
 describe("findCommitsMissingId", () => {
@@ -134,6 +166,14 @@ describe("findUnclosedCommitMaps", () => {
   it("passes a closed map", () => {
     expect(findUnclosedCommitMaps(map(entry("main")))).toEqual([]);
   });
+
+  it("reports the packageManager attribute in an unclosed tag", () => {
+    const text = `<CommitMap packageManager="npm">\n${entry("main")}`;
+
+    expect(findUnclosedCommitMaps(text)).toEqual([
+      '<CommitMap packageManager="npm">',
+    ]);
+  });
 });
 
 describe("findCommitMapsWithBlankLines", () => {
@@ -153,5 +193,13 @@ describe("findCommitMapsWithBlankLines", () => {
     expect(
       findCommitMapsWithBlankLines(map(entry("main"), entry("to-spec-skill")))
     ).toEqual([]);
+  });
+
+  it("reports the packageManager attribute on a broken map", () => {
+    const text = `<CommitMap packageManager="npm">\n${entry("main")}\n\n${entry("to-spec-skill")}\n</CommitMap>`;
+
+    expect(findCommitMapsWithBlankLines(text)).toEqual([
+      '<CommitMap packageManager="npm">',
+    ]);
   });
 });

--- a/apps/local/app/features/article-writer/commit-map-syntax.ts
+++ b/apps/local/app/features/article-writer/commit-map-syntax.ts
@@ -13,8 +13,20 @@
  * find the blocks it would not accept.
  */
 
-const OPEN_TAG = "<CommitMap>";
+/**
+ * The opening tag, with its one optional attribute: `packageManager="npm"` or
+ * `="pnpm"`. Global so a scan can walk forward from an arbitrary offset the
+ * way `text.indexOf("<CommitMap>", at)` used to; any other value in the
+ * attribute (a typo, an invented package manager) fails the whole match, the
+ * same way a scanner treats any other malformed tag — as not a `<CommitMap>`
+ * at all.
+ */
+const OPEN_TAG_PATTERN = /<CommitMap(?:\s+packageManager="(npm|pnpm)")?\s*>/g;
 const CLOSE_TAG = "</CommitMap>";
+const DEFAULT_PACKAGE_MANAGER: PackageManager = "pnpm";
+
+/** The package manager a course's project repo uses. `pnpm` unless stated. */
+export type PackageManager = "npm" | "pnpm";
 
 /** `<Commit …>`, but never `<CommitMap>` — `\b` refuses the longer name. */
 const ENTRY_PATTERN = /<Commit\b([^>]*)>([\s\S]*?)<\/Commit>/g;
@@ -37,6 +49,10 @@ export interface CommitMapBlock {
   start: number;
   /** Offset just past the `</CommitMap>` that closes it. */
   end: number;
+  /** The raw opening tag, so a violation can point the author at the line. */
+  openTag: string;
+  /** The course's package manager, `pnpm` when the attribute is omitted. */
+  packageManager: PackageManager;
   entries: CommitMapEntry[];
   /**
    * A blank line inside the block, which changes how markdown parses it: the
@@ -45,10 +61,16 @@ export interface CommitMapBlock {
   hasBlankLine: boolean;
 }
 
+/** An unclosed `<CommitMap …>` — kept with its exact text for reporting. */
+interface UnclosedCommitMap {
+  start: number;
+  tag: string;
+}
+
 interface CommitMapScan {
   blocks: CommitMapBlock[];
-  /** Offsets of `<CommitMap>` tags that are never closed. */
-  unclosedStarts: number[];
+  /** `<CommitMap>` tags that are never closed. */
+  unclosedStarts: UnclosedCommitMap[];
 }
 
 function parseEntries(inner: string): CommitMapEntry[] {
@@ -75,23 +97,31 @@ function parseEntries(inner: string): CommitMapEntry[] {
  */
 export function scanCommitMaps(text: string): CommitMapScan {
   const blocks: CommitMapBlock[] = [];
-  const unclosedStarts: number[] = [];
+  const unclosedStarts: UnclosedCommitMap[] = [];
 
   let at = 0;
   while (true) {
-    const start = text.indexOf(OPEN_TAG, at);
-    if (start === -1) break;
+    OPEN_TAG_PATTERN.lastIndex = at;
+    const openMatch = OPEN_TAG_PATTERN.exec(text);
+    if (openMatch === null) break;
 
-    const closeAt = text.indexOf(CLOSE_TAG, start + OPEN_TAG.length);
+    const start = openMatch.index;
+    const openEnd = start + openMatch[0]!.length;
+    const packageManager: PackageManager =
+      openMatch[1] === "npm" ? "npm" : DEFAULT_PACKAGE_MANAGER;
+
+    const closeAt = text.indexOf(CLOSE_TAG, openEnd);
     if (closeAt === -1) {
-      unclosedStarts.push(start);
+      unclosedStarts.push({ start, tag: openMatch[0]! });
       break;
     }
 
-    const inner = text.slice(start + OPEN_TAG.length, closeAt);
+    const inner = text.slice(openEnd, closeAt);
     blocks.push({
       start,
       end: closeAt + CLOSE_TAG.length,
+      openTag: openMatch[0]!,
+      packageManager,
       entries: parseEntries(inner),
       hasBlankLine: BLANK_LINE.test(inner),
     });
@@ -114,7 +144,7 @@ export function parseCommitMaps(text: string): CommitMapBlock[] {
 function coveredRanges(scan: CommitMapScan, textLength: number) {
   return [
     ...scan.blocks.map((block) => ({ start: block.start, end: block.end })),
-    ...scan.unclosedStarts.map((start) => ({ start, end: textLength })),
+    ...scan.unclosedStarts.map((u) => ({ start: u.start, end: textLength })),
   ];
 }
 
@@ -172,12 +202,12 @@ export function findCommitsOutsideCommitMap(text: string): string[] {
  * writer is streaming.
  */
 export function findUnclosedCommitMaps(text: string): string[] {
-  return scanCommitMaps(text).unclosedStarts.map(() => OPEN_TAG);
+  return scanCommitMaps(text).unclosedStarts.map((u) => u.tag);
 }
 
 /** Commit maps broken by a blank line. */
 export function findCommitMapsWithBlankLines(text: string): string[] {
   return parseCommitMaps(text)
     .filter((block) => block.hasBlankLine)
-    .map(() => OPEN_TAG);
+    .map((block) => block.openTag);
 }

--- a/apps/local/app/prompts/commit-map-instructions.ts
+++ b/apps/local/app/prompts/commit-map-instructions.ts
@@ -28,6 +28,7 @@ When you are asked for one, this is the shape:
 The rules:
 
 - It goes at the **top of the body**, before the first line of prose. It is navigation: the reader needs it before they start, not after.
+- The opening tag may carry \`packageManager="npm"\`: \`<CommitMap packageManager="npm">\`. Omit it and the course repo is assumed to use pnpm — that is still true for most courses. Never add or change this attribute yourself; use exactly what you are told the course's repo uses, the same as a slug.
 - Each \`id\` is a **slug** — the id of a commit in the course project repo, in kebab-case. It names what the commit does to the tree (\`add-settings-json\`), not the lesson it appears in. Never invent a slug. Use the ones you are given.
 - \`main\` is the one legal id that is not a slug. It names the course's starting point, the state a student first clones.
 - The **first entry is the reset point** — where a student goes to start the lesson. Later entries are the other points the lesson mentions, in the order the lesson reaches them.


### PR DESCRIPTION
## Summary
- The Crash Course's project repo uses npm, but the `CommitMap` preview card always rendered `pnpm reset <slug>` / `pnpm cherry-pick <slug>`, with no way for a body to say otherwise (per Matt's Aug 7 Slack note in `#cc-matt-p`: "the CommitMap components need to be updated to say `npm run reset` and `npm run cherry-pick`").
- Adds an optional `packageManager="npm"` attribute on the opening `<CommitMap>` tag. Omitted, it defaults to `pnpm` (today's universal behaviour, unchanged for every existing lesson).
- Threaded through: the scanner (`commit-map-syntax.ts`, whose exact-string `<CommitMap>` match now also accepts the attribute), the preview card (`commit-map-card.tsx` renders `npm run reset`/`npm run cherry-pick` vs `pnpm reset`/`pnpm cherry-pick`), the Article Writer's instructions, and the `CONTEXT.md` domain entry.
- Note for whoever owns the aihero.dev site's own `CommitMap`/Copy-dropdown component: this PR only fixes the CVM's authoring/lint/preview surface. The live site compiles the body as real MDX (a separate pipeline, not in this repo) and will need the same `packageManager` read to actually change the displayed/copyable command for readers.

## Test plan
- [x] `pnpm vitest run app/features/article-writer/commit-map-syntax.test.ts app/features/article-writer/commit-map-components.test.tsx` — new + existing cases pass (default pnpm, explicit npm/pnpm, invalid value left adrift, unclosed/blank-line lint reports the real tag)
- [x] `pnpm typecheck`
- [x] `pnpm lint:boundaries`
- [x] pre-commit hook (typecheck, boundaries, file-token/dirname checks) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)