### PR TITLE
Add cvm lesson archive verb

### DIFF
--- a/apps/local/app/cli/cli-lesson-video-writes.test.ts
+++ b/apps/local/app/cli/cli-lesson-video-writes.test.ts
@@ -16,6 +16,7 @@ import {
   type RunResult,
   type WriteSeed,
 } from "./cli-write-test-harness";
+import * as schema from "@/db/schema";
 
 // ===========================================================================
 // cvm WRITE verbs — lesson create + video create/move/update
@@ -307,6 +308,72 @@ describe("lesson update", () => {
     expect((JSON.parse(stderr.trim()) as { entity: string }).entity).toBe(
       "lesson"
     );
+  });
+});
+
+describe("lesson archive", () => {
+  interface Lesson {
+    id: string;
+    sectionId: string;
+    title: string;
+    archived: boolean;
+  }
+  const lobj = (stdout: string): Lesson => one<Lesson>(stdout);
+
+  it("hides the lesson from get/list/tree and echoes the archived row", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "lesson",
+      "archive",
+      s.lessonId,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    const archived = lobj(stdout);
+    expect(archived.id).toBe(s.lessonId);
+    expect(archived.archived).toBe(true);
+
+    expect((await run(["lesson", "get", s.lessonId])).exitCode).toBe(2);
+    expect((await run(["lesson", "tree", s.lessonId])).exitCode).toBe(2);
+    const list = ndjson(
+      (await run(["lesson", "list", "--section", s.draftSectionId])).stdout
+    ) as Lesson[];
+    expect(list.map((l) => l.id)).not.toContain(s.lessonId);
+  });
+
+  it("rejects an unknown id => exit 2", async () => {
+    expect((await run(["lesson", "archive", "les_missing"])).exitCode).toBe(2);
+  });
+
+  it("is not repeatable — an archived lesson is not addressable", async () => {
+    await run(["lesson", "archive", s.lessonId]);
+    expect((await run(["lesson", "archive", s.lessonId])).exitCode).toBe(2);
+  });
+
+  it("refuses to archive a lesson in a published (frozen) version (exit 3)", async () => {
+    const [oldCourse] = await testDb
+      .insert(schema.courses)
+      .values({ name: "Old", slug: "old-course" })
+      .returning();
+    const [oldVersion] = await testDb
+      .insert(schema.courseVersions)
+      .values({ repoId: oldCourse!.id, name: "v1", commitState: "published" })
+      .returning();
+    const [oldSection] = await testDb
+      .insert(schema.sections)
+      .values({ repoVersionId: oldVersion!.id, title: "01-old", order: 1 })
+      .returning();
+    const [oldLesson] = await testDb
+      .insert(schema.lessons)
+      .values({ sectionId: oldSection!.id, title: "Old One", order: 1 })
+      .returning();
+
+    const { exitCode, stderr } = await run([
+      "lesson",
+      "archive",
+      oldLesson!.id,
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stderr).toContain("ParseError");
   });
 });
 

--- a/apps/local/app/cli/commands/lesson.help.ts
+++ b/apps/local/app/cli/commands/lesson.help.ts
@@ -27,7 +27,8 @@ KEY FIELDS
 
 ARCHIVED
   Archived lessons are deleted lessons: they are ALWAYS filtered out and never
-  shown. There is no --archived flag for lessons.
+  shown. There is no --archived flag for lessons — 'archive' is the verb that
+  puts a lesson into that state (see 'cvm lesson archive --help').
 
 VERBS
   list --section <id>   All active lessons in a Section (NDJSON, identity-rich).
@@ -41,6 +42,7 @@ VERBS
                         authoring status (WRITE; slug unchanged).
   move <id> [--section <id>] [--before|--after <lessonId>]
                         Reorder within a section, or re-home to another (WRITE).
+  archive <id>          Soft-delete the lesson (WRITE; one-way).
   search <id> <query>   Substring search down this lesson's subtree
                         (--type lesson|video|beat).
 
