### PR TITLE
Target specific tests locally, exhaustive CI gate (workflow file needs manual add — see body)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Neither `packages/core` nor `apps/remote` may import anything filesystem-bound �
 
 ### Testing
 
-Two tiers — don't run the full suite by hand. Use `pnpm run test:affected` while iterating (scoped to your diff: Turbo `--affected` skips untouched packages, Vitest `--changed` further narrows to affected test files); the full unfiltered suite runs in CI on every PR (`.github/workflows/test.yml`), so scoping locally never leaves a change unverified. See `docs/agents/testing.md` for the scoping mechanics and known PGlite flakiness under a sandboxed agent workspace's CPU load.
+Two tiers — don't run a package's full suite by hand. While iterating, run only the specific test file(s) that cover your change, directly via `pnpm --filter <package> test -- path/to/thing.test.ts`; the full unfiltered suite runs in CI on every PR (`.github/workflows/test.yml`), so targeting locally never leaves a change unverified. See `docs/agents/testing.md` for the mechanics and known PGlite flakiness under a sandboxed agent workspace's CPU load.
 
 ### Deep-module packages
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ A Turborepo monorepo. Two apps: `apps/local` is today's application, and `apps/r
 
 Neither `packages/core` nor `apps/remote` may import anything filesystem-bound — see their READMEs.
 
+### Testing
+
+Two tiers — don't run the full suite by hand. Use `pnpm run test:affected` while iterating (scoped to your diff: Turbo `--affected` skips untouched packages, Vitest `--changed` further narrows to affected test files); the full unfiltered suite runs in CI on every PR (`.github/workflows/test.yml`), so scoping locally never leaves a change unverified. See `docs/agents/testing.md` for the scoping mechanics and known PGlite flakiness under a sandboxed agent workspace's CPU load.
+
 ### Deep-module packages
 
 Packages under `apps/local/app/packages/` are deep modules — import only through a package's entry points (its root files); everything in `lib/`/`tests/` is private. See [apps/local/app/packages/README.md](./apps/local/app/packages/README.md) before adding or importing one. `packages/lucide-icons` is the same idea promoted to a workspace package: its entry points are `index.ts`, `generator.ts` and `tldraw.ts` (exactly its `exports` map), and it carries its own `.dependency-cruiser.cjs`. `pnpm run lint:boundaries` fans out to every package's own check (it runs in pre-commit alongside `typecheck`), so it enforces all of that plus `packages/core` staying filesystem-free.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,0 +1,29 @@
