### PR TITLE
Show section title, not numbered path, in Next Up and Section Workbench

### DIFF
--- a/apps/local/app/features/course-view/next-todo-card.tsx
+++ b/apps/local/app/features/course-view/next-todo-card.tsx
@@ -78,7 +78,7 @@ export function NextTodoCard({
       </h3>
       <div className="rounded-lg border bg-card">
         <div className="px-4 py-3 border-b bg-muted/30 flex items-center justify-between">
-          <h2 className="font-medium text-sm">{bestSection.path}</h2>
+          <h2 className="font-medium text-sm">{bestSection.title}</h2>
           <button
             onClick={onDismiss}
             className="text-muted-foreground hover:text-foreground transition-colors"

--- a/apps/local/app/routes/_app.courses.$courseId.sections.$sectionId.tsx
+++ b/apps/local/app/routes/_app.courses.$courseId.sections.$sectionId.tsx
@@ -56,7 +56,7 @@ export const meta: Route.MetaFunction = ({ data }) => {
   const section = data?.selectedCourse?.sections[0];
   const courseName = data?.selectedCourse?.name;
   if (section && courseName) {
-    return [{ title: `CVM - ${courseName} - ${section.path}` }];
+    return [{ title: `CVM - ${courseName} - ${section.title}` }];
   }
   return [{ title: "CVM" }];
 };
@@ -250,7 +250,7 @@ export default function Component(props: Route.ComponentProps) {
                   {currentCourse.name}
                 </Link>
 
-                <h1 className="text-2xl font-bold mb-4">{section.path}</h1>
+                <h1 className="text-2xl font-bold mb-4">{section.title}</h1>
 
                 {loaderData.selectedVersion && !loaderData.isLatestVersion && (
                   <div className="mb-4">


### PR DESCRIPTION
## What's wrong

Two surfaces render a section as a standalone heading but read the derived `path` (`NN-slug`) instead of the clean `title` — the same bug class as the section-title data cleanup from earlier today, just baked into the UI code instead of the DB rows.

```
Section { title: "Domain Language", order: 2 }
                │
                ├─ path (derived, NN-slug) ──► "02-domain-language"
                └─ title (stored, clean)   ──► "Domain Language"
```

| Surface | Before | After |
|---|---|---|
| Course view → **Next Up** card header | `bestSection.path` → `02-domain-language` | `bestSection.title` → `Domain Language` |
| **Section Workbench** page `<h1>` + browser tab title | `section.path` | `section.title` |

## What's untouched, on purpose

Every other `.path` read is an intentional ordered-wayfinding breadcrumb (move-video/move-lesson pickers, publish blockers, changelog, media-files page) — those already match how `SectionTitleRow` and the rest of the course view work, so they're out of scope here.

## Verification

- `pnpm --filter local typecheck` — clean
- `pnpm check` (typecheck + lint:boundaries) via pre-commit hook — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)