@@ -156,6 +158,26 @@ Examples:
   cvm lesson update les_abc --authoring-status done
   cvm lesson update les_abc --authoring-status todo
   cvm lesson update les_abc --title "Setup" --authoring-status todo`;
+
+export const ARCHIVE_HELP = `WRITE. Archive a lesson — the only way to delete one.
+
+Sets archived = true. The lesson drops out of this CLI entirely: it stops
+appearing in 'list' and 'tree', 'get' returns not-found, and
+'update'/'move'/'archive' can no longer address it. Editing a published
+(frozen) version is refused (exit 3); archiving only ever targets the Draft.
+Echoes the archived lesson (shaped like 'get', with archived: true) one last
+time — the lesson's own Section/Version/Repo hierarchy included, since
+'archive' does not re-fetch after the write.
+
+ONE-WAY DOOR. There is no CLI verb, no HTTP route and no UI action that
+un-archives a lesson — the CVM UI's own "delete lesson" dialog is this same
+soft delete with no undo. Archiving is effectively a delete you cannot undo
+without touching the database directly. Reach for it accordingly.
+
+EXAMPLES
+  cvm lesson archive les_abc
+  cvm lesson list --section sec_123 | jq -r 'select(.title=="Scratch") | .id' \\
+    | xargs -n1 cvm lesson archive`;
 
 export const MOVE_HELP = `Reposition a lesson: reorder it within its Section, or re-home it to another.
 

--- a/apps/local/app/cli/commands/lesson.ts
+++ b/apps/local/app/cli/commands/lesson.ts
@@ -24,6 +24,7 @@ import {
   CREATE_HELP,
   UPDATE_HELP,
   MOVE_HELP,
+  ARCHIVE_HELP,
 } from "./lesson.help";
 
 /**
@@ -451,6 +452,33 @@ const moveCmd = Command.make(
 ).pipe(Command.withDescription(detail(MOVE_HELP)));
 
 // ---------------------------------------------------------------------------
+// archive <id>
+// ---------------------------------------------------------------------------
+
+const archiveId = Args.text({ name: "id" });
+
+const archiveCmd = Command.make("archive", { id: archiveId }, ({ id }) =>
+  Effect.gen(function* () {
+    const svc = yield* LessonSectionOperationsService;
+
+    // Read the row first — once archived it is deleted-equivalent, so this is
+    // the last chance to fetch it (and the draft guard needs its hierarchy).
+    const lesson = yield* svc
+      .getLessonWithHierarchyById(id)
+      .pipe(Effect.catchTag("NotFoundError", () => notFound("lesson", id)));
+    if (lesson.archived) return yield* notFound("lesson", id);
+    yield* assertDraftLesson(lesson);
+
+    yield* svc.deleteLesson(id);
+
+    // deleteLesson does not return the row (a plain UPDATE, no RETURNING), so
+    // echo what we already read with the one field the write actually
+    // changed — shaped the same way `get` would return it.
+    yield* emitObject({ ...lesson, archived: true });
+  })
+).pipe(Command.withDescription(detail(ARCHIVE_HELP)));
+
+// ---------------------------------------------------------------------------
 // lesson (parent)
 // ---------------------------------------------------------------------------
 
@@ -463,6 +491,7 @@ export const lessonCommand = Command.make("lesson").pipe(
     createCmd,
     updateCmd,
     moveCmd,
+    archiveCmd,
     lessonSearchCmd,
   ])
 );

--- a/apps/local/app/cli/index.ts
+++ b/apps/local/app/cli/index.ts
@@ -25,7 +25,7 @@ const ROOT_HELP = `cvm — agent-facing access to this Course Video Manager proj
 Read-mostly: most verbs are READS. A growing set of nouns has WRITE verbs —
 'beat' (add/update/move/delete), 'clip' (add/update/move/delete), 'chapter'
 (add/update/move/delete), 'overlay' (add/update/delete), 'lesson'
-(create/update/move), 'video'
+(create/update/move/archive), 'video'
 (create/move/update), 'file' (add/delete), 'footage' (transcribe), 'pitch'
 (create/update), 'deliverable' (create/update/archive) and 'course' (publish).
 Every other verb is read-only, and each verb's own --help is authoritative about
@@ -124,8 +124,10 @@ WRITES
                                      no archive, no restore)
     footage transcribe               cache a raw footage file's transcript on
                                      disk (LOCAL-ONLY; feeds 'clip add')
-    lesson  create/update/move       create a lesson, rename its title,
-                                     or reorder / re-home it
+    lesson
+            create/update/move/      create a lesson, rename its title,
+            archive                  reorder / re-home it, or soft-delete it
+                                     ('archive' is one-way, no restore)
     video   create/move/update       create a Video, re-home it to a lesson/
                                      pitch, or rename it (--name)
     file    add/delete               attach scratch files to a Video (writer

--- a/apps/local/app/cli/rpc-layer.ts
+++ b/apps/local/app/cli/rpc-layer.ts
@@ -123,6 +123,9 @@ const lessonSectionService = (client: RpcClient) =>
     batchUpdateLessonOrders: rpcMethod((json) =>
       client.rpc.lesson.batchUpdateLessonOrders.$post({ json })
     ),
+    deleteLesson: rpcMethod((json) =>
+      client.rpc.lesson.deleteLesson.$post({ json })
+    ),
   }) satisfies RemoteService<LessonSectionOperationsService>;
 
 /** `cvm lesson move` — structural writes, in the `lesson` group with them. */

