### PR TITLE
Drop numbered prefix from derived paths; fix title-corrupting lesson-move bug

### DIFF
--- a/apps/local/app/cli/cli-course-readiness.test.ts
+++ b/apps/local/app/cli/cli-course-readiness.test.ts
@@ -103,7 +103,10 @@ describe("course readiness", () => {
     expect(out.exportsRequired).toBe(1);
     expect(out.unexportedVideos).toEqual([
       // The title is the DERIVED section/lesson path, not the raw titles.
-      { id: s.lessonVideoId, title: "01-01-intro/01.01-welcome/intro.mp4" },
+      // The section's literal title happens to be "01-intro" (chosen so the
+      // pre-ADR-0028 double-numbered path — "01-01-intro" — was
+      // distinguishable from a coincidence); its slug is unchanged either way.
+      { id: s.lessonVideoId, title: "01-intro/welcome/intro.mp4" },
     ]);
   });
 

--- a/apps/local/app/features/course-view/course-editor-helpers.ts
+++ b/apps/local/app/features/course-view/course-editor-helpers.ts
@@ -285,7 +285,7 @@ export function computeFlatLessons(sections: Section[]) {
       number: `${sectionIdx + 1}.${lessonIdx + 1}`,
       title: lesson.title || lesson.path,
       sectionId: section.id,
-      sectionTitle: section.path,
+      sectionTitle: section.title,
       sectionNumber: sectionIdx + 1,
     }))
   );

--- a/apps/local/app/features/course-view/optimistic-applier-reorders.test.ts
+++ b/apps/local/app/features/course-view/optimistic-applier-reorders.test.ts
@@ -306,21 +306,20 @@ describe("applyOptimisticEvent — reorders", () => {
       ).toEqual(["l2"]);
     });
 
