### PR TITLE
Default-open Learning Goals on an empty section page

### DIFF
--- a/apps/local/app/features/course-view/section-card.tsx
+++ b/apps/local/app/features/course-view/section-card.tsx
@@ -69,12 +69,20 @@ export function SectionCard({
   dropIndicator,
   activeLesson,
   bulkDragIds,
+  singleColumn = false,
 }: {
   section: NonNullable<LoaderData["selectedCourse"]>["sections"][number];
   currentCourse: NonNullable<LoaderData["selectedCourse"]>;
   data: LoaderData;
   isReadOnly: boolean;
   viewMode: "expanded" | "compact";
+  /**
+   * Mirrors `SectionGrid`'s own `singleColumn` — set only by the section
+   * page's route, never the multi-section course view — so it doubles here
+   * as "is this the section page?" for `SectionLearningGoals`'s default-open
+   * behaviour below.
+   */
+  singleColumn?: boolean;
   priorityFilter: number[];
   iconFilter: string[];
   todoFilter: boolean;
@@ -199,7 +207,10 @@ export function SectionCard({
                     />
                   )}
                 </div>
-                <SectionLearningGoals learningGoals={section.learningGoals} />
+                <SectionLearningGoals
+                  learningGoals={section.learningGoals}
+                  defaultOpen={singleColumn && lessons.length === 0}
+                />
                 {(!collapsedSections.has(section.id) || searchQuery) && (
                   <CompactLessonList
                     pairs={spinePairs}

--- a/apps/local/app/features/course-view/section-grid.tsx
+++ b/apps/local/app/features/course-view/section-grid.tsx
@@ -263,6 +263,7 @@ export function SectionGrid({
                     dropIndicator={dropIndicator}
                     activeLesson={activeLesson}
                     bulkDragIds={bulkDragIds}
+                    singleColumn={singleColumn}
                   />
                 ))}
               </div>

--- a/apps/local/app/features/course-view/section-learning-goals.tsx
+++ b/apps/local/app/features/course-view/section-learning-goals.tsx
@@ -35,9 +35,10 @@ function PriorityBadge({ priority }: { priority: number }) {
 
 /**
  * A Section's Learning Goals — the pre-Beat planning artifact — shown as a
- * closed-by-default collapsible (mirrors publish-blockers.tsx's pattern:
- * a ChevronRight that rotates 90deg on open, no `open`/`defaultOpen` prop so
- * Radix defaults to closed).
+ * closed-by-default collapsible (mirrors publish-blockers.tsx's pattern: a
+ * ChevronRight that rotates 90deg on open). `defaultOpen` lets a caller flip
+ * that default: the section page opens it when the Section has no Lessons
+ * yet, since the goals are all there is to look at at that point.
  *
  * Deliberately READ-ONLY: the `cvm learning-goal` CLI is the editing surface
  * (see CONTEXT.md / apps/local/app/cli/commands/learning-goal.ts). Renders
@@ -45,15 +46,20 @@ function PriorityBadge({ priority }: { priority: number }) {
  */
 export function SectionLearningGoals({
   learningGoals,
+  defaultOpen = false,
 }: {
   learningGoals: Section["learningGoals"];
+  defaultOpen?: boolean;
 }) {
   if (learningGoals.length === 0) {
     return null;
   }
 
   return (
-    <Collapsible className="border-b bg-muted/10 px-4 py-2">
+    <Collapsible
+      defaultOpen={defaultOpen}
+      className="border-b bg-muted/10 px-4 py-2"
+    >
       <CollapsibleTrigger className="group flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground w-full text-left">
         <ChevronRight className="w-3.5 h-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
         Learning Goals


### PR DESCRIPTION
## What changed

```
SectionGrid ──singleColumn──▶ SectionCard ──defaultOpen──▶ SectionLearningGoals
 (true only on                 defaultOpen =                 <Collapsible defaultOpen>
  the section page)            singleColumn && lessons.length === 0
```

- `SectionLearningGoals` gains an optional `defaultOpen` prop (default `false` — every existing caller/behavior is unchanged).
- `SectionCard` computes it from `singleColumn` (already threaded from the section page's own route, never set by the multi-section course view) and whether the Section has any Lessons yet.
- `SectionGrid` forwards its `singleColumn` down to `SectionCard`, which didn't previously receive it.

## Why

On a Section's own page, an empty Section (no Lessons yet) has nothing else to show — the Learning Goals are the whole point of looking at it — so the collapsible now starts open instead of making you click to see the only content there is. The multi-section course view keeps the closed-by-default behavior.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint:boundaries` (ran via pre-commit, both green)
- [ ] Open a Section with Learning Goals and zero Lessons on its own page (`/courses/:id/sections/:id`) — Learning Goals should render open
- [ ] Same Section, viewed from the course view grid — Learning Goals should still render closed
- [ ] A Section with Lessons on its own page — Learning Goals should still render closed