--- a/apps/remote/routes/lesson.ts
+++ b/apps/remote/routes/lesson.ts
@@ -47,6 +47,10 @@ export const lessonRoutes = (runtime: RemoteRuntime) =>
       )
     )
     .post(
+      "/deleteLesson",
+      forward(runtime, LessonSectionOperationsService, "deleteLesson")
+    )
+    .post(
       "/reorderLessons",
       forward(runtime, CourseWriteService, "reorderLessons")
     )


### PR DESCRIPTION
## Summary

`deleteLesson` (soft-delete: `archived = true`, draft-guarded) already existed in `LessonSectionOperationsService` — it just had no way to reach it from `cvm`. This wires the existing plumbing all the way through, mirroring `deliverable archive`.

```mermaid
flowchart LR
    subgraph before["Before — dead end"]
        direction LR
        b1["cvm lesson --help"] -.->|"no archive verb"| bx["✗"]
        b2["deleteLesson()"]:::exists -.->|"no route"| bx
    end
    subgraph after["After — wired end to end"]
        direction LR
        a1["cvm lesson archive id"] --> a2["apps/remote/routes/lesson.ts\nPOST /deleteLesson"]
        a2 --> a3["LessonSectionOperationsService\n.deleteLesson()"]:::exists
        a3 --> a4[("archived = true")]
    end
    classDef exists fill:#dfe,stroke:#4a4
```

`get`/`tree`/`update`/`move` already treat `archived` as deleted-equivalent (checked before starting this), so no further CLI changes were needed once the verb existed.

## What changed

| File | Change |
|---|---|
| `apps/remote/routes/lesson.ts` | `POST /deleteLesson` → forwards to `LessonSectionOperationsService.deleteLesson` |
| `apps/local/app/cli/rpc-layer.ts` | `deleteLesson` added to the RPC client's `lessonSectionService` |
| `apps/local/app/cli/commands/lesson.ts` | new `archiveCmd`: draft-guard (`assertDraftLesson`, same convention as `update`/`move`) → `deleteLesson` → echoes the pre-read row with `archived: true` (the write is a bare `UPDATE`, no `RETURNING`) |
| `apps/local/app/cli/commands/lesson.help.ts` | new `ARCHIVE_HELP`; `VERBS`/`ARCHIVED` sections updated |
| `apps/local/app/cli/index.ts` | root `--help` write-surface list updated |
| `apps/local/app/cli/cli-lesson-video-writes.test.ts` | new `describe("lesson archive", ...)`, mirroring `cli-deliverable-writes.test.ts`'s archive block |

One correction to the "ONE-WAY DOOR" framing I copied from `deliverable archive`'s help text: I checked the UI codebase for a lesson restore/unarchive path (there's precedent for archived-but-restorable entities — courses, clips) and found none — the CVM UI's own "delete lesson" dialog *is* this same `deleteLesson` soft-delete, with no undo. So the one-way-door claim holds for lessons as written.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint:boundaries` pass
- [x] New tests: hides from `get`/`list`/`tree`, unknown/already-archived id → exit 2, non-Draft version → exit 3 (`cli-lesson-video-writes.test.ts`)
- [x] Full `apps/local` + `packages/core` suites pass (a handful of unrelated pre-existing flaky/timeout failures reproduce identically on `main`, verified via `git stash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)