### PR TITLE
Add 2-column breakpoint to compact course view grid

### DIFF
--- a/apps/local/app/features/course-view/section-grid.tsx
+++ b/apps/local/app/features/course-view/section-grid.tsx
@@ -222,7 +222,7 @@ export function SectionGrid({
                   singleColumn
                     ? "lg:grid-cols-1"
                     : viewMode === "compact"
-                      ? "lg:grid-cols-3"
+                      ? "md:grid-cols-2 xl:grid-cols-3"
                       : "lg:grid-cols-2"
                 )}
                 onClick={handleGridClick}


### PR DESCRIPTION
## Summary

Compact course view jumped straight from 1 column to 3 columns at the `lg` breakpoint — no halfway house for medium-width screens.

```diff
  singleColumn
    ? "lg:grid-cols-1"
    : viewMode === "compact"
-     ? "lg:grid-cols-3"
+     ? "md:grid-cols-2 xl:grid-cols-3"
      : "lg:grid-cols-2"
```

**Breakpoint progression (compact view):**

```
< md         md–xl        ≥ xl
[ 1 col ] → [ 2 cols ] → [ 3 cols ]
```

(Expanded view's `lg:grid-cols-2` is untouched — it already only has a 1→2 step.)

## Test plan
- [ ] Open a course in compact view, resize the window through the `md`/`xl` breakpoints, confirm the grid steps 1 → 2 → 3 columns
- [ ] Confirm expanded view and `singleColumn` mode are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)