-    it("renumbers the moved lesson and source as part of the cascade", () => {
-      // Both sections stay real (no materialize/dematerialize): a plain
-      // cross-section move that still renumbers the moved lesson and the
-      // source's remaining lessons. See docs/adr/0011-shared-lesson-move-planner.
+    it("moves the lesson without touching any other lesson's or section's path", () => {
+      // Neither section's title changes, so neither section's path changes,
+      // and the moved lesson's path is just its own (unchanged) title's slug.
+      // See docs/adr/0028-drop-numbered-path-prefix.
       const section1 = makeSection(
-        { id: "s1", path: "01-intro", title: "intro" },
+        { id: "s1", path: "intro", title: "intro" },
         [
-          makeLesson({ id: "l1", path: "01.01-a", title: "a", order: 0 }),
-          makeLesson({ id: "keep", path: "01.02-b", title: "b", order: 1 }),
+          makeLesson({ id: "l1", path: "a", title: "a", order: 0 }),
+          makeLesson({ id: "keep", path: "b", title: "b", order: 1 }),
         ]
       );
-      const section2 = makeSection(
-        { id: "s2", path: "02-next", title: "next" },
-        [makeLesson({ id: "existing", path: "02.01-c", title: "c", order: 0 })]
-      );
+      const section2 = makeSection({ id: "s2", path: "next", title: "next" }, [
+        makeLesson({ id: "existing", path: "c", title: "c", order: 0 }),
+      ]);
       const loaderData = makeLoaderData([section1, section2]);
 
       const event: CourseEditorEvent = {
@@ -332,30 +331,27 @@ describe("applyOptimisticEvent — reorders", () => {
       const result = applyOptimisticEvent(loaderData, event);
 
       const target = result.selectedCourse!.sections[1]!;
-      // Appended to the end of the target, renumbered to its slot.
+      // Appended to the end of the target; path is just its own title's slug.
       expect(target.lessons.map((l) => l.id)).toEqual(["existing", "l1"]);
-      expect(target.lessons[1]!.path).toBe("02.02-a");
-      // Source closed its gap: keep 01.02 → 01.01.
+      expect(target.lessons[1]!.path).toBe("a");
+      // Source's remaining lesson keeps its own path untouched.
       const source = result.selectedCourse!.sections[0]!;
       expect(source.lessons.map((l) => l.id)).toEqual(["keep"]);
-      expect(source.lessons[0]!.path).toBe("01.01-b");
+      expect(source.lessons[0]!.path).toBe("b");
     });
 
     it("inserts before the drop anchor when beforeLessonId is set", () => {
       const section1 = makeSection(
-        { id: "s1", path: "01-intro", title: "intro" },
+        { id: "s1", path: "intro", title: "intro" },
         [
-          makeLesson({ id: "l1", path: "01.01-a", title: "a", order: 0 }),
-          makeLesson({ id: "keep", path: "01.02-b", title: "b", order: 1 }),
+          makeLesson({ id: "l1", path: "a", title: "a", order: 0 }),
+          makeLesson({ id: "keep", path: "b", title: "b", order: 1 }),
         ]
       );
-      const section2 = makeSection(
-        { id: "s2", path: "02-next", title: "next" },
-        [
-          makeLesson({ id: "t1", path: "02.01-c", title: "c", order: 0 }),
-          makeLesson({ id: "t2", path: "02.02-d", title: "d", order: 1 }),
-        ]
-      );
+      const section2 = makeSection({ id: "s2", path: "next", title: "next" }, [
+        makeLesson({ id: "t1", path: "c", title: "c", order: 0 }),
+        makeLesson({ id: "t2", path: "d", title: "d", order: 1 }),
+      ]);
       const loaderData = makeLoaderData([section1, section2]);
 
       const event: CourseEditorEvent = {
@@ -369,8 +365,8 @@ describe("applyOptimisticEvent — reorders", () => {
 
       const target = result.selectedCourse!.sections[1]!;
       expect(target.lessons.map((l) => l.id)).toEqual(["t1", "l1", "t2"]);
-      expect(target.lessons[1]!.path).toBe("02.02-a");
-      expect(target.lessons[2]!.path).toBe("02.03-d");
+      expect(target.lessons[1]!.path).toBe("a");
+      expect(target.lessons[2]!.path).toBe("d");
     });
 
     it("returns loaderData unchanged when lesson is not found", () => {
@@ -404,24 +400,24 @@ describe("applyOptimisticEvent — reorders", () => {
       expect(result).toBe(loaderData);
     });
 
-    it("leaves sections outside the cascade structurally unchanged", () => {
-      // A move that changes no section's realness must not renumber sections,
-      // so a truly unrelated section keeps its structure (paths recomputed by
-      // attachDerivedPaths mean reference equality no longer holds).
+    it("leaves sections outside the move structurally unchanged", () => {
+      // A move never touches any section's title/path, so an unrelated
+      // section keeps its structure (attachDerivedPaths recomputes every
+      // path from the same, unchanged title, so it deep-equals the input —
+      // even though it isn't the same object).
       const section1 = makeSection(
-        { id: "s1", path: "01-intro", title: "intro" },
+        { id: "s1", path: "intro", title: "intro" },
         [
-          makeLesson({ id: "l1", path: "01.01-a", title: "a", order: 0 }),
-          makeLesson({ id: "keep", path: "01.02-b", title: "b", order: 1 }),
+          makeLesson({ id: "l1", path: "a", title: "a", order: 0 }),
+          makeLesson({ id: "keep", path: "b", title: "b", order: 1 }),
         ]
       );
-      const section2 = makeSection(
-        { id: "s2", path: "02-next", title: "next" },
-        [makeLesson({ id: "existing", path: "02.01-c", title: "c", order: 0 })]
-      );
+      const section2 = makeSection({ id: "s2", path: "next", title: "next" }, [
+        makeLesson({ id: "existing", path: "c", title: "c", order: 0 }),
+      ]);
       const section3 = makeSection(
-        { id: "s3", path: "03-other", title: "other" },
-        [makeLesson({ id: "l3", path: "03.01-d", title: "d", order: 0 })]
+        { id: "s3", path: "other", title: "other" },
+        [makeLesson({ id: "l3", path: "d", title: "d", order: 0 })]
       );
       const loaderData = makeLoaderData([section1, section2, section3]);
 
@@ -476,17 +472,16 @@ describe("applyOptimisticEvent — reorders", () => {
   describe("move-lessons-to-section", () => {
     it("moves a whole multi-lesson selection into another section as a block", () => {
       const section1 = makeSection(
-        { id: "s1", path: "01-intro", title: "intro" },
+        { id: "s1", path: "intro", title: "intro" },
         [
-          makeLesson({ id: "a", path: "01.01-a", title: "a", order: 0 }),
-          makeLesson({ id: "b", path: "01.02-b", title: "b", order: 1 }),
-          makeLesson({ id: "c", path: "01.03-c", title: "c", order: 2 }),
+          makeLesson({ id: "a", path: "a", title: "a", order: 0 }),
+          makeLesson({ id: "b", path: "b", title: "b", order: 1 }),
+          makeLesson({ id: "c", path: "c", title: "c", order: 2 }),
         ]
       );
-      const section2 = makeSection(
-        { id: "s2", path: "02-next", title: "next" },
-        [makeLesson({ id: "x", path: "02.01-x", title: "x", order: 0 })]
-      );
+      const section2 = makeSection({ id: "s2", path: "next", title: "next" }, [
+        makeLesson({ id: "x", path: "x", title: "x", order: 0 }),
+      ]);
       const loaderData = makeLoaderData([section1, section2]);
 
       const event: CourseEditorEvent = {
@@ -498,31 +493,28 @@ describe("applyOptimisticEvent — reorders", () => {
       const result = applyOptimisticEvent(loaderData, event);
 
       // Both selected lessons land in the target, appended as a block in
-      // selection order; the unselected source lesson stays and renumbers.
+      // selection order; the unselected source lesson keeps its own path.
       const source = result.selectedCourse!.sections[0]!;
       const target = result.selectedCourse!.sections[1]!;
       expect(source.lessons.map((l) => l.id)).toEqual(["b"]);
-      expect(source.lessons[0]!.path).toBe("01.01-b");
+      expect(source.lessons[0]!.path).toBe("b");
       expect(target.lessons.map((l) => l.id)).toEqual(["x", "a", "c"]);
-      expect(target.lessons[1]!.path).toBe("02.02-a");
-      expect(target.lessons[2]!.path).toBe("02.03-c");
+      expect(target.lessons[1]!.path).toBe("a");
+      expect(target.lessons[2]!.path).toBe("c");
     });
 
     it("inserts the block before the drop anchor", () => {
       const section1 = makeSection(
-        { id: "s1", path: "01-intro", title: "intro" },
+        { id: "s1", path: "intro", title: "intro" },
         [
-          makeLesson({ id: "a", path: "01.01-a", title: "a", order: 0 }),
-          makeLesson({ id: "b", path: "01.02-b", title: "b", order: 1 }),
+          makeLesson({ id: "a", path: "a", title: "a", order: 0 }),
+          makeLesson({ id: "b", path: "b", title: "b", order: 1 }),
         ]
       );
-      const section2 = makeSection(
-        { id: "s2", path: "02-next", title: "next" },
-        [
-          makeLesson({ id: "x", path: "02.01-x", title: "x", order: 0 }),
-          makeLesson({ id: "y", path: "02.02-y", title: "y", order: 1 }),
-        ]
-      );
+      const section2 = makeSection({ id: "s2", path: "next", title: "next" }, [
+        makeLesson({ id: "x", path: "x", title: "x", order: 0 }),
+        makeLesson({ id: "y", path: "y", title: "y", order: 1 }),
+      ]);
       const loaderData = makeLoaderData([section1, section2]);
 
       const event: CourseEditorEvent = {

--- a/apps/local/app/features/course-view/optimistic-applier.test.ts
+++ b/apps/local/app/features/course-view/optimistic-applier.test.ts
@@ -85,7 +85,7 @@ describe("applyOptimisticEvent", () => {
 
       const result = applyOptimisticEvent(loaderData, event);
 
-      expect(result.selectedCourse!.sections[0]!.path).toBe("01-basics");
+      expect(result.selectedCourse!.sections[0]!.path).toBe("basics");
     });
 
     it("returns loaderData unchanged when section is not found", () => {
@@ -118,7 +118,7 @@ describe("applyOptimisticEvent", () => {
       expect(result.selectedCourse!.sections[0]!.path).toBe("renamed-section");
     });
 
-    it("handles section path with dotted prefix", () => {
+    it("ignores whatever the section's previous path happened to be", () => {
       const section = makeSection({ id: "section-1", path: "01.03-advanced" });
       const loaderData = makeLoaderData([section]);
       const event: CourseEditorEvent = {
@@ -129,7 +129,7 @@ describe("applyOptimisticEvent", () => {
 
       const result = applyOptimisticEvent(loaderData, event);
 
-      expect(result.selectedCourse!.sections[0]!.path).toBe("01.03-expert");
+      expect(result.selectedCourse!.sections[0]!.path).toBe("expert");
     });
 
     it("does not mutate the original loaderData", () => {
@@ -192,7 +192,7 @@ describe("applyOptimisticEvent", () => {
       const result = applyOptimisticEvent(loaderData, event);
 
       expect(result.selectedCourse!.sections[0]!.lessons[0]!.path).toBe(
-        "01-getting-started"
+        "getting-started"
       );
     });
 
@@ -209,7 +209,7 @@ describe("applyOptimisticEvent", () => {
       expect(result).toBe(loaderData);
     });
 
-    it("handles new-format lesson path with dotted prefix", () => {
+    it("ignores whatever the lesson's previous path happened to be", () => {
       const lesson = makeLesson({ id: "lesson-1", path: "01.03-intro" });
       const loaderData = makeLoaderData([makeSection({}, [lesson])]);
       const event: CourseEditorEvent = {
@@ -221,7 +221,7 @@ describe("applyOptimisticEvent", () => {
       const result = applyOptimisticEvent(loaderData, event);
 
       expect(result.selectedCourse!.sections[0]!.lessons[0]!.path).toBe(
-        "01.03-overview"
+        "overview"
       );
     });
 
@@ -241,7 +241,7 @@ describe("applyOptimisticEvent", () => {
       );
     });
 
-    it("preserves prefix when new slug contains hyphens", () => {
+    it("handles a new slug that contains hyphens", () => {
       const loaderData = makeLoaderData();
       const event: CourseEditorEvent = {
         type: "update-lesson-name",
@@ -252,7 +252,7 @@ describe("applyOptimisticEvent", () => {
       const result = applyOptimisticEvent(loaderData, event);
 
       expect(result.selectedCourse!.sections[0]!.lessons[0]!.path).toBe(
-        "01-my-long-slug-name"
+        "my-long-slug-name"
       );
     });
   });

--- a/apps/local/app/features/course-view/optimistic-applier.ts
+++ b/apps/local/app/features/course-view/optimistic-applier.ts
@@ -92,8 +92,8 @@ export function applyOptimisticEvent(
         title: event.title,
       }));
     case "update-lesson-name":
-      return withPatchedLesson(loaderData, event.lessonId, (lesson) => ({
-        path: replaceSlug(lesson.path, event.newSlug),
+      return withPatchedLesson(loaderData, event.lessonId, () => ({
+        path: toSlug(event.newSlug) || "untitled",
       }));
     case "update-lesson-description":
       return withPatchedLesson(loaderData, event.lessonId, () => ({
@@ -112,9 +112,9 @@ export function applyOptimisticEvent(
         authoringStatus: event.status,
       }));
     case "update-section-name":
-      return withPatchedSection(loaderData, event.sectionId, (section) => ({
+      return withPatchedSection(loaderData, event.sectionId, () => ({
         title: event.title,
-        path: replaceSlug(section.path, toSlug(event.title) || "untitled"),
+        path: toSlug(event.title) || "untitled",
       }));
     case "update-section-description":
       return withPatchedSection(loaderData, event.sectionId, () => ({
@@ -151,11 +151,6 @@ export function applyOptimisticEvent(
     default:
       return loaderData;
   }
-}
-
-function replaceSlug(path: string, newSlug: string): string {
-  const match = path.match(/^(\d[\d.]*-)/);
-  return match ? match[1] + newSlug : newSlug;
 }
 
 export function applyOptimisticDeleteVideo(
@@ -317,10 +312,8 @@ function applyReorderLessons(
 function toPlannerSections(course: NonNullable<LoaderData["selectedCourse"]>) {
   return course.sections.map((s) => ({
     id: s.id,
-    path: s.path,
     lessons: s.lessons.map((l) => ({
       id: l.id,
-      path: l.path,
       order: l.order,
     })),
   }));
@@ -375,12 +368,14 @@ function applyMoveLessonsToSection(
 }
 
 /**
- * Replay a move plan onto loader data. The moved lessons are dropped from their
- * current sections and re-inserted as one contiguous block (in
- * `orderedLessonIds` order) at the drop anchor in the target; every other
- * lesson/section is patched per the plan's path/order/renumber deltas.
- * Untouched sections keep their reference so the measured dep-group spine
- * avoids re-measuring. See docs/adr/0011-shared-lesson-move-planner.md and
+ * Replay a move plan onto loader data. The moved lessons are dropped from
+ * their current sections and re-inserted as one contiguous block (in
+ * `orderedLessonIds` order) at the drop anchor in the target. No other
+ * lesson's `order` changes and no section's path is ever touched by a move
+ * (see `lesson-move-planner.ts`) — `attachDerivedPaths` at the end just
+ * re-projects every path fresh from title + membership. Untouched sections
+ * keep their reference so the measured dep-group spine avoids re-measuring.
+ * See docs/adr/0011-shared-lesson-move-planner.md and
  * docs/adr/0012-bulk-lesson-reorder-within-section.md.
  */
 function applyMovePlanToLoader(
@@ -394,9 +389,6 @@ function applyMovePlanToLoader(
   if (!course || plan.noop) return loaderData;
 
   const lessonUpdateById = new Map(plan.lessonUpdates.map((u) => [u.id, u]));
-  const sectionPathById = new Map(
-    plan.sectionUpdates.map((u) => [u.id, u.path])
-  );
 
   // Lessons that actually landed in the target, in insertion order.
   const movedIds = orderedLessonIds.filter(
@@ -418,14 +410,8 @@ function applyMovePlanToLoader(
   const sections = course.sections.map((section) => {
     const hadMoved = section.lessons.some((l) => movedSet.has(l.id));
     const isTarget = section.id === targetSectionId;
-    const newPath = sectionPathById.get(section.id);
-    const hasPatchedLesson = section.lessons.some(
-      (l) => !movedSet.has(l.id) && lessonUpdateById.has(l.id)
-    );
     // Sections the cascade doesn't touch keep their reference.
-    if (!hadMoved && !isTarget && newPath === undefined && !hasPatchedLesson) {
-      return section;
-    }
+    if (!hadMoved && !isTarget) return section;
 
     // Drop the moved lessons from wherever they currently live.
     let lessons = section.lessons.filter((l) => !movedSet.has(l.id));
@@ -443,12 +429,7 @@ function applyMovePlanToLoader(
           : [...lessons.slice(0, idx), ...movedBlock, ...lessons.slice(idx)];
     }
 
-    // Apply path/order patches to the rest (source renumber, target shifts).
-    lessons = lessons.map((l) => (movedSet.has(l.id) ? l : patch(l)));
-
-    return newPath !== undefined
-      ? { ...section, path: newPath, lessons }
-      : { ...section, lessons };
+    return { ...section, lessons };
   });
 
   return {

--- a/apps/local/app/services/course-publish-service-batch-export.test.ts
+++ b/apps/local/app/services/course-publish-service-batch-export.test.ts
@@ -303,9 +303,9 @@ describe("CoursePublishService", () => {
 
       // "Problem" is the 20s video seeded by setup().
       expect(announcedTitles(events)).toEqual([
-        "01-intro/01.01-welcome/B Long",
-        "01-intro/01.01-welcome/Problem",
-        "01-intro/01.01-welcome/A Tiny",
+        "intro/welcome/B Long",
+        "intro/welcome/Problem",
+        "intro/welcome/A Tiny",
       ]);
     });
 
@@ -321,9 +321,9 @@ describe("CoursePublishService", () => {
       const events = await runBatchExport(context);
 
       expect(announcedTitles(events)).toEqual([
-        "01-intro/01.01-welcome/Z Many Short",
-        "01-intro/01.01-welcome/A One Long",
-        "01-intro/01.01-welcome/Problem",
+        "intro/welcome/Z Many Short",
+        "intro/welcome/A One Long",
+        "intro/welcome/Problem",
       ]);
     });
 

--- a/apps/local/app/services/course-publish-service-sync.test.ts
+++ b/apps/local/app/services/course-publish-service-sync.test.ts
@@ -537,7 +537,7 @@ describe("CoursePublishService.syncToDropbox (Dropbox HTTP API)", () => {
     expect(result.missingVideos).toEqual([]);
     const videos = getManifestVideos(getRemoteManifest());
     expect(videos).toHaveLength(1);
-    expect(videos[0]!.relativePath).not.toContain("01.02-setup");
+    expect(videos[0]!.relativePath).not.toContain("setup");
   });
 
   // ── Withholding to-do lessons (includeTodoLessons = false) ──────────
@@ -555,10 +555,10 @@ describe("CoursePublishService.syncToDropbox (Dropbox HTTP API)", () => {
     const doc = getRemoteManifest();
     const videos = getManifestVideos(doc);
     expect(videos).toHaveLength(1);
-    expect(videos[0]!.relativePath).toContain("01.01-welcome/Problem.mp4");
+    expect(videos[0]!.relativePath).toContain("welcome/Problem.mp4");
     const fullPath = `${DROPBOX_REMOTE_PATH}/test-course/${videos[0]!.relativePath}`;
     expect(fakeDropbox.get(fullPath)).toBeDefined();
-    expect(videos[0]!.relativePath).not.toContain("01.02-setup");
+    expect(videos[0]!.relativePath).not.toContain("setup");
 
     expect(doc.sections).toHaveLength(1);
     expect(doc.sections[0].lessons).toHaveLength(1);
@@ -576,7 +576,7 @@ describe("CoursePublishService.syncToDropbox (Dropbox HTTP API)", () => {
     );
     const firstDoc = getRemoteManifest();
     const previousTodoVideo = getManifestVideos(firstDoc).find((video) =>
-      video.relativePath.includes("01.02-setup")
+      video.relativePath.includes("setup")
     )!;
     const previousTodoPath = `${DROPBOX_REMOTE_PATH}/test-course/${previousTodoVideo.relativePath}`;
     expect(fakeDropbox.get(previousTodoPath)).toBeDefined();
@@ -591,7 +591,7 @@ describe("CoursePublishService.syncToDropbox (Dropbox HTTP API)", () => {
     const secondDoc = getRemoteManifest();
     expect(
       getManifestVideos(secondDoc).some((video) =>
-        video.relativePath.includes("01.02-setup")
+        video.relativePath.includes("setup")
       )
     ).toBe(false);
     // The prior bundle's files are still in Dropbox.

--- a/apps/local/app/services/course-publish-service-test-setup.ts
+++ b/apps/local/app/services/course-publish-service-test-setup.ts
@@ -223,6 +223,12 @@ export const setupPublishableCourse = async (opts?: {
 
   for (let index = 0; index < videoCount; index++) {
     const lessonPath = `01.${String(index + 1).padStart(2, "0")}-welcome`;
+    // Every lesson's fixture path parses to the same title ("welcome") once
+    // stripped, so the derived path (title-only, no number — see
+    // docs/adr/0028-drop-numbered-path-prefix) disambiguates same-titled
+    // siblings by rank order: bare "welcome" for the first, "welcome-2" for
+    // the second, and so on.
+    const derivedLessonPath = index === 0 ? "welcome" : `welcome-${index + 1}`;
     const lesson = await Effect.gen(function* () {
       const lsOps = yield* LessonSectionOperationsService;
       const lessons = yield* lsOps.createLessons(section.id, [
@@ -265,7 +271,7 @@ export const setupPublishableCourse = async (opts?: {
       title: video.title,
       lessonPath,
       exportHash: computeExportHash(videoClips, "landscape")!,
-      relativeAssetPath: `01-intro/${lessonPath}/${video.title}.mp4`,
+      relativeAssetPath: `intro/${derivedLessonPath}/${video.title}.mp4`,
     });
   }
 

--- a/apps/local/app/services/course-publish-service-video-tasks.test.ts
+++ b/apps/local/app/services/course-publish-service-video-tasks.test.ts
@@ -60,7 +60,7 @@ describe("CoursePublishService — per-Video upload tasks", () => {
       videos.map((v) => v.id).sort()
     );
     for (const video of roster!.data.videos) {
-      expect(video.title).toMatch(/^01-intro\/.+\/Problem$/);
+      expect(video.title).toMatch(/^intro\/.+\/Problem$/);
     }
 
     // The export roster is the strict subset that still needs encoding.

--- a/apps/local/app/services/course-publish-service.test.ts
+++ b/apps/local/app/services/course-publish-service.test.ts
@@ -398,8 +398,8 @@ describe("CoursePublishService", () => {
 
       expect(result.incompleteVideos).toMatchObject([
         {
-          sectionPath: "01-intro",
-          lessonPath: "01.01-welcome",
+          sectionPath: "intro",
+          lessonPath: "welcome",
           videoTitle: "Problem",
           missing: ["body", "description"],
         },

--- a/apps/local/app/services/video-posting-context.server.test.ts
+++ b/apps/local/app/services/video-posting-context.server.test.ts
@@ -286,15 +286,13 @@ describe("loadVideoPostingContext", () => {
 
         expect(ctx.courseStructure).not.toBeNull();
         expect(ctx.courseStructure!.repoName).toBe("test-course");
-        expect(ctx.courseStructure!.currentSectionPath).toBe("01-intro");
-        expect(ctx.courseStructure!.currentLessonPath).toBe(
-          "01.01-getting-started"
-        );
+        expect(ctx.courseStructure!.currentSectionPath).toBe("intro");
+        expect(ctx.courseStructure!.currentLessonPath).toBe("getting-started");
         expect(ctx.courseStructure!.sections).toHaveLength(1);
 
         const sectionResult = ctx.courseStructure!.sections[0]!;
         expect(sectionResult.lessons).toHaveLength(1);
-        expect(sectionResult.lessons[0]!.path).toBe("01.01-getting-started");
+        expect(sectionResult.lessons[0]!.path).toBe("getting-started");
       }).pipe(Effect.provide(testLayer))
     );
 

--- a/docs/adr/0011-shared-lesson-move-planner.md
+++ b/docs/adr/0011-shared-lesson-move-planner.md
@@ -1,5 +1,5 @@
 ---
-status: accepted
+status: superseded by 0028-drop-numbered-path-prefix
 ---
 
 # Lesson moves are computed by a shared pure planner, executed server-side and replayed optimistically

--- a/docs/adr/0028-drop-numbered-path-prefix.md
+++ b/docs/adr/0028-drop-numbered-path-prefix.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+---
+
+# Derived path drops its numbered prefix; the lesson-move planner sheds the renumbering cascade it existed to serve
+
+A section/lesson's display path has been derived (never stored) since [ADR 0018](0018-db-only-courses.md), but the derivation still baked the same numbering scheme the old on-disk format used — `NN-slug` for a Section, `NN.MM-slug` for a Lesson — recomputed fresh from rank-by-`order` on every read. Nothing downstream actually needs that number: `course.json` already carries explicit array order plus `title` (ADR 0019), and the Dropbox bundle's Video paths (ADR 0023) only need to be unique on disk, not ordered by name. Meanwhile the numbering had a real cost: [ADR 0011](0011-shared-lesson-move-planner.md)'s move planner treated the number as something that must be kept correct, so moving a Lesson between Sections renumbered siblings, "materialized"/"dematerialized" Section prefixes, and emitted a `sectionUpdates` list of `{ id, path }` pairs. The server executed that list by writing the numbered path straight into `sections.title` (`db.updateSectionTitle(u.id, u.path)`) — a live bug that re-seeded `01-my-section`-style titles into the database every time a Lesson move flipped a Section's real/empty status, undoing manual title cleanups over time.
+
+`deriveSectionPath`/`deriveLessonPath` now take only a `title` and return `toSlug(title) || "untitled"` — no number. Same-titled siblings (title uniqueness is not enforced; only `order` uniqueness per parent is, per ADR 0018) are disambiguated with a `-2`, `-3`, … suffix, assigned in rank order, computed at projection time in `path-projection.ts` and nowhere else.
+
+## Why this shape
+
+- **A path that only depends on title never needs recomputing on a structural change.** Moving a Lesson, reordering a Section, or emptying/filling a Section no longer changes anyone's path — only the moved Lesson's own `order`/`sectionId` changes. That removes the entire reason `lesson-move-planner.ts` computed `sectionUpdates`/`fsOps`: there is nothing left to renumber, so `planLessonMove`/`planLessonsMove` now return just `lessonUpdates`, and `course-write-move-ops.ts`'s `executeMovePlan` no longer writes to `title` at all. The corruption bug is closed by construction, not by a guard.
+- **Fixing the bug without dropping the number would have left the cascade in place.** The renumbering machinery existed only to keep the number correct; patching the one buggy write (`updateSectionTitle`) while leaving `sectionUpdates`/`fsOps`/the materialize-dematerialize cascade computing dead data would keep ~300 lines of pre-ADR-0018 git-repo logic alive for no consumer. Removing the number and the cascade together is the smaller, more honest change.
+- **Reordering no longer perturbs the Dropbox bundle's `assetFingerprint`.** The fingerprint (ADR 0023) hashes each Video's `relativeAssetPath`, which is built from `section.path`/`lesson.path`. Because the old paths embedded rank, reordering a Section changed the path — and therefore the fingerprint — of every Video after it, forcing a full re-address even though no Video's content changed. A title-only path is stable under reordering, so only an actual title/membership change touches a Video's address now.
+- **Collision disambiguation only has to run where it can see all siblings.** `path-projection.ts` is the sole place paths are computed from the full sibling set on every read, so it is the only place a `-2` suffix can be assigned correctly; it was already the single source of truth per ADR 0018, so no new seam was added.
+
+## Consequences
+
+- [ADR 0011](0011-shared-lesson-move-planner.md) is superseded by this ADR: `planLessonMove`/`planLessonsMove` no longer compute or return `sectionUpdates`/`fsOps`, and the optimistic applier (`optimistic-applier.ts`) no longer patches a section's `path` when a Lesson moves — `attachDerivedPaths` re-projects every path fresh from the (unchanged) title.
+- `buildSectionPath`, `buildLessonPath`, `computeSectionRenumberingPlan`, `computeRenumberingPlan`, and `computeInsertionPlan` are deleted; they existed only to build or reshuffle numbered paths. `parseSectionPath`/`parseLessonPath` are kept — they still tolerate a numbered name typed in at Section/Lesson creation, stripping it down to a title.
+- A previously-numbered title cleaned up by hand (or by a future migration) now stays clean permanently: no code path can regenerate a numbered title, because no code path ever computes one.
+- Two same-titled sibling Sections (or sibling Lessons in one Section) now get `slug`/`slug-2` instead of silently colliding on disk; before this change the rank number made that collision impossible by accident. This is new, deliberate behaviour, not a gap.

--- a/packages/core/services/course-write-move-ops.ts
+++ b/packages/core/services/course-write-move-ops.ts
@@ -5,32 +5,20 @@ import {
   planLessonsMove,
   type LessonMovePlan,
 } from "./lesson-move-planner.js";
-import { projectVersionPaths } from "./path-projection.js";
-import { toSlug } from "./lesson-path-service.js";
 
 type DbSection = {
   id: string;
-  title: string;
-  order: number;
   lessons: {
     id: string;
-    title: string;
     order: number;
   }[];
 };
 
-const toPlannerSections = (dbSections: DbSection[]) => {
-  const derived = projectVersionPaths(dbSections);
-  return dbSections.map((s) => ({
+const toPlannerSections = (dbSections: DbSection[]) =>
+  dbSections.map((s) => ({
     id: s.id,
-    path: derived.get(s.id) ?? s.title,
-    lessons: s.lessons.map((l) => ({
-      id: l.id,
-      path: derived.get(l.id) ?? (toSlug(l.title) || "untitled"),
-      order: l.order,
-    })),
+    lessons: s.lessons.map((l) => ({ id: l.id, order: l.order })),
   }));
-};
 
 export function createMoveOps(db: LessonSectionOperationsService) {
   const executeMovePlan = Effect.fn("executeMovePlan")(function* (
@@ -48,9 +36,6 @@ export function createMoveOps(db: LessonSectionOperationsService) {
     yield* db.batchUpdateLessonOrders(
       plan.lessonUpdates.map((u) => ({ id: u.id, order: u.order }))
     );
-    for (const u of plan.sectionUpdates) {
-      yield* db.updateSectionTitle(u.id, u.path);
-    }
 
     return { success: true } as const;
   });

--- a/packages/core/services/lesson-move-planner.test.ts
+++ b/packages/core/services/lesson-move-planner.test.ts
@@ -2,29 +2,22 @@ import { describe, expect, it } from "vitest";
 import {
   planLessonMove,
   planLessonsMove,
-  type FsOp,
   type PlannerSection,
 } from "./lesson-move-planner.js";
 
 /** Compact builder for a lesson. */
-const real = (id: string, path: string, order: number) => ({
-  id,
-  path,
-  order,
-});
+const lesson = (id: string, order: number) => ({ id, order });
 
 /** Maps lessonUpdates to a {id: {sectionId, order}} lookup. */
 const byId = (updates: { id: string; sectionId: string; order: number }[]) =>
   Object.fromEntries(updates.map((u) => [u.id, u]));
 
-const fsKinds = (ops: FsOp[]) => ops.map((o) => o.kind);
-
 describe("planLessonMove", () => {
   describe("guards", () => {
     it("is a no-op when the lesson does not exist", () => {
       const sections: PlannerSection[] = [
-        { id: "s1", path: "01-intro", lessons: [real("a", "01.01-a", 0)] },
-        { id: "s2", path: "02-next", lessons: [] },
+        { id: "s1", lessons: [lesson("a", 0)] },
+        { id: "s2", lessons: [] },
       ];
       const plan = planLessonMove({
         sections,
@@ -37,7 +30,7 @@ describe("planLessonMove", () => {
 
     it("is a no-op when source and target are the same section", () => {
       const sections: PlannerSection[] = [
-        { id: "s1", path: "01-intro", lessons: [real("a", "01.01-a", 0)] },
+        { id: "s1", lessons: [lesson("a", 0)] },
       ];
       const plan = planLessonMove({
         sections,
@@ -49,22 +42,20 @@ describe("planLessonMove", () => {
     });
   });
 
-  describe("real lesson, append (beforeLessonId = null)", () => {
-    it("moves the lesson, renumbers the source to close the gap", () => {
+  describe("append (beforeLessonId = null)", () => {
+    it("moves only the dragged lesson; siblings are untouched", () => {
       const sections: PlannerSection[] = [
         {
           id: "s1",
-          path: "01-intro",
           lessons: [
-            real("first", "01.01-first", 0),
-            real("second", "01.02-second", 1),
-            real("third", "01.03-third", 2),
+            lesson("first", 0),
+            lesson("second", 1),
+            lesson("third", 2),
           ],
         },
         {
           id: "s2",
-          path: "02-advanced",
-          lessons: [real("existing", "02.01-existing", 0)],
+          lessons: [lesson("existing", 0)],
         },
       ];
 
@@ -81,52 +72,25 @@ describe("planLessonMove", () => {
         sectionId: "s2",
         order: 1,
       });
-      // Source gap closed on disk, but third's order/sectionId are unchanged
-      // so it doesn't appear in the DB diff.
-      expect(updates.third).toBeUndefined();
-      // First untouched (no update emitted)
-      expect(updates.first).toBeUndefined();
-      // Existing target lesson untouched (append, nothing shifts)
-      expect(updates.existing).toBeUndefined();
-
-      expect(plan.sectionUpdates).toEqual([]);
-      expect(fsKinds(plan.fsOps)).toEqual(["moveLesson", "renameLessons"]);
-      const move = plan.fsOps[0];
-      expect(move).toMatchObject({
-        kind: "moveLesson",
-        sourceSectionPath: "01-intro",
-        targetSectionPath: "02-advanced",
-        oldLessonDirName: "01.02-second",
-        newLessonDirName: "02.02-second",
-      });
+      // Nothing else is ever touched by a move: order is fractional, and
+      // path is derived from title alone, so no sibling needs an update.
+      expect(plan.lessonUpdates).toHaveLength(1);
     });
   });
 
-  describe("real lesson, positional insert (beforeLessonId set)", () => {
-    it("inserts before an anchor and shifts target lessons up", () => {
+  describe("positional insert (beforeLessonId set)", () => {
+    it("inserts before an anchor with a fractional order, touching nothing else", () => {
       const sections: PlannerSection[] = [
         {
           id: "s1",
-          path: "01-intro",
-          // Two lessons so the source stays real (isolates positional insert
-          // from the dematerialize/renumber cascade).
-          lessons: [
-            real("moving", "01.01-moving", 0),
-            real("stay", "01.02-stay", 1),
-          ],
+          lessons: [lesson("moving", 0), lesson("stay", 1)],
         },
         {
           id: "s2",
-          path: "02-target",
-          lessons: [
-            real("t1", "02.01-t1", 0),
-            real("t2", "02.02-t2", 1),
-            real("t3", "02.03-t3", 2),
-          ],
+          lessons: [lesson("t1", 0), lesson("t2", 1), lesson("t3", 2)],
         },
       ];
 
-      // Drop before t2 → moving becomes 02.02, t2/t3 shift up.
       const plan = planLessonMove({
         sections,
         lessonId: "moving",
@@ -139,29 +103,18 @@ describe("planLessonMove", () => {
       // order strictly between t1 (0) and t2 (1)
       expect(updates.moving!.order).toBeGreaterThan(0);
       expect(updates.moving!.order).toBeLessThan(1);
-      expect(updates.t1).toBeUndefined();
-
-      // Source emptied → it dematerializes and sections renumber.
-      // Target shift renames must precede the moveLesson so the slot is free.
-      const idxShift = plan.fsOps.findIndex(
-        (o) => o.kind === "renameLessons" && o.sectionPath === "02-target"
-      );
-      const idxMove = plan.fsOps.findIndex((o) => o.kind === "moveLesson");
-      expect(idxShift).toBeGreaterThanOrEqual(0);
-      expect(idxShift).toBeLessThan(idxMove);
+      expect(plan.lessonUpdates).toHaveLength(1);
     });
 
     it("inserting before the first lesson yields an order below it", () => {
       const sections: PlannerSection[] = [
         {
           id: "s1",
-          path: "01-intro",
-          lessons: [real("a", "01.01-a", 0), real("b", "01.02-b", 1)],
+          lessons: [lesson("a", 0), lesson("b", 1)],
         },
         {
           id: "s2",
-          path: "02-target",
-          lessons: [real("t1", "02.01-t1", 5)],
+          lessons: [lesson("t1", 5)],
         },
       ];
       const plan = planLessonMove({
@@ -175,20 +128,15 @@ describe("planLessonMove", () => {
     });
   });
 
-  describe("materialize target / dematerialize source", () => {
-    it("numbers a now-non-empty target, keeps numbering when source stays non-empty", () => {
+  describe("emptying the source / filling the target", () => {
+    it("moving into a section that had no lessons still only touches the moved lesson", () => {
       const sections: PlannerSection[] = [
         {
           id: "s1",
-          path: "01-intro",
-          lessons: [
-            real("first", "01.01-first", 0),
-            real("second", "01.02-second", 1),
-          ],
+          lessons: [lesson("first", 0), lesson("second", 1)],
         },
         {
           id: "s2",
-          path: "Advanced Topics",
           lessons: [],
         },
       ];
@@ -202,29 +150,17 @@ describe("planLessonMove", () => {
 
       const updates = byId(plan.lessonUpdates);
       expect(updates.first!.sectionId).toBe("s2");
-
-      const secUpdates = Object.fromEntries(
-        plan.sectionUpdates.map((s) => [s.id, s.path])
-      );
-      expect(secUpdates.s2).toBe("02-advanced-topics");
-      expect(secUpdates.s1).toBeUndefined();
-
-      expect(plan.fsOps[0]).toMatchObject({
-        kind: "makeSectionDir",
-        sectionPath: "02-advanced-topics",
-      });
+      expect(plan.lessonUpdates).toHaveLength(1);
     });
 
-    it("dematerializes the source when its last real lesson leaves", () => {
+    it("emptying the source by moving its only lesson still only touches that lesson", () => {
       const sections: PlannerSection[] = [
         {
           id: "s1",
-          path: "01-intro",
-          lessons: [real("only", "01.01-only-lesson", 0)],
+          lessons: [lesson("only", 0)],
         },
         {
           id: "s2",
-          path: "02-advanced",
           lessons: [],
         },
       ];
@@ -238,21 +174,7 @@ describe("planLessonMove", () => {
 
       const updates = byId(plan.lessonUpdates);
       expect(updates.only!.sectionId).toBe("s2");
-
-      const secUpdates = Object.fromEntries(
-        plan.sectionUpdates.map((s) => [s.id, s.path])
-      );
-      // Source reverts to an unnumbered title, target becomes 01.
-      expect(secUpdates.s1).toBe("Intro");
-      expect(secUpdates.s2).toBe("01-advanced");
-
-      expect(fsKinds(plan.fsOps)).toEqual([
-        "makeSectionDir",
-        "moveLesson",
-        "deleteSectionDir",
-        "renameSections",
-        "renameLessons",
-      ]);
+      expect(plan.lessonUpdates).toHaveLength(1);
     });
   });
 });
@@ -260,8 +182,8 @@ describe("planLessonMove", () => {
 describe("planLessonsMove", () => {
   it("is a no-op when no lessons are given", () => {
     const sections: PlannerSection[] = [
-      { id: "s1", path: "01-intro", lessons: [real("a", "01.01-a", 0)] },
-      { id: "s2", path: "02-next", lessons: [] },
+      { id: "s1", lessons: [lesson("a", 0)] },
+      { id: "s2", lessons: [] },
     ];
     const plan = planLessonsMove({
       sections,
@@ -276,17 +198,11 @@ describe("planLessonsMove", () => {
     const sections: PlannerSection[] = [
       {
         id: "s1",
-        path: "01-intro",
-        lessons: [
-          real("a", "01.01-a", 0),
-          real("b", "01.02-b", 1),
-          real("c", "01.03-c", 2),
-        ],
+        lessons: [lesson("a", 0), lesson("b", 1), lesson("c", 2)],
       },
       {
         id: "s2",
-        path: "02-advanced",
-        lessons: [real("x", "02.01-x", 0)],
+        lessons: [lesson("x", 0)],
       },
     ];
 
@@ -299,36 +215,23 @@ describe("planLessonsMove", () => {
     });
 
     const updates = byId(plan.lessonUpdates);
-    // Both selected lessons land in the target...
     expect(updates.a!.sectionId).toBe("s2");
     expect(updates.c!.sectionId).toBe("s2");
-    // ...appended after the existing target lesson, in selection order a then c.
     expect(updates.a!.order).toBeLessThan(updates.c!.order);
-    // x is unchanged (order 0, already first), so it isn't in the diff; the
-    // appended block sorts after it.
-    expect(updates.x).toBeUndefined();
     expect(updates.a!.order).toBeGreaterThan(0);
-
-    // The unselected source lesson is renumbered on disk, but its
-    // order/sectionId are unchanged so it doesn't appear in the DB diff.
-    expect(updates.b).toBeUndefined();
+    // Only the moved lessons appear in the diff.
+    expect(plan.lessonUpdates).toHaveLength(2);
   });
 
   it("preserves source display order and lands contiguous before the anchor", () => {
     const sections: PlannerSection[] = [
       {
         id: "s1",
-        path: "01-intro",
-        lessons: [
-          real("a", "01.01-a", 0),
-          real("b", "01.02-b", 1),
-          real("c", "01.03-c", 2),
-        ],
+        lessons: [lesson("a", 0), lesson("b", 1), lesson("c", 2)],
       },
       {
         id: "s2",
-        path: "02-advanced",
-        lessons: [real("x", "02.01-x", 0), real("y", "02.02-y", 1)],
+        lessons: [lesson("x", 0), lesson("y", 1)],
       },
     ];
 
@@ -345,50 +248,14 @@ describe("planLessonsMove", () => {
     expect(order("x")).toBeLessThan(order("a"));
     expect(order("a")).toBeLessThan(order("b"));
     expect(order("b")).toBeLessThan(order("c"));
-    // The anchor y ends up after the whole block.
     const yOrder = updates.y ? updates.y.order : 1;
     expect(order("c")).toBeLessThan(yOrder);
   });
 
-  it("dematerializes the source section when the move empties it", () => {
-    const sections: PlannerSection[] = [
-      {
-        id: "s1",
-        path: "01-intro",
-        lessons: [real("a", "01.01-a", 0), real("b", "01.02-b", 1)],
-      },
-      {
-        id: "s2",
-        path: "02-advanced",
-        lessons: [real("x", "02.01-x", 0)],
-      },
-    ];
-
-    // Move both source lessons out → source has no real lessons left.
-    const plan = planLessonsMove({
-      sections,
-      lessonIds: ["a", "b"],
-      targetSectionId: "s2",
-      beforeLessonId: null,
-    });
-
-    const secUpdates = Object.fromEntries(
-      plan.sectionUpdates.map((s) => [s.id, s.path])
-    );
-    // Source reverts to an unnumbered title; target renumbers 02 → 01.
-    expect(secUpdates.s1).toBe("Intro");
-    expect(secUpdates.s2).toBe("01-advanced");
-    expect(plan.fsOps.some((o) => o.kind === "deleteSectionDir")).toBe(true);
-  });
-
   it("matches a single planLessonMove when the selection is one lesson", () => {
     const sections: PlannerSection[] = [
-      {
-        id: "s1",
-        path: "01-intro",
-        lessons: [real("a", "01.01-a", 0), real("b", "01.02-b", 1)],
-      },
-      { id: "s2", path: "02-next", lessons: [real("x", "02.01-x", 0)] },
+      { id: "s1", lessons: [lesson("a", 0), lesson("b", 1)] },
+      { id: "s2", lessons: [lesson("x", 0)] },
     ];
     const single = planLessonMove({
       sections,

--- a/packages/core/services/lesson-move-planner.ts
+++ b/packages/core/services/lesson-move-planner.ts
@@ -1,63 +1,35 @@
 /**
  * Pure planner for moving a Lesson between Sections.
  *
- * Moving a lesson is not an FK update — it renames the lesson's folder on
- * disk, renumbers the source section's remaining lessons to close the gap,
- * numbers a newly-non-empty target section, un-numbers a source section emptied
- * by the move, and renumbers every section's path prefix. The on-disk number
- * (`NN.MM-slug`) is positional and counts real lessons only, while the `order`
- * field orders all lessons together.
+ * Since ADR 0018, a course has no filesystem presence and a section/lesson's
+ * display path is derived fresh from its title on every read (see
+ * `path-projection.ts`) — never stored, never renamed. Moving a lesson
+ * between sections is therefore nothing but an `order`/`sectionId`
+ * reassignment for the moved lesson(s): no other lesson's `order` changes
+ * (insertion uses a fractional `order` between neighbours, so nothing needs
+ * to shift), and no section's title or path is ever touched by a move.
  *
- * This module computes that entire cascade as pure data. The server (in
- * `course-write-service.ts`) runs the planner, executes `fsOps` against the
- * git repo, and applies `lessonUpdates`/`sectionUpdates` to the database. The
- * client optimistic applier runs the SAME planner and applies the updates to
- * loader data, ignoring `fsOps`. One numbering algorithm, two consumers, no
- * drift. See docs/adr/0011-shared-lesson-move-planner.md.
- *
- * The `fsOps` are emitted in the same staged order the server has always used
- * (materialize → shift target → move lesson → renumber source → dematerialize
- * → renumber sections), so executing a plan reproduces the proven behaviour.
+ * This module computes that reassignment as pure data. The server (in
+ * `course-write-move-ops.ts`) runs the planner and applies `lessonUpdates`
+ * to the database; the client optimistic applier runs the SAME planner and
+ * applies the same updates to loader data. One algorithm, two consumers, no
+ * drift. See docs/adr/0011-shared-lesson-move-planner.md and
+ * docs/adr/0028-drop-numbered-path-prefix.md.
  */
-
-import {
-  buildLessonPath,
-  computeInsertionPlan,
-  parseLessonPath,
-} from "./lesson-path-service.js";
-import {
-  buildSectionPath,
-  parseSectionPath,
-  sectionHasLessons,
-  sectionSlugFromPath,
-} from "./section-path-service.js";
-
-/**
- * Title-cases a slug for the in-model path of a section that dematerialized
- * mid-move ("advanced-topics" → "Advanced Topics"). Local to this pure planner;
- * the shared lossy slug→title helper is deleted from the authoring model.
- */
-const titleCaseFromSlug = (slug: string): string =>
-  slug
-    .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
 
 export type PlannerLesson = {
   id: string;
-  path: string;
   order: number;
 };
 
 export type PlannerSection = {
   id: string;
-  path: string;
   /** Lessons in display order (ascending `order`). */
   lessons: PlannerLesson[];
 };
 
 export type LessonMoveInput = {
-  /** All sections of the version, in section order. */
+  /** All sections of the version. */
   sections: PlannerSection[];
   lessonId: string;
   targetSectionId: string;
@@ -74,43 +46,14 @@ export type LessonUpdate = {
   order: number;
 };
 
-export type SectionUpdate = {
-  id: string;
-  path: string;
-};
-
-export type FsOp =
-  | { kind: "makeSectionDir"; sectionPath: string }
-  | { kind: "deleteSectionDir"; sectionPath: string }
-  | {
-      kind: "moveLesson";
-      sourceSectionPath: string;
-      targetSectionPath: string;
-      oldLessonDirName: string;
-      newLessonDirName: string;
-    }
-  | {
-      kind: "renameLessons";
-      sectionPath: string;
-      renames: { oldPath: string; newPath: string }[];
-    }
-  | {
-      kind: "renameSections";
-      renames: { oldPath: string; newPath: string }[];
-    };
-
 export type LessonMovePlan = {
   lessonUpdates: LessonUpdate[];
-  sectionUpdates: SectionUpdate[];
-  fsOps: FsOp[];
   /** True when the move is a no-op (lesson/target missing, or same section). */
   noop: boolean;
 };
 
 const NOOP: LessonMovePlan = {
   lessonUpdates: [],
-  sectionUpdates: [],
-  fsOps: [],
   noop: true,
 };
 
@@ -129,36 +72,16 @@ function computeInsertOrder(
   return (predOrder + anchor.order) / 2;
 }
 
-/** Index among the target's real lessons at which to insert the moved lesson. */
-function computeInsertRealIndex(
-  targetRealLessons: PlannerLesson[],
-  targetLessons: PlannerLesson[],
-  beforeLessonId: string | null
-): number {
-  if (beforeLessonId === null) return targetRealLessons.length;
-  const anchor = targetLessons.find((l) => l.id === beforeLessonId);
-  if (!anchor) return targetRealLessons.length;
-  return targetRealLessons.filter((l) => l.order < anchor.order).length;
-}
-
 export function planLessonMove(input: LessonMoveInput): LessonMovePlan {
   const { sections, lessonId, targetSectionId, beforeLessonId } = input;
 
-  // Deep clone into a working model we can mutate as we apply the cascade.
-  const model = sections.map((s) => ({
-    id: s.id,
-    path: s.path,
-    lessons: s.lessons.map((l) => ({ ...l })),
-  }));
-
-  const sourceSection = model.find((s) =>
+  const sourceSection = sections.find((s) =>
     s.lessons.some((l) => l.id === lessonId)
   );
-  const targetSection = model.find((s) => s.id === targetSectionId);
+  const targetSection = sections.find((s) => s.id === targetSectionId);
   if (!sourceSection || !targetSection) return NOOP;
   if (sourceSection.id === targetSectionId) return NOOP;
 
-  const lesson = sourceSection.lessons.find((l) => l.id === lessonId)!;
   const targetLessons = targetSection.lessons;
   const maxOrder =
     targetLessons.length > 0
@@ -166,139 +89,16 @@ export function planLessonMove(input: LessonMoveInput): LessonMovePlan {
       : 0;
   const newOrder = computeInsertOrder(targetLessons, beforeLessonId, maxOrder);
 
-  const fsOps: FsOp[] = [];
-  // Sections that currently have a directory on disk (real sections do).
-  const hasDir = new Set(
-    model.filter((s) => sectionHasLessons(s.lessons)).map((s) => s.id)
-  );
-
-  const sourceOldPath = sourceSection.path;
-  const sourceParsed = parseSectionPath(sourceOldPath);
-  const sourceSectionNumber = sourceParsed?.sectionNumber ?? 1;
-
-  // Number a now-non-empty target section: assign a provisional number from its
-  // position among real sections, create its directory. renumberSections below
-  // corrects the number once source realness is recomputed.
-  const targetWasEmpty = !sectionHasLessons(targetLessons);
-  let targetSectionNumbered = false;
-  if (targetWasEmpty) {
-    const posIdx = model.findIndex((s) => s.id === targetSectionId);
-    let realBefore = 0;
-    for (let i = 0; i < posIdx; i++) {
-      if (sectionHasLessons(model[i]!.lessons)) realBefore++;
-    }
-    const sectionNumber = realBefore + 1;
-    targetSection.path = buildSectionPath(
-      sectionNumber,
-      sectionSlugFromPath(targetSection.path)
-    );
-    fsOps.push({ kind: "makeSectionDir", sectionPath: targetSection.path });
-    hasDir.add(targetSection.id);
-    targetSectionNumbered = true;
-  }
-  const targetSectionNumber =
-    parseSectionPath(targetSection.path)?.sectionNumber ?? 1;
-
-  const lessonParsed = parseLessonPath(lesson.path);
-  const slug = lessonParsed?.slug ?? lesson.path;
-
-  const targetSortedLessons = [...targetLessons].sort(
-    (a, b) => a.order - b.order
-  );
-  const insertAtIndex = computeInsertRealIndex(
-    targetSortedLessons,
-    targetLessons,
-    beforeLessonId
-  );
-  const insertion = computeInsertionPlan({
-    existingRealLessons: targetSortedLessons.map((l) => ({
-      id: l.id,
-      path: l.path,
-    })),
-    insertAtIndex,
-    sectionNumber: targetSectionNumber,
-    slug,
-  });
-
-  // Free the slot first (rename highest-numbered shifted lesson first so a
-  // git mv never lands on a path still occupied), then move the lesson in.
-  if (insertion.renames.length > 0) {
-    const ordered = [...insertion.renames].reverse();
-    fsOps.push({
-      kind: "renameLessons",
-      sectionPath: targetSection.path,
-      renames: ordered.map((r) => ({ oldPath: r.oldPath, newPath: r.newPath })),
-    });
-    for (const r of insertion.renames) {
-      const l = targetSection.lessons.find((x) => x.id === r.id);
-      if (l) l.path = r.newPath;
-    }
-  }
-
-  fsOps.push({
-    kind: "moveLesson",
-    sourceSectionPath: sourceOldPath,
-    targetSectionPath: targetSection.path,
-    oldLessonDirName: lesson.path,
-    newLessonDirName: insertion.newLessonDirName,
-  });
-
-  // Move the lesson in the model: out of source, into target.
-  sourceSection.lessons = sourceSection.lessons.filter(
-    (l) => l.id !== lessonId
-  );
-  lesson.path = insertion.newLessonDirName;
-  lesson.order = newOrder;
-  targetSection.lessons.push(lesson);
-
-  const sourceRealLessons = [...sourceSection.lessons].sort(
-    (a, b) => a.order - b.order
-  );
-  if (sourceRealLessons.length > 0) {
-    const sourceRenames: { oldPath: string; newPath: string }[] = [];
-    for (let i = 0; i < sourceRealLessons.length; i++) {
-      const l = sourceRealLessons[i]!;
-      const p = parseLessonPath(l.path);
-      if (!p) continue;
-      const np = buildLessonPath(sourceSectionNumber, i + 1, p.slug);
-      if (np !== l.path) {
-        sourceRenames.push({ oldPath: l.path, newPath: np });
-        l.path = np;
-      }
-    }
-    if (sourceRenames.length > 0) {
-      fsOps.push({
-        kind: "renameLessons",
-        sectionPath: sourceOldPath,
-        renames: sourceRenames,
-      });
-    }
-  }
-
-  // If no lessons remain in source, delete its dir and revert to unnumbered.
-  let sourceSectionUnnumbered = false;
-  if (sourceRealLessons.length === 0 && sourceParsed) {
-    fsOps.push({ kind: "deleteSectionDir", sectionPath: sourceOldPath });
-    sourceSection.path = titleCaseFromSlug(sourceParsed.slug);
-    hasDir.delete(sourceSection.id);
-    sourceSectionUnnumbered = true;
-  }
-
-  // Renumber all sections (and their lessons' prefixes) if realness changed.
-  if (targetSectionNumbered || sourceSectionUnnumbered) {
-    renumberSectionsInModel(model, hasDir, fsOps);
-  }
-
   return {
-    lessonUpdates: diffLessons(sections, model),
-    sectionUpdates: diffSections(sections, model),
-    fsOps,
+    lessonUpdates: [
+      { id: lessonId, sectionId: targetSectionId, order: newOrder },
+    ],
     noop: false,
   };
 }
 
 export type LessonsMoveInput = {
-  /** All sections of the version, in section order. */
+  /** All sections of the version. */
   sections: PlannerSection[];
   /**
    * Lessons to move, in the order they should land in the target. The caller
@@ -314,18 +114,16 @@ export type LessonsMoveInput = {
 /**
  * Plan a bulk cross-section move by folding {@link planLessonMove} over the
  * selected lessons one at a time, threading the post-move model into the next
- * step. Each single move reuses the proven placement / renumbering /
- * materialize / dematerialize cascade; anchoring every lesson at the same
- * `beforeLessonId` and iterating in target order leaves them contiguous and in
- * order just before the anchor. fsOps from each step concatenate into one
- * sequentially-valid script. See
- * docs/adr/0012-bulk-lesson-reorder-within-section.md.
+ * step. Anchoring every lesson at the same `beforeLessonId` and iterating in
+ * target order leaves them contiguous and in order just before the anchor.
+ * See docs/adr/0012-bulk-lesson-reorder-within-section.md and
+ * docs/adr/0013-cross-section-bulk-lesson-move.md.
  */
 export function planLessonsMove(input: LessonsMoveInput): LessonMovePlan {
   const { lessonIds, targetSectionId, beforeLessonId } = input;
 
   let model: PlannerSection[] = input.sections;
-  const fsOps: FsOp[] = [];
+  const lessonUpdates: LessonUpdate[] = [];
   let moved = false;
 
   for (const lessonId of lessonIds) {
@@ -337,18 +135,13 @@ export function planLessonsMove(input: LessonsMoveInput): LessonMovePlan {
     });
     if (step.noop) continue;
     moved = true;
-    fsOps.push(...step.fsOps);
+    lessonUpdates.push(...step.lessonUpdates);
     model = applyPlanToModel(model, step);
   }
 
   if (!moved) return NOOP;
 
-  return {
-    lessonUpdates: diffLessons(input.sections, model),
-    sectionUpdates: diffSections(input.sections, model),
-    fsOps,
-    noop: false,
-  };
+  return { lessonUpdates, noop: false };
 }
 
 /**
@@ -360,9 +153,6 @@ function applyPlanToModel(
   plan: LessonMovePlan
 ): PlannerSection[] {
   const lessonUpdateById = new Map(plan.lessonUpdates.map((u) => [u.id, u]));
-  const sectionPathById = new Map(
-    plan.sectionUpdates.map((u) => [u.id, u.path])
-  );
 
   const placed: { lesson: PlannerLesson; sectionId: string }[] = [];
   for (const s of sections) {
@@ -380,134 +170,9 @@ function applyPlanToModel(
 
   return sections.map((s) => ({
     id: s.id,
-    path: sectionPathById.get(s.id) ?? s.path,
     lessons: placed
       .filter((p) => p.sectionId === s.id)
       .map((p) => p.lesson)
       .sort((a, b) => a.order - b.order),
   }));
-}
-
-type WorkingSection = {
-  id: string;
-  path: string;
-  lessons: PlannerLesson[];
-};
-
-/**
- * Non-empty sections get sequential numbers, empty ones are skipped, and each
- * renumbered section's real lessons keep their own lessonNumber under the
- * new prefix.
- */
-function renumberSectionsInModel(
-  model: WorkingSection[],
-  hasDir: Set<string>,
-  fsOps: FsOp[]
-): void {
-  const sectionRenames: Array<{
-    id: string;
-    oldPath: string;
-    newPath: string;
-    newSectionNumber: number;
-  }> = [];
-
-  let realNumber = 0;
-  for (const section of model) {
-    if (!sectionHasLessons(section.lessons)) continue;
-    realNumber++;
-    const newPath = buildSectionPath(
-      realNumber,
-      sectionSlugFromPath(section.path)
-    );
-    if (newPath !== section.path) {
-      sectionRenames.push({
-        id: section.id,
-        oldPath: section.path,
-        newPath,
-        newSectionNumber: realNumber,
-      });
-    }
-  }
-
-  if (sectionRenames.length === 0) return;
-
-  const fsRenames = sectionRenames.filter((r) => hasDir.has(r.id));
-  if (fsRenames.length > 0) {
-    fsOps.push({
-      kind: "renameSections",
-      renames: fsRenames.map((r) => ({
-        oldPath: r.oldPath,
-        newPath: r.newPath,
-      })),
-    });
-  }
-
-  for (const rename of sectionRenames) {
-    const section = model.find((s) => s.id === rename.id)!;
-    section.path = rename.newPath;
-
-    const realLessons = section.lessons;
-    const lessonRenames: { oldPath: string; newPath: string }[] = [];
-    for (const l of realLessons) {
-      const p = parseLessonPath(l.path);
-      if (!p) continue;
-      const np = buildLessonPath(
-        rename.newSectionNumber,
-        p.lessonNumber,
-        p.slug
-      );
-      if (np !== l.path) {
-        lessonRenames.push({ oldPath: l.path, newPath: np });
-        l.path = np;
-      }
-    }
-    if (lessonRenames.length > 0) {
-      fsOps.push({
-        kind: "renameLessons",
-        sectionPath: rename.newPath,
-        renames: lessonRenames,
-      });
-    }
-  }
-}
-
-function diffLessons(
-  before: PlannerSection[],
-  after: WorkingSection[]
-): LessonUpdate[] {
-  const beforeById = new Map<string, { sectionId: string; order: number }>();
-  for (const s of before) {
-    for (const l of s.lessons) {
-      beforeById.set(l.id, { sectionId: s.id, order: l.order });
-    }
-  }
-
-  const updates: LessonUpdate[] = [];
-  for (const s of after) {
-    for (const l of s.lessons) {
-      const prev = beforeById.get(l.id);
-      if (!prev || prev.sectionId !== s.id || prev.order !== l.order) {
-        updates.push({
-          id: l.id,
-          sectionId: s.id,
-          order: l.order,
-        });
-      }
-    }
-  }
-  return updates;
-}
-
-function diffSections(
-  before: PlannerSection[],
-  after: WorkingSection[]
-): SectionUpdate[] {
-  const beforeById = new Map(before.map((s) => [s.id, s.path]));
-  const updates: SectionUpdate[] = [];
-  for (const s of after) {
-    if (beforeById.get(s.id) !== s.path) {
-      updates.push({ id: s.id, path: s.path });
-    }
-  }
-  return updates;
 }

--- a/packages/core/services/lesson-path-service.test.ts
+++ b/packages/core/services/lesson-path-service.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   toSlug,
-  buildLessonPath,
   deriveLessonPath,
   parseLessonPath,
-  computeRenumberingPlan,
-  computeInsertionPlan,
 } from "./lesson-path-service.js";
 
 describe("toSlug", () => {
@@ -50,41 +47,17 @@ describe("toSlug", () => {
   });
 });
 
-describe("buildLessonPath", () => {
-  it("produces XX.YY-slug format", () => {
-    expect(buildLessonPath(1, 3, "my-lesson")).toBe("01.03-my-lesson");
-  });
-
-  it("zero-pads single-digit numbers", () => {
-    expect(buildLessonPath(2, 5, "intro")).toBe("02.05-intro");
-  });
-
-  it("handles double-digit numbers", () => {
-    expect(buildLessonPath(12, 15, "advanced-topic")).toBe(
-      "12.15-advanced-topic"
-    );
-  });
-
-  it("handles section 1 lesson 1", () => {
-    expect(buildLessonPath(1, 1, "getting-started")).toBe(
-      "01.01-getting-started"
-    );
-  });
-});
-
 describe("deriveLessonPath", () => {
-  it("derives path from title and numbers", () => {
-    expect(deriveLessonPath("Getting Started", 1, 3)).toBe(
-      "01.03-getting-started"
-    );
+  it("derives path from title alone, no ordering number", () => {
+    expect(deriveLessonPath("Getting Started")).toBe("getting-started");
   });
 
   it("falls back to 'untitled' for empty title", () => {
-    expect(deriveLessonPath("", 1, 1)).toBe("01.01-untitled");
+    expect(deriveLessonPath("")).toBe("untitled");
   });
 
   it("falls back to 'untitled' for symbols-only title", () => {
-    expect(deriveLessonPath("!@#", 2, 5)).toBe("02.05-untitled");
+    expect(deriveLessonPath("!@#")).toBe("untitled");
   });
 });
 
@@ -153,242 +126,5 @@ describe("parseLessonPath", () => {
     it("returns null for number-only path (no slug)", () => {
       expect(parseLessonPath("003")).toBeNull();
     });
-  });
-
-  describe("roundtrip", () => {
-    it("buildLessonPath output is parseable by parseLessonPath", () => {
-      const built = buildLessonPath(3, 7, "my-lesson");
-      const parsed = parseLessonPath(built);
-      expect(parsed).toEqual({
-        sectionNumber: 3,
-        lessonNumber: 7,
-        slug: "my-lesson",
-      });
-    });
-  });
-});
-
-describe("computeRenumberingPlan", () => {
-  const makeLessons = (slugs: string[], sectionNumber = 1) =>
-    slugs.map((slug, i) => ({
-      id: `lesson-${i + 1}`,
-      path: buildLessonPath(sectionNumber, i + 1, slug),
-    }));
-
-  it("returns empty array for empty lessons", () => {
-    expect(computeRenumberingPlan([], [])).toEqual([]);
-  });
-
-  it("returns empty array for empty newOrderIds", () => {
-    const lessons = makeLessons(["alpha", "beta"]);
-    expect(computeRenumberingPlan(lessons, [])).toEqual([]);
-  });
-
-  it("returns empty array when order is unchanged (no-op)", () => {
-    const lessons = makeLessons(["alpha", "beta", "gamma"]);
-    expect(
-      computeRenumberingPlan(lessons, ["lesson-1", "lesson-2", "lesson-3"])
-    ).toEqual([]);
-  });
-
-  it("moves last lesson to first position", () => {
-    const lessons = makeLessons(["alpha", "beta", "gamma"]);
-    // New order: gamma, alpha, beta
-    const plan = computeRenumberingPlan(lessons, [
-      "lesson-3",
-      "lesson-1",
-      "lesson-2",
-    ]);
-
-    expect(plan).toEqual([
-      { id: "lesson-3", oldPath: "01.03-gamma", newPath: "01.01-gamma" },
-      { id: "lesson-1", oldPath: "01.01-alpha", newPath: "01.02-alpha" },
-      { id: "lesson-2", oldPath: "01.02-beta", newPath: "01.03-beta" },
-    ]);
-  });
-
-  it("moves first lesson to last position", () => {
-    const lessons = makeLessons(["alpha", "beta", "gamma"]);
-    // New order: beta, gamma, alpha
-    const plan = computeRenumberingPlan(lessons, [
-      "lesson-2",
-      "lesson-3",
-      "lesson-1",
-    ]);
-
-    expect(plan).toEqual([
-      { id: "lesson-2", oldPath: "01.02-beta", newPath: "01.01-beta" },
-      { id: "lesson-3", oldPath: "01.03-gamma", newPath: "01.02-gamma" },
-      { id: "lesson-1", oldPath: "01.01-alpha", newPath: "01.03-alpha" },
-    ]);
-  });
-
-  it("moves a middle lesson down one position", () => {
-    const lessons = makeLessons(["alpha", "beta", "gamma", "delta"]);
-    // New order: alpha, gamma, beta, delta
-    const plan = computeRenumberingPlan(lessons, [
-      "lesson-1",
-      "lesson-3",
-      "lesson-2",
-      "lesson-4",
-    ]);
-
-    // alpha stays 01.01 (no change), gamma: 01.03→01.02, beta: 01.02→01.03, delta stays 01.04
-    expect(plan).toEqual([
-      { id: "lesson-3", oldPath: "01.03-gamma", newPath: "01.02-gamma" },
-      { id: "lesson-2", oldPath: "01.02-beta", newPath: "01.03-beta" },
-    ]);
-  });
-
-  it("handles single lesson with same order (no-op)", () => {
-    const lessons = makeLessons(["only-lesson"]);
-    expect(computeRenumberingPlan(lessons, ["lesson-1"])).toEqual([]);
-  });
-
-  it("preserves section number from existing paths", () => {
-    const lessons = [
-      { id: "a", path: "03.01-intro" },
-      { id: "b", path: "03.02-basics" },
-      { id: "c", path: "03.03-advanced" },
-    ];
-    // New order: advanced, intro, basics
-    const plan = computeRenumberingPlan(lessons, ["c", "a", "b"]);
-
-    expect(plan).toEqual([
-      { id: "c", oldPath: "03.03-advanced", newPath: "03.01-advanced" },
-      { id: "a", oldPath: "03.01-intro", newPath: "03.02-intro" },
-      { id: "b", oldPath: "03.02-basics", newPath: "03.03-basics" },
-    ]);
-  });
-
-  it("only includes lessons whose path actually changes", () => {
-    const lessons = makeLessons(["alpha", "beta", "gamma", "delta", "epsilon"]);
-    // New order: alpha, delta, beta, gamma, epsilon
-    const plan = computeRenumberingPlan(lessons, [
-      "lesson-1",
-      "lesson-4",
-      "lesson-2",
-      "lesson-3",
-      "lesson-5",
-    ]);
-
-    // alpha stays 01.01, epsilon stays 01.05
-    expect(plan).toHaveLength(3);
-    expect(plan.find((r) => r.id === "lesson-1")).toBeUndefined();
-    expect(plan.find((r) => r.id === "lesson-5")).toBeUndefined();
-  });
-
-  it("handles two lessons swapping positions", () => {
-    const lessons = makeLessons(["first", "second"]);
-    // New order: second, first
-    const plan = computeRenumberingPlan(lessons, ["lesson-2", "lesson-1"]);
-
-    expect(plan).toEqual([
-      { id: "lesson-2", oldPath: "01.02-second", newPath: "01.01-second" },
-      { id: "lesson-1", oldPath: "01.01-first", newPath: "01.02-first" },
-    ]);
-  });
-
-  it("ignores unknown IDs in newOrderIds", () => {
-    const lessons = makeLessons(["alpha", "beta"]);
-    const plan = computeRenumberingPlan(lessons, [
-      "lesson-2",
-      "unknown-id",
-      "lesson-1",
-    ]);
-
-    // unknown-id is skipped; lesson-2 becomes position 1, lesson-1 becomes position 3
-    expect(plan).toEqual([
-      { id: "lesson-2", oldPath: "01.02-beta", newPath: "01.01-beta" },
-      { id: "lesson-1", oldPath: "01.01-alpha", newPath: "01.03-alpha" },
-    ]);
-  });
-});
-
-describe("computeInsertionPlan", () => {
-  const makeLessons = (slugs: string[], sectionNumber = 1) =>
-    slugs.map((slug, i) => ({
-      id: `lesson-${i + 1}`,
-      path: buildLessonPath(sectionNumber, i + 1, slug),
-    }));
-
-  it("inserts between two existing lessons", () => {
-    const existing = makeLessons(["alpha", "beta", "gamma"]);
-    // Insert at position 1 (between alpha and beta)
-    const plan = computeInsertionPlan({
-      existingRealLessons: existing,
-      insertAtIndex: 1,
-      sectionNumber: 1,
-      slug: "new-lesson",
-    });
-
-    expect(plan.newLessonDirName).toBe("01.02-new-lesson");
-    expect(plan.newLessonNumber).toBe(2);
-    expect(plan.renames).toEqual([
-      { id: "lesson-2", oldPath: "01.02-beta", newPath: "01.03-beta" },
-      { id: "lesson-3", oldPath: "01.03-gamma", newPath: "01.04-gamma" },
-    ]);
-  });
-
-  it("appends at the end with no renumbering", () => {
-    const existing = makeLessons(["alpha", "beta"]);
-    const plan = computeInsertionPlan({
-      existingRealLessons: existing,
-      insertAtIndex: 2,
-      sectionNumber: 1,
-      slug: "new-lesson",
-    });
-
-    expect(plan.newLessonDirName).toBe("01.03-new-lesson");
-    expect(plan.newLessonNumber).toBe(3);
-    expect(plan.renames).toEqual([]);
-  });
-
-  it("inserts at the beginning and shifts all lessons", () => {
-    const existing = makeLessons(["alpha", "beta"]);
-    const plan = computeInsertionPlan({
-      existingRealLessons: existing,
-      insertAtIndex: 0,
-      sectionNumber: 1,
-      slug: "new-lesson",
-    });
-
-    expect(plan.newLessonDirName).toBe("01.01-new-lesson");
-    expect(plan.newLessonNumber).toBe(1);
-    expect(plan.renames).toEqual([
-      { id: "lesson-1", oldPath: "01.01-alpha", newPath: "01.02-alpha" },
-      { id: "lesson-2", oldPath: "01.02-beta", newPath: "01.03-beta" },
-    ]);
-  });
-
-  it("inserts into an empty section", () => {
-    const plan = computeInsertionPlan({
-      existingRealLessons: [],
-      insertAtIndex: 0,
-      sectionNumber: 3,
-      slug: "first-lesson",
-    });
-
-    expect(plan.newLessonDirName).toBe("03.01-first-lesson");
-    expect(plan.newLessonNumber).toBe(1);
-    expect(plan.renames).toEqual([]);
-  });
-
-  it("preserves section number from input", () => {
-    const existing = [
-      { id: "a", path: "05.01-intro" },
-      { id: "b", path: "05.02-basics" },
-    ];
-    const plan = computeInsertionPlan({
-      existingRealLessons: existing,
-      insertAtIndex: 1,
-      sectionNumber: 5,
-      slug: "middle",
-    });
-
-    expect(plan.newLessonDirName).toBe("05.02-middle");
-    expect(plan.renames).toEqual([
-      { id: "b", oldPath: "05.02-basics", newPath: "05.03-basics" },
-    ]);
   });
 });

--- a/packages/core/services/lesson-path-service.ts
+++ b/packages/core/services/lesson-path-service.ts
@@ -1,11 +1,17 @@
 /**
  * Pure functions for lesson path naming conventions.
  *
- * New format: XX.YY-slug (e.g., 01.03-my-lesson)
- *   XX = section number, YY = lesson number (both 2-digit zero-padded)
+ * A lesson's display path is its slugified title (e.g. "My Lesson" →
+ * "my-lesson") — no ordering number. Order is carried by the `order` column
+ * and by array position in `course.json`; the path exists purely for
+ * filesystem legibility (the Dropbox bundle's directory layout, ADR 0023),
+ * so it never needs to change when a lesson is reordered or moved between
+ * sections. Collisions between same-titled sibling lessons are disambiguated
+ * at the point paths are projected (`path-projection.ts`), not here.
  *
- * Legacy format: XXX-slug (e.g., 003-my-lesson)
- *   XXX = lesson number only (3-digit zero-padded)
+ * `parseLessonPath` still understands the legacy numbered formats
+ * (`XX.YY-slug` / `XXX-slug`) so old-format input is tolerated when a lesson
+ * is created from a name that still carries a number prefix.
  */
 
 /**
@@ -22,29 +28,8 @@ export const toSlug = (input: string): string => {
     .replace(/^-|-$/g, "");
 };
 
-/**
- * Builds a lesson directory name in XX.YY-slug format.
- */
-export const buildLessonPath = (
-  sectionNumber: number,
-  lessonNumber: number,
-  slug: string
-): string => {
-  const section = String(sectionNumber).padStart(2, "0");
-  const lesson = String(lessonNumber).padStart(2, "0");
-  return `${section}.${lesson}-${slug}`;
-};
-
-export const deriveLessonPath = (
-  title: string,
-  sectionNumber: number,
-  lessonNumber: number
-): string => {
-  return buildLessonPath(
-    sectionNumber,
-    lessonNumber,
-    toSlug(title) || "untitled"
-  );
+export const deriveLessonPath = (title: string): string => {
+  return toSlug(title) || "untitled";
 };
 
 export type ParsedLessonPath = {
@@ -54,105 +39,11 @@ export type ParsedLessonPath = {
 };
 
 /**
- * Parses a lesson directory name.
+ * Parses a legacy numbered lesson directory name.
  *
  * Two-digit format: "01.03-slug-name" → { sectionNumber: 1, lessonNumber: 3, slug: "slug-name" }
  * Three-digit format: "003-slug-name" → { sectionNumber: undefined, lessonNumber: 3, slug: "slug-name" }
  */
-export type LessonForReorder = {
-  id: string;
-  path: string; // directory name like "01.03-my-lesson"
-};
-
-export type RenameEntry = {
-  id: string;
-  oldPath: string;
-  newPath: string;
-};
-
-/**
- * Given the current lessons in a section and the desired new order (as an array of IDs),
- * returns the list of renames needed to keep numbering sequential.
- *
- * @param currentLessons - Lessons with their current paths
- * @param newOrderIds - Lesson IDs in the desired new order
- * @returns Array of renames where the path actually changed
- */
-export const computeRenumberingPlan = (
-  currentLessons: LessonForReorder[],
-  newOrderIds: readonly string[]
-): RenameEntry[] => {
-  if (currentLessons.length === 0 || newOrderIds.length === 0) return [];
-
-  const lessonMap = new Map(currentLessons.map((l) => [l.id, l]));
-
-  // Determine section number from the first parseable lesson
-  let sectionNumber = 1;
-  for (const lesson of currentLessons) {
-    const parsed = parseLessonPath(lesson.path);
-    if (parsed?.sectionNumber != null) {
-      sectionNumber = parsed.sectionNumber;
-      break;
-    }
-  }
-
-  // Compute new paths based on the provided order
-  const renames: RenameEntry[] = [];
-  for (let i = 0; i < newOrderIds.length; i++) {
-    const lesson = lessonMap.get(newOrderIds[i]!);
-    if (!lesson) continue;
-
-    const parsed = parseLessonPath(lesson.path);
-    if (!parsed) continue;
-
-    const newPath = buildLessonPath(sectionNumber, i + 1, parsed.slug);
-    if (newPath !== lesson.path) {
-      renames.push({ id: lesson.id, oldPath: lesson.path, newPath });
-    }
-  }
-
-  return renames;
-};
-
-/**
- * Given the existing real lessons in a section and a desired insert position,
- * returns the new lesson's directory name and any renames needed to shift
- * subsequent lessons.
- */
-export const computeInsertionPlan = (opts: {
-  existingRealLessons: LessonForReorder[];
-  insertAtIndex: number;
-  sectionNumber: number;
-  slug: string;
-}): {
-  newLessonDirName: string;
-  newLessonNumber: number;
-  renames: RenameEntry[];
-} => {
-  const { existingRealLessons, insertAtIndex, sectionNumber, slug } = opts;
-
-  const newLessonNumber = insertAtIndex + 1;
-  const newLessonDirName = buildLessonPath(
-    sectionNumber,
-    newLessonNumber,
-    slug
-  );
-
-  const renames: RenameEntry[] = [];
-  for (let i = insertAtIndex; i < existingRealLessons.length; i++) {
-    const lesson = existingRealLessons[i]!;
-    const parsed = parseLessonPath(lesson.path);
-    if (!parsed) continue;
-
-    const newPath = buildLessonPath(sectionNumber, i + 2, parsed.slug);
-    if (newPath !== lesson.path) {
-      renames.push({ id: lesson.id, oldPath: lesson.path, newPath });
-    }
-  }
-
-  return { newLessonDirName, newLessonNumber, renames };
-};
-
 export const parseLessonPath = (
   lessonPath: string
 ): ParsedLessonPath | null => {

--- a/packages/core/services/path-projection.test.ts
+++ b/packages/core/services/path-projection.test.ts
@@ -84,63 +84,43 @@ describe("rankByOrder", () => {
 });
 
 describe("deriveSectionPath", () => {
-  it("produces NN-slug format from title", () => {
-    expect(deriveSectionPath("Introduction", 1)).toBe("01-introduction");
+  it("produces a plain slug from title, no ordering number", () => {
+    expect(deriveSectionPath("Introduction")).toBe("introduction");
   });
 
   it("handles title with special characters", () => {
-    expect(deriveSectionPath("What's New?", 3)).toBe("03-whats-new");
+    expect(deriveSectionPath("What's New?")).toBe("whats-new");
   });
 
   it("falls back to 'untitled' for empty title", () => {
-    expect(deriveSectionPath("", 2)).toBe("02-untitled");
+    expect(deriveSectionPath("")).toBe("untitled");
   });
 
   it("falls back to 'untitled' for symbols-only title", () => {
-    expect(deriveSectionPath("!@#$", 1)).toBe("01-untitled");
-  });
-
-  it("zero-pads section number", () => {
-    expect(deriveSectionPath("Basics", 5)).toBe("05-basics");
-  });
-
-  it("handles double-digit section number", () => {
-    expect(deriveSectionPath("Advanced", 12)).toBe("12-advanced");
+    expect(deriveSectionPath("!@#$")).toBe("untitled");
   });
 });
 
 describe("deriveLessonPath", () => {
-  it("produces NN.MM-slug format from title", () => {
-    expect(deriveLessonPath("Getting Started", 1, 3)).toBe(
-      "01.03-getting-started"
-    );
+  it("produces a plain slug from title, no ordering number", () => {
+    expect(deriveLessonPath("Getting Started")).toBe("getting-started");
   });
 
   it("handles title with special characters", () => {
-    expect(deriveLessonPath("What's Up, Doc?", 2, 1)).toBe(
-      "02.01-whats-up-doc"
-    );
+    expect(deriveLessonPath("What's Up, Doc?")).toBe("whats-up-doc");
   });
 
   it("falls back to 'untitled' for empty title", () => {
-    expect(deriveLessonPath("", 1, 1)).toBe("01.01-untitled");
+    expect(deriveLessonPath("")).toBe("untitled");
   });
 
   it("falls back to 'untitled' for symbols-only title", () => {
-    expect(deriveLessonPath("!@#", 3, 2)).toBe("03.02-untitled");
-  });
-
-  it("zero-pads both numbers", () => {
-    expect(deriveLessonPath("Intro", 1, 1)).toBe("01.01-intro");
-  });
-
-  it("handles double-digit numbers", () => {
-    expect(deriveLessonPath("Deep Dive", 12, 15)).toBe("12.15-deep-dive");
+    expect(deriveLessonPath("!@#")).toBe("untitled");
   });
 });
 
 describe("projectVersionPaths", () => {
-  it("derives paths for all sections and lessons", () => {
+  it("derives paths for all sections and lessons from title alone", () => {
     const sections = [
       {
         id: "s1",
@@ -161,53 +141,95 @@ describe("projectVersionPaths", () => {
     const paths = projectVersionPaths(sections);
     expect(paths).toEqual(
       new Map([
-        ["s1", "01-introduction"],
-        ["s2", "02-advanced"],
-        ["l1", "01.01-getting-started"],
-        ["l2", "01.02-next-steps"],
-        ["l3", "02.01-deep-dive"],
+        ["s1", "introduction"],
+        ["s2", "advanced"],
+        ["l1", "getting-started"],
+        ["l2", "next-steps"],
+        ["l3", "deep-dive"],
       ])
     );
   });
 
-  it("same-slug siblings derive distinct paths by number alone", () => {
+  it("reordering sections/lessons never changes any path", () => {
+    const sections = [
+      {
+        id: "s1",
+        order: 5,
+        title: "Introduction",
+        lessons: [{ id: "l1", order: 9, title: "Getting Started" }],
+      },
+      {
+        id: "s2",
+        order: 1,
+        title: "Advanced",
+        lessons: [{ id: "l2", order: 2, title: "Deep Dive" }],
+      },
+    ];
+    const paths = projectVersionPaths(sections);
+    expect(paths.get("s1")).toBe("introduction");
+    expect(paths.get("s2")).toBe("advanced");
+    expect(paths.get("l1")).toBe("getting-started");
+    expect(paths.get("l2")).toBe("deep-dive");
+  });
+
+  it("disambiguates same-titled sibling sections with a numeric suffix, in rank order", () => {
+    const sections = [
+      {
+        id: "s2",
+        order: 2,
+        title: "React",
+        lessons: [{ id: "l1", order: 1, title: "A" }],
+      },
+      {
+        id: "s1",
+        order: 1,
+        title: "React",
+        lessons: [{ id: "l2", order: 1, title: "B" }],
+      },
+    ];
+    const paths = projectVersionPaths(sections);
+    // s1 ranks first (order 1), so it keeps the bare slug; s2 gets the suffix.
+    expect(paths.get("s1")).toBe("react");
+    expect(paths.get("s2")).toBe("react-2");
+  });
+
+  it("disambiguates same-titled sibling lessons within a section, in rank order", () => {
     const sections = [
       {
         id: "s1",
         order: 1,
         title: "React",
         lessons: [
-          { id: "l1", order: 1, title: "React" },
-          { id: "l2", order: 2, title: "React" },
+          { id: "l2", order: 2, title: "Hooks" },
+          { id: "l1", order: 1, title: "Hooks" },
+          { id: "l3", order: 3, title: "Hooks" },
         ],
       },
     ];
     const paths = projectVersionPaths(sections);
-    expect(paths.get("l1")).toBe("01.01-react");
-    expect(paths.get("l2")).toBe("01.02-react");
-    expect(paths.get("s1")).toBe("01-react");
+    expect(paths.get("l1")).toBe("hooks");
+    expect(paths.get("l2")).toBe("hooks-2");
+    expect(paths.get("l3")).toBe("hooks-3");
   });
 
-  it("mid-list fractional insert renumbers correctly", () => {
-    // Simulate a fractional insert between items at order 1 and 2
+  it("lesson slug collisions in different sections don't disambiguate each other", () => {
     const sections = [
       {
         id: "s1",
         order: 1,
-        title: "Section",
-        lessons: [
-          { id: "l1", order: 1, title: "Alpha" },
-          { id: "l-new", order: 1.5, title: "Inserted" },
-          { id: "l2", order: 2, title: "Beta" },
-          { id: "l3", order: 3, title: "Gamma" },
-        ],
+        title: "Basics",
+        lessons: [{ id: "l1", order: 1, title: "Recap" }],
+      },
+      {
+        id: "s2",
+        order: 2,
+        title: "Advanced",
+        lessons: [{ id: "l2", order: 1, title: "Recap" }],
       },
     ];
     const paths = projectVersionPaths(sections);
-    expect(paths.get("l1")).toBe("01.01-alpha");
-    expect(paths.get("l-new")).toBe("01.02-inserted");
-    expect(paths.get("l2")).toBe("01.03-beta");
-    expect(paths.get("l3")).toBe("01.04-gamma");
+    expect(paths.get("l1")).toBe("recap");
+    expect(paths.get("l2")).toBe("recap");
   });
 
   it("returns empty map for empty sections", () => {
@@ -240,8 +262,8 @@ describe("attachDerivedPaths", () => {
       },
     ];
     const result = attachDerivedPaths(sections);
-    expect(result[0]!.path).toBe("01-intro");
-    expect(result[0]!.lessons[0]!.path).toBe("01.01-hello");
+    expect(result[0]!.path).toBe("intro");
+    expect(result[0]!.lessons[0]!.path).toBe("hello");
   });
 
   it("preserves all original fields", () => {
@@ -266,7 +288,7 @@ describe("attachDerivedPaths", () => {
     expect((result[0]!.lessons[0] as any).anotherField).toBe(42);
   });
 
-  it("uses section number from section rank in lesson paths", () => {
+  it("does not couple lesson paths to section rank", () => {
     const sections = [
       {
         id: "s1",
@@ -282,9 +304,9 @@ describe("attachDerivedPaths", () => {
       },
     ];
     const result = attachDerivedPaths(sections);
-    expect(result[0]!.path).toBe("01-first-section");
-    expect(result[0]!.lessons[0]!.path).toBe("01.01-a");
-    expect(result[1]!.path).toBe("02-second-section");
-    expect(result[1]!.lessons[0]!.path).toBe("02.01-b");
+    expect(result[0]!.path).toBe("first-section");
+    expect(result[0]!.lessons[0]!.path).toBe("a");
+    expect(result[1]!.path).toBe("second-section");
+    expect(result[1]!.lessons[0]!.path).toBe("b");
   });
 });

--- a/packages/core/services/path-projection.ts
+++ b/packages/core/services/path-projection.ts
@@ -37,6 +37,22 @@ type ProjectableLesson = {
   title: string;
 };
 
+/**
+ * First occurrence of a slug keeps it bare; each repeat gets a `-2`, `-3`, …
+ * suffix, in the order `slugs` is iterated. Titles aren't required to be
+ * unique among siblings (ADR 0018 only enforces `order`), but paths are
+ * used as real directory names in the Dropbox bundle (ADR 0023), so two
+ * same-titled siblings must not collide there.
+ */
+const dedupeSlugs = (slugs: readonly string[]): string[] => {
+  const counts = new Map<string, number>();
+  return slugs.map((slug) => {
+    const n = (counts.get(slug) ?? 0) + 1;
+    counts.set(slug, n);
+    return n === 1 ? slug : `${slug}-${n}`;
+  });
+};
+
 export const projectVersionPaths = (
   sections: readonly ProjectableSection[]
 ): Map<string, DerivedPath> => {
@@ -46,21 +62,28 @@ export const projectVersionPaths = (
     sectionHasLessons(s.lessons)
   );
   const sectionRanks = rankByOrder(sectionsWithLessons);
+  const orderedSections = [...sectionsWithLessons].sort(
+    (a, b) => sectionRanks.get(a.id)! - sectionRanks.get(b.id)!
+  );
 
-  for (const section of sectionsWithLessons) {
-    const sectionNumber = sectionRanks.get(section.id)!;
-    paths.set(section.id, deriveSectionPath(section.title, sectionNumber));
+  const sectionPaths = dedupeSlugs(
+    orderedSections.map((s) => deriveSectionPath(s.title))
+  );
+
+  orderedSections.forEach((section, i) => {
+    paths.set(section.id, sectionPaths[i]!);
 
     const lessonRanks = rankByOrder(section.lessons);
-
-    for (const lesson of section.lessons) {
-      const lessonNumber = lessonRanks.get(lesson.id)!;
-      paths.set(
-        lesson.id,
-        deriveLessonPath(lesson.title, sectionNumber, lessonNumber)
-      );
-    }
-  }
+    const orderedLessons = [...section.lessons].sort(
+      (a, b) => lessonRanks.get(a.id)! - lessonRanks.get(b.id)!
+    );
+    const lessonPaths = dedupeSlugs(
+      orderedLessons.map((l) => deriveLessonPath(l.title))
+    );
+    orderedLessons.forEach((lesson, j) => {
+      paths.set(lesson.id, lessonPaths[j]!);
+    });
+  });
 
   return paths;
 };

--- a/packages/core/services/section-path-service.test.ts
+++ b/packages/core/services/section-path-service.test.ts
@@ -1,36 +1,17 @@
 import { describe, expect, it } from "vitest";
-import {
-  buildSectionPath,
-  deriveSectionPath,
-  parseSectionPath,
-  computeSectionRenumberingPlan,
-} from "./section-path-service.js";
-
-describe("buildSectionPath", () => {
-  it("produces NN-slug format", () => {
-    expect(buildSectionPath(1, "intro")).toBe("01-intro");
-  });
-
-  it("zero-pads single-digit numbers", () => {
-    expect(buildSectionPath(3, "advanced")).toBe("03-advanced");
-  });
-
-  it("handles double-digit numbers", () => {
-    expect(buildSectionPath(12, "deep-dive")).toBe("12-deep-dive");
-  });
-});
+import { deriveSectionPath, parseSectionPath } from "./section-path-service.js";
 
 describe("deriveSectionPath", () => {
-  it("derives path from title and section number", () => {
-    expect(deriveSectionPath("Introduction", 1)).toBe("01-introduction");
+  it("derives path from title alone, no ordering number", () => {
+    expect(deriveSectionPath("Introduction")).toBe("introduction");
   });
 
   it("falls back to 'untitled' for empty title", () => {
-    expect(deriveSectionPath("", 2)).toBe("02-untitled");
+    expect(deriveSectionPath("")).toBe("untitled");
   });
 
   it("falls back to 'untitled' for symbols-only title", () => {
-    expect(deriveSectionPath("!@#$", 1)).toBe("01-untitled");
+    expect(deriveSectionPath("!@#$")).toBe("untitled");
   });
 });
 
@@ -66,163 +47,5 @@ describe("parseSectionPath", () => {
 
   it("returns null for number-only path (no slug)", () => {
     expect(parseSectionPath("03")).toBeNull();
-  });
-
-  describe("roundtrip", () => {
-    it("buildSectionPath output is parseable by parseSectionPath", () => {
-      const built = buildSectionPath(5, "my-section");
-      const parsed = parseSectionPath(built);
-      expect(parsed).toEqual({
-        sectionNumber: 5,
-        slug: "my-section",
-      });
-    });
-  });
-});
-
-describe("computeSectionRenumberingPlan", () => {
-  const makeSections = (slugs: string[]) =>
-    slugs.map((slug, i) => ({
-      id: `section-${i + 1}`,
-      path: buildSectionPath(i + 1, slug),
-      hasLessons: true,
-    }));
-
-  it("returns empty array for empty sections", () => {
-    expect(computeSectionRenumberingPlan([], [])).toEqual([]);
-  });
-
-  it("returns empty array for empty newOrderIds", () => {
-    const sections = makeSections(["intro", "basics"]);
-    expect(computeSectionRenumberingPlan(sections, [])).toEqual([]);
-  });
-
-  it("returns empty array when order is unchanged (no-op)", () => {
-    const sections = makeSections(["intro", "basics", "advanced"]);
-    expect(
-      computeSectionRenumberingPlan(sections, [
-        "section-1",
-        "section-2",
-        "section-3",
-      ])
-    ).toEqual([]);
-  });
-
-  it("moves last section to first position", () => {
-    const sections = makeSections(["intro", "basics", "advanced"]);
-    const plan = computeSectionRenumberingPlan(sections, [
-      "section-3",
-      "section-1",
-      "section-2",
-    ]);
-
-    expect(plan).toEqual([
-      {
-        id: "section-3",
-        oldPath: "03-advanced",
-        newPath: "01-advanced",
-        oldSectionNumber: 3,
-        newSectionNumber: 1,
-      },
-      {
-        id: "section-1",
-        oldPath: "01-intro",
-        newPath: "02-intro",
-        oldSectionNumber: 1,
-        newSectionNumber: 2,
-      },
-      {
-        id: "section-2",
-        oldPath: "02-basics",
-        newPath: "03-basics",
-        oldSectionNumber: 2,
-        newSectionNumber: 3,
-      },
-    ]);
-  });
-
-  it("swaps two sections", () => {
-    const sections = makeSections(["first", "second"]);
-    const plan = computeSectionRenumberingPlan(sections, [
-      "section-2",
-      "section-1",
-    ]);
-
-    expect(plan).toEqual([
-      {
-        id: "section-2",
-        oldPath: "02-second",
-        newPath: "01-second",
-        oldSectionNumber: 2,
-        newSectionNumber: 1,
-      },
-      {
-        id: "section-1",
-        oldPath: "01-first",
-        newPath: "02-first",
-        oldSectionNumber: 1,
-        newSectionNumber: 2,
-      },
-    ]);
-  });
-
-  it("only includes sections whose path actually changes", () => {
-    const sections = makeSections(["intro", "basics", "advanced", "outro"]);
-    // Move basics to end: intro, advanced, outro, basics
-    const plan = computeSectionRenumberingPlan(sections, [
-      "section-1",
-      "section-3",
-      "section-4",
-      "section-2",
-    ]);
-
-    // section-1 stays 01-intro (no change)
-    expect(plan.find((r) => r.id === "section-1")).toBeUndefined();
-    expect(plan).toHaveLength(3);
-  });
-
-  it("skips empty sections even when their path is numbered", () => {
-    // An empty section can carry a numbered path; emptiness is decided by
-    // hasLessons, not by whether the path parses.
-    const sections = [
-      { id: "section-1", path: "01-intro", hasLessons: true },
-      { id: "section-2", path: "02-concepts", hasLessons: false },
-      { id: "section-3", path: "03-advanced", hasLessons: true },
-    ];
-    const plan = computeSectionRenumberingPlan(sections, [
-      "section-3",
-      "section-2",
-      "section-1",
-    ]);
-
-    // The empty section (section-2) must not be renumbered/renamed.
-    expect(plan.find((r) => r.id === "section-2")).toBeUndefined();
-    expect(plan.map((r) => r.id)).toEqual(["section-3", "section-1"]);
-  });
-
-  it("ignores unknown IDs in newOrderIds", () => {
-    const sections = makeSections(["intro", "basics"]);
-    const plan = computeSectionRenumberingPlan(sections, [
-      "section-2",
-      "unknown-id",
-      "section-1",
-    ]);
-
-    expect(plan).toEqual([
-      {
-        id: "section-2",
-        oldPath: "02-basics",
-        newPath: "01-basics",
-        oldSectionNumber: 2,
-        newSectionNumber: 1,
-      },
-      {
-        id: "section-1",
-        oldPath: "01-intro",
-        newPath: "03-intro",
-        oldSectionNumber: 1,
-        newSectionNumber: 3,
-      },
-    ]);
   });
 });

--- a/packages/core/services/section-path-service.ts
+++ b/packages/core/services/section-path-service.ts
@@ -1,8 +1,14 @@
 /**
  * Pure functions for section path naming conventions.
  *
- * Format: NN-slug (e.g., 01-intro, 02-advanced)
- *   NN = section number (zero-padded to match existing width)
+ * A section's display path is its slugified title (e.g. "Advanced Topics" →
+ * "advanced-topics") — no ordering number. Order is carried by the `order`
+ * column and by array position in `course.json`; the path exists purely for
+ * filesystem legibility (the Dropbox bundle's directory layout, ADR 0023),
+ * so it never needs to change when a section is reordered or when a lesson
+ * moves in or out of it. Collisions between same-titled sibling sections are
+ * disambiguated at the point paths are projected (`path-projection.ts`), not
+ * here.
  */
 
 import { toSlug } from "./lesson-path-service.js";
@@ -15,54 +21,15 @@ export type ParsedSectionPath = {
 export const sectionHasLessons = (lessons: ReadonlyArray<unknown>): boolean =>
   lessons.length > 0;
 
-/**
- * Derives the slug for a section regardless of whether its path is already
- * numbered ("02-concepts" → "concepts") or a plain title ("Concepts" →
- * "concepts").
- */
-export const sectionSlugFromPath = (sectionPath: string): string => {
-  const parsed = parseSectionPath(sectionPath);
-  if (parsed) return parsed.slug;
-  return toSlug(sectionPath) || "untitled";
-};
-
-export type SectionForReorder = {
-  id: string;
-  path: string; // directory name like "01-intro"
-  hasLessons: boolean; // whether the section has lessons (not the path)
-};
-
-export type SectionRenameEntry = {
-  id: string;
-  oldPath: string;
-  newPath: string;
-  oldSectionNumber: number;
-  newSectionNumber: number;
+export const deriveSectionPath = (title: string): string => {
+  return toSlug(title) || "untitled";
 };
 
 /**
- * Builds a section directory name in NN-slug format.
- */
-export const buildSectionPath = (
-  sectionNumber: number,
-  slug: string
-): string => {
-  const num = String(sectionNumber).padStart(2, "0");
-  return `${num}-${slug}`;
-};
-
-export const deriveSectionPath = (
-  title: string,
-  sectionNumber: number
-): string => {
-  return buildSectionPath(sectionNumber, toSlug(title) || "untitled");
-};
-
-/**
- * Parses a section directory name.
- *
- * "01-intro" → { sectionNumber: 1, slug: "intro" }
- * "12-advanced-topic" → { sectionNumber: 12, slug: "advanced-topic" }
+ * Parses a legacy numbered section directory name, for tolerating
+ * old-format input when a section is created from a name that still carries
+ * a number prefix ("01-intro" → { sectionNumber: 1, slug: "intro" }). Not
+ * used to build or project display paths, which are never numbered.
  */
 export const parseSectionPath = (
   sectionPath: string
@@ -73,48 +40,4 @@ export const parseSectionPath = (
     sectionNumber: Number(match[1]),
     slug: match[2]!,
   };
-};
-
-/**
- * Given the current sections and the desired new order (as an array of IDs),
- * returns the list of renames needed to keep numbering sequential.
- *
- * @param currentSections - Sections with their current paths
- * @param newOrderIds - Section IDs in the desired new order
- * @returns Array of renames where the path actually changed
- */
-export const computeSectionRenumberingPlan = (
-  currentSections: SectionForReorder[],
-  newOrderIds: readonly string[]
-): SectionRenameEntry[] => {
-  if (currentSections.length === 0 || newOrderIds.length === 0) return [];
-
-  const sectionMap = new Map(currentSections.map((s) => [s.id, s]));
-
-  const renames: SectionRenameEntry[] = [];
-  for (let i = 0; i < newOrderIds.length; i++) {
-    const section = sectionMap.get(newOrderIds[i]!);
-    if (!section) continue;
-
-    // Empty sections (no lessons) don't get numbered paths.
-    if (!section.hasLessons) continue;
-
-    const newSectionNumber = i + 1;
-    const newPath = buildSectionPath(
-      newSectionNumber,
-      sectionSlugFromPath(section.path)
-    );
-    if (newPath !== section.path) {
-      renames.push({
-        id: section.id,
-        oldPath: section.path,
-        newPath,
-        oldSectionNumber:
-          parseSectionPath(section.path)?.sectionNumber ?? newSectionNumber,
-        newSectionNumber,
-      });
-    }
-  }
-
-  return renames;
 };


### PR DESCRIPTION
## What was happening

```mermaid
sequenceDiagram
    participant Author
    participant Planner as lesson-move-planner
    participant DB as sections.title

    Author->>Planner: drag a lesson into a section that was empty
    Note over Planner: section flips empty → real,<br/>renumbers every real section's path
    Planner->>DB: updateSectionTitle(id, "02-my-section")
    Note over DB: title is now the derived,<br/>numbered PATH — the exact<br/>"O2-domain-language" bug
```

`path` has been derived-not-stored since ADR 0018 (title is identity), but the derivation still baked in a `NN-`/`NN.MM-` ordering number, and the lesson-move planner treated that number as state to keep in sync. A cross-section move that changed a section's empty/real status renumbered siblings and wrote the result straight into `title` — silently re-seeding the legacy numbered titles a previous cleanup (#1607) had just removed.

## The fix

Drop the number. `path` is now just `toSlug(title)`, with a `-2`/`-3` suffix only on an actual sibling collision (computed once, in `path-projection.ts`).

| | before | after |
|---|---|---|
| section path | `02-advanced` | `advanced` |
| lesson path | `01.03-hooks` | `hooks` |
| two lessons both titled "Hooks" | `01.01-hooks`, `01.02-hooks` | `hooks`, `hooks-2` |

Nothing legitimate depended on the number:
- `course.json` already carries explicit array order + `title` (ADR 0019) — the number in `path` never communicated order downstream.
- The Dropbox bundle (ADR 0023) only needs `path` to be *unique*, not ordered — and reordering a section no longer perturbs every later Video's `relativeAssetPath` / `assetFingerprint`, so a routine reorder no longer forces a spurious full bundle re-address.

Since a path never changes on a lesson move now, the entire renumbering cascade in `lesson-move-planner.ts` (materialize/dematerialize, `sectionUpdates`, `fsOps`) had nothing left to compute — it's gone, and `course-write-move-ops.ts` no longer writes to `title` at all. The bug is closed by construction, not patched.

```
packages/core/services/
├── section-path-service.ts      deriveSectionPath(title) — no number
├── lesson-path-service.ts       deriveLessonPath(title) — no number
├── path-projection.ts           +collision suffix (-2, -3, ...)
├── lesson-move-planner.ts       -sectionUpdates/fsOps, just lessonUpdates
└── course-write-move-ops.ts     no more updateSectionTitle(id, path)

apps/local/app/features/course-view/
└── optimistic-applier.ts        mirrors the simplified planner
```

Also fixed one more instance of the original "shows path instead of title" bug, found in passing: the dependency-selector's section grouping used `section.path` instead of `section.title`.

ADR 0011 marked superseded by new [ADR 0028](docs/adr/0028-drop-numbered-path-prefix.md), which records the shape and the bug it closes.

## Testing

- `pnpm typecheck`, `pnpm lint:boundaries` — clean
- Full `packages/core` + `apps/local` test suites — green, apart from 4 pre-existing failures confirmed unrelated (reproduced identically on unmodified `main`): PGlite cold-start timeouts under this sandbox's CPU load, and 3 bullet-panel overlay tests unrelated to paths.
- Updated every test that asserted a numbered derived path to the new plain-slug form.