### PR TITLE
Fix caret not facing down when Learning Goals / Publish Blockers open

### DIFF
--- a/apps/local/app/features/course-view/section-learning-goals.tsx
+++ b/apps/local/app/features/course-view/section-learning-goals.tsx
@@ -54,8 +54,8 @@ export function SectionLearningGoals({
 
   return (
     <Collapsible className="border-b bg-muted/10 px-4 py-2">
-      <CollapsibleTrigger className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground w-full text-left">
-        <ChevronRight className="w-3.5 h-3.5 shrink-0 transition-transform data-[state=open]:rotate-90" />
+      <CollapsibleTrigger className="group flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground w-full text-left">
+        <ChevronRight className="w-3.5 h-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
         Learning Goals
         <span className="text-muted-foreground/60">
           ({learningGoals.length})

--- a/apps/local/app/features/publish/publish-blockers.tsx
+++ b/apps/local/app/features/publish/publish-blockers.tsx
@@ -127,8 +127,8 @@ export function PublishBlockers({
       <BlockerLists lists={mine} />
       {clearableCount > 0 && (
         <Collapsible className="mb-8 rounded-lg border border-border p-4">
-          <CollapsibleTrigger className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground w-full text-left">
-            <ChevronRight className="w-4 h-4 shrink-0 transition-transform data-[state=open]:rotate-90" />
+          <CollapsibleTrigger className="group flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground w-full text-left">
+            <ChevronRight className="w-4 h-4 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
             {clearableCount} blocker{clearableCount !== 1 ? "s" : ""} the
             Autofill will clear
           </CollapsibleTrigger>


### PR DESCRIPTION
## Summary

- The Learning Goals caret (and the identical Publish Blockers "clearable" caret) never rotated to face down on open.
- Root cause: `data-[state=open]:rotate-90` was applied straight to the `ChevronRight` icon, but Radix's `CollapsibleTrigger` only sets `data-state` on the `<button>` it renders — not on children. The selector never matched.

## Fix

```diff
- <CollapsibleTrigger className="flex items-center gap-2 ...">
-   <ChevronRight className="... data-[state=open]:rotate-90" />
+ <CollapsibleTrigger className="group flex items-center gap-2 ...">
+   <ChevronRight className="... group-data-[state=open]:rotate-90" />
```

`group` on the trigger + `group-data-[state=open]` on the icon is the pattern already used elsewhere in this codebase (`label.tsx`, `calendar.tsx`) for matching a Radix data attribute from a nested child.

Applied to both occurrences of the same copied pattern:
- `apps/local/app/features/course-view/section-learning-goals.tsx`
- `apps/local/app/features/publish/publish-blockers.tsx` (doc comment on the former explicitly says it mirrors this one)

## Test plan

- [x] `pnpm --filter local run typecheck` passes
- [x] pre-commit hooks (typecheck, lint:boundaries) pass
- [ ] Manually confirm in the app: open Learning Goals / the Publish Blockers "clearable" section and see the chevron rotate 90° to face down