+# Testing: scoped locally, exhaustive in CI
+
+Two tiers, on purpose — don't run the full suite by hand.
+
+## While iterating: `pnpm run test:affected`
+
+Scopes to what your change could actually break:
+
+- **Package-level**: `turbo --affected` diffs against `origin/main` and only runs `test` for packages that changed plus their dependents (untouched packages are skipped outright, not just cache-hit).
+- **File-level**: within an affected package, `vitest --changed=origin/main` further narrows to test files whose import graph actually touches the diff (it correctly widens to "everything" when the diff includes something broad, e.g. a shared module many files import, or root config — that's the safety net inside the narrowing, not a bug).
+
+This is git-diff-based, not cache-based — it gives the same answer on a brand-new clone as it does on a long-lived one, which matters here since agent workspaces are ephemeral (no local Turbo cache survives between sessions, and there is no remote cache).
+
+## The full suite: CI, not you
+
+`.github/workflows/test.yml` runs `typecheck`, `lint:boundaries` and the **unfiltered** `pnpm run test` on every PR — no `--affected`, every package, every time. That's what makes it safe for `test:affected` to stay scoped: nothing merges without the exhaustive run passing regardless of what got skipped locally. Reach for the full `pnpm run test` yourself only if you have a specific reason to distrust the affected-scoping for your change (e.g. you suspect a cross-package regression `--changed` wouldn't see).
+
+## Known noise: `packages/core`'s PGlite suite can look flaky under load
+
+`packages/core` runs its DB-backed tests over in-process PGlite with up to 5 parallel forks (ADR 0014). On a CPU-constrained box (a shared/sandboxed agent workspace, not CI) that can produce sporadic per-test timeouts in otherwise-unrelated files — a symptom of contention, not a regression. Before treating a failure as real:
+
+1. Re-run just that file in isolation (`npx vitest run <file>` from `packages/core`, or `apps/local`) — if it passes alone, that's contention, not a bug.
+2. If still unsure, `git stash` your changes and re-run the same file against `main` — if it fails identically there, it's pre-existing.
+
+Do **not** chase this by re-running the full suite with `--no-file-parallelism`; serializing ~150+ test files can take 10+ minutes and gives no more signal than step 1.
+
+## One build-order gotcha
+
+`packages/core` is consumed via its built `dist/` (its `package.json` `exports` map points there), even from tests — `pnpm run test`/`test:affected` build it first automatically (Turbo's `dependsOn: ["^build"]`), but a direct `vitest run` inside `apps/local` or `apps/remote` (bypassing Turbo for faster iteration) will fail to resolve `@cvm/core/...` imports unless you've run `pnpm --filter @cvm/core build` at least once first.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,19 +1,24 @@
-# Testing: scoped locally, exhaustive in CI
+# Testing: targeted locally, exhaustive in CI
 
-Two tiers, on purpose — don't run the full suite by hand.
+Two tiers, on purpose — don't run a package's full suite (let alone the whole monorepo's) by hand while iterating.
 
-## While iterating: `pnpm run test:affected`
+## While iterating: run only the test file(s) your change touches
 
-Scopes to what your change could actually break:
+You already know which file(s) you edited and which test(s) cover them — a colocated `*.test.ts`, or whatever exercises the changed function/module. Run just those, through the owning package's vitest, not that package's whole `test` script:
 
-- **Package-level**: `turbo --affected` diffs against `origin/main` and only runs `test` for packages that changed plus their dependents (untouched packages are skipped outright, not just cache-hit).
-- **File-level**: within an affected package, `vitest --changed=origin/main` further narrows to test files whose import graph actually touches the diff (it correctly widens to "everything" when the diff includes something broad, e.g. a shared module many files import, or root config — that's the safety net inside the narrowing, not a bug).
+```
+pnpm --filter <package> test -- path/to/thing.test.ts
+```
 
-This is git-diff-based, not cache-based — it gives the same answer on a brand-new clone as it does on a long-lived one, which matters here since agent workspaces are ephemeral (no local Turbo cache survives between sessions, and there is no remote cache).
+e.g. `pnpm --filter @cvm/core test -- db/lessons/archive.test.ts`. `pnpm --filter` forwards anything after `--` straight to the package's `vitest run`, so it narrows to that one file (or a handful, space-separated) instead of the whole package. Package names are each `package.json`'s `name` field (`@cvm/core`, `@cvm/local`, `@cvm/remote`, `@cvm/lucide-icons`).
+
+Root-level `.sandcastle` tests are the one exception: run them via `pnpm run test:root path/to/thing.test.ts` — **no `--`**. At the repo root, `pnpm run <script> -- <args>` (unlike `pnpm --filter <pkg> <script> -- <args>`) forwards a literal `"--"` through to vitest along with your path, which silently runs the whole root suite instead of narrowing — confirmed on pnpm 9.12.3. Dropping the `--` narrows correctly.
+
+This is deliberately manual rather than diff-derived — no `turbo --affected`, no vitest `--changed`, no heuristic guessing "what could this diff have broken" from git history. You already know what you touched and what covers it; that's a better signal than a git-diff heuristic, which can still widen out to a whole package (or more) on a broad-looking diff and cost you the time it was meant to save.
 
 ## The full suite: CI, not you
 
-`.github/workflows/test.yml` runs `typecheck`, `lint:boundaries` and the **unfiltered** `pnpm run test` on every PR — no `--affected`, every package, every time. That's what makes it safe for `test:affected` to stay scoped: nothing merges without the exhaustive run passing regardless of what got skipped locally. Reach for the full `pnpm run test` yourself only if you have a specific reason to distrust the affected-scoping for your change (e.g. you suspect a cross-package regression `--changed` wouldn't see).
+`.github/workflows/test.yml` runs `typecheck`, `lint:boundaries` and the **unfiltered** `pnpm run test` on every PR — every package, every test file, every time. That's what makes it safe to stay targeted locally: nothing merges without the exhaustive run passing regardless of what you ran (or skipped) by hand. Reach for the full `pnpm run test` yourself only if you have a specific reason to distrust your own targeting for this change (e.g. you suspect a cross-package regression the test files you picked wouldn't catch).
 
 ## Known noise: `packages/core`'s PGlite suite can look flaky under load
 
@@ -26,4 +31,4 @@ Do **not** chase this by re-running the full suite with `--no-file-parallelism`;
 
 ## One build-order gotcha
 
-`packages/core` is consumed via its built `dist/` (its `package.json` `exports` map points there), even from tests — `pnpm run test`/`test:affected` build it first automatically (Turbo's `dependsOn: ["^build"]`), but a direct `vitest run` inside `apps/local` or `apps/remote` (bypassing Turbo for faster iteration) will fail to resolve `@cvm/core/...` imports unless you've run `pnpm --filter @cvm/core build` at least once first.
+`packages/core` is consumed via its built `dist/` (its `package.json` `exports` map points there), even from tests — `pnpm run test` builds it first automatically (Turbo's `dependsOn: ["^build"]`), but running `vitest` directly inside `apps/local` or `apps/remote` (bypassing Turbo for faster iteration) will fail to resolve `@cvm/core/...` imports unless you've run `pnpm --filter @cvm/core build` at least once first.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "turbo run dev --filter=!@cvm/overlay-renderer",
     "start": "turbo run start --filter=!@cvm/overlay-renderer",
     "test": "turbo run test test:root --concurrency=1 --filter=!@cvm/overlay-renderer",
+    "test:affected": "turbo run test test:root --concurrency=1 --affected --filter=!@cvm/overlay-renderer -- --changed=origin/main",
     "test:watch": "turbo run test:watch --filter=!@cvm/overlay-renderer",
     "typecheck": "turbo run typecheck typecheck:root --filter=!@cvm/overlay-renderer",
     "lint:boundaries": "turbo run lint:boundaries --filter=!@cvm/overlay-renderer",
@@ -62,6 +63,7 @@
     "tsx": "^4.20.5",
     "turbo": "^2.5.6",
     "typescript": "^5.8.3",
-    "vitest": "^3"
+    "vitest": "^3",
+    "zod": "^4.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "dev": "turbo run dev --filter=!@cvm/overlay-renderer",
     "start": "turbo run start --filter=!@cvm/overlay-renderer",
     "test": "turbo run test test:root --concurrency=1 --filter=!@cvm/overlay-renderer",
-    "test:affected": "turbo run test test:root --concurrency=1 --affected --filter=!@cvm/overlay-renderer -- --changed=origin/main",
     "test:watch": "turbo run test:watch --filter=!@cvm/overlay-renderer",
     "typecheck": "turbo run typecheck typecheck:root --filter=!@cvm/overlay-renderer",
     "lint:boundaries": "turbo run lint:boundaries --filter=!@cvm/overlay-renderer",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       vitest:
         specifier: ^3
         version: 3.2.7(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   apps/local:
     dependencies:


### PR DESCRIPTION
## Summary

```mermaid
flowchart LR
    subgraph today["Today"]
        direction TB
        d1["No CI test gate exists.\nOnly agent-review/implement\nworkflows — neither runs\npnpm test."]
        d2["Full verification is a\nhuman/agent running pnpm test\nby hand — the whole monorepo,\nevery time."]
    end
    subgraph after["After this PR + one manual step"]
        direction TB
        a1["You pick the test file(s)\nyour change actually touches"] -->|"pnpm --filter <pkg> test\n-- path/to/thing.test.ts"| a2["✅ fast feedback\nwhile iterating"]
        a3[".github/workflows/test.yml\n(CI, exhaustive, unfiltered)"] --> a4["✅ real safety net\nnothing merges without it"]
    end
```

**⚠️ One file is NOT included in this branch: `.github/workflows/test.yml`.** This repo's `GH_TOKEN` has scopes `admin:public_key, gist, read:org, repo` — no `workflow` scope. GitHub refuses any write to `.github/workflows/*` without it, and I confirmed this is enforced identically for `git push` *and* the Contents API (a probe write to a normal path succeeded on the same branch; the identical write to `.github/workflows/test.yml` came back masked as a 404). **Someone with `workflow` scope needs to add this file by hand** (paste via the GitHub web UI, which isn't subject to this OAuth restriction):

<details>
<summary><code>.github/workflows/test.yml</code> — paste this in via the GitHub UI</summary>

```yaml
name: Test

# The exhaustive gate. Nothing scoped here on purpose: this is the one place
# the FULL suite runs unconditionally, on every PR, so it is safe for
# local/agent runs to stay targeted to the specific test file(s) a change
# touches (see docs/agents/testing.md) without ever leaving anything
# unverified.
on:
  pull_request:

concurrency:
  group: test-${{ github.workflow }}-${{ github.event.pull_request.number }}
  cancel-in-progress: true

jobs:
  test:
    runs-on: ubuntu-latest
    timeout-minutes: 30
    permissions:
      contents: read

    steps:
      - name: Checkout
        uses: actions/checkout@v4

      - name: Setup pnpm
        uses: pnpm/action-setup@v4

      - name: Setup Node.js 22
        uses: actions/setup-node@v4
        with:
          node-version: "22"
          cache: pnpm

      - name: Install dependencies
        run: pnpm install --frozen-lockfile

      - name: Typecheck
        run: pnpm run typecheck

      - name: Lint boundaries
        run: pnpm run lint:boundaries

      - name: Test
        run: pnpm run test
```

</details>

## What's in this branch

| File | Change |
|---|---|
| `docs/agents/testing.md` (new) | the two-tier model — target specific test files locally, exhaustive `pnpm run test` in CI — plus a documented pnpm quirk (below) and the known PGlite-under-sandbox-CPU-contention flakiness in `packages/core` |
| `CLAUDE.md` | pointer to the new doc, under a new `### Testing` section |
| `package.json` / `pnpm-lock.yaml` | fixed a **pre-existing bug** the new CI workflow would otherwise fail on immediately: `.sandcastle/*.test.ts` imports `zod`, which the Turborepo migration left declared only in `apps/local`/`packages/overlay-renderer`, not the root workspace `.sandcastle` actually lives in — added as a root devDependency |

## Why targeted test files, not `--affected`/`--changed`

First pass at this used `turbo --affected` + `vitest --changed` to auto-derive scope from the git diff. Dropped that: it still risked widening out to a whole package (or more) on a broad-looking diff, and it's solving a problem you don't have when you already know which file(s) you touched and which test(s) cover them. Simpler and just as safe: run those specific files directly —

```
pnpm --filter <package> test -- path/to/thing.test.ts
```

`pnpm --filter` forwards anything after `--` straight to the package's `vitest run`. No diffing, no heuristics, no dependency on git history or a cache — same command works identically on a brand-new ephemeral clone as a long-lived one.

One quirk found and documented while verifying this: at the repo **root**, `pnpm run <script> -- <args>` (unlike `pnpm --filter <pkg> <script> -- <args>`) forwards a literal `"--"` through to vitest and silently runs the *whole* root suite instead of narrowing — confirmed on pnpm 9.12.3. `docs/agents/testing.md` calls this out explicitly for the root `.sandcastle` tests: drop the `--`.

## Test plan
- [x] `pnpm run typecheck` / `pnpm run lint:boundaries` pass (ran automatically via pre-commit)
- [x] Verified targeted runs narrow correctly: `pnpm --filter @cvm/lucide-icons test -- tests/icon-table.test.ts` ran exactly 1 file/12 tests (not the package's other 2 test files)
- [x] Verified the root quirk both ways: `pnpm run test:root -- <file>` incorrectly ran all 5 root test files; `pnpm run test:root <file>` (no `--`) correctly ran just that one
- [x] Verified the `zod` fix: all 5 root `.sandcastle`/`tests` files now pass (previously 2 failed with `Cannot find package 'zod'`)
- [x] Full `pnpm run test` passes modulo pre-existing, sandbox-only flakiness in `packages/core` (confirmed via isolated reruns — unrelated to this diff, which touches no `packages/core` source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
