### PR TITLE
Add course view display settings: hide clutter per phase of work

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -157,7 +157,7 @@ A single film-time planning unit of a **Video**, classified by its **job** for t
 _Avoid_: Chapter (the recorded YouTube grouping), Segment (now only the transcript/silence homonym), Section (course Section), Block, Unit
 
 **Beat Description**:
-A free-text planning note on a **Beat** — "what I'm actually going to do or say here" — distinct from its short **title**. Plain text, edited inline (auto-growing textarea). A purely in-app authoring aid: like the Beat itself, it is never published (Publish skips it). Surfaced and editable on the **Section Workbench** and on the editor's **Beats tab** (the current video's plan, read while recording); deliberately **hidden on the course view**, which is already information-dense.
+A free-text planning note on a **Beat** — "what I'm actually going to do or say here" — distinct from its short **title**. Plain text, edited inline (auto-growing textarea). A purely in-app authoring aid: like the Beat itself, it is never published (Publish skips it). Surfaced and editable on the **Section Workbench** and on the editor's **Beats tab** (the current video's plan, read while recording); hidden by default on the course view, which is already information-dense, but can be switched on there per browser via **Course View Display Settings**.
 _Avoid_: Notes, Summary, Body, Caption
 
 **Script**:
@@ -165,8 +165,12 @@ The high-fidelity, screenplay-style plan of a **Video** — one flowing document
 _Avoid_: Body (the published article), Beat Description (the per-beat note), Transcript (what was actually said), Caption
 
 **Section Workbench**:
-A drill-down authoring surface for one **Section** (`/courses/:courseId/sections/:sectionId`), reached from the course view via a Section header (top) or Lesson title (deep link). An expanded reskin of the compact course view: shows each Lesson's **Videos** and **Beats** with **Beat Descriptions** inline-editable. Its added value is that beat/description layer; structural editing is inherited from the reused course-view components. Sibling sections are not shown — go back through the course view.
+A drill-down authoring surface for one **Section** (`/courses/:courseId/sections/:sectionId`), reached from the course view via a Section header (top) or Lesson title (deep link). An expanded reskin of the compact course view: shows each Lesson's **Videos** and **Beats** with **Beat Descriptions** inline-editable. Its added value is that beat/description layer; structural editing is inherited from the reused course-view components. Sibling sections are not shown — go back through the course view. Always shows everything — it does not read **Course View Display Settings**.
 _Avoid_: Section page, Lesson page (the workbench is section-altitude; there is no lesson-altitude page), Section editor
+
+**Course View Display Settings**:
+A per-browser (not per-course) set of checkboxes, opened from a toolbar button on the course view, that shows or hides individual elements of the tree — **Section** Descriptions, **Learning Goals** (and their Descriptions), **Lesson** Descriptions/Priorities/Types/To-do markers/**Lesson Dependency** selectors, **Video**s, **Beat**s (and their Descriptions and Add-beat button) — so a phase of work that only needs, say, Learning Goals and Beats can hide the rest of the clutter. Some checkboxes depend on another (a Video's Beats checkbox is meaningless with Videos itself hidden); unchecking a parent greys out and suppresses its children without discarding their own setting, so re-checking the parent restores them. Sections themselves are never hidden. The same preferences constrain the course view's filter bar — a filter control (priority, lesson type, to-do) only shows, and only applies, while its field is visible. Stored in `localStorage`, not the database — see `course-view-visibility.tsx`.
+_Avoid_: View mode (that's Compact/Expanded, a different, orthogonal toggle also on the course view)
 
 ### Video warnings
 

--- a/apps/local/app/features/beats/beat-list.tsx
+++ b/apps/local/app/features/beats/beat-list.tsx
@@ -68,6 +68,7 @@ export function BeatList({
   submitEvent,
   isReadOnly,
   showDescriptions,
+  showAddButton = true,
   courseId,
   sectionId,
   className,
@@ -82,6 +83,13 @@ export function BeatList({
    * ambient context (off on the dense course view, which hides the note).
    */
   showDescriptions?: boolean;
+  /**
+   * Render the "Add beat" dropdown below the rows. Defaults on; the course
+   * view's display settings (see `course-view-visibility.tsx`) turn it off
+   * independently of the Beat rows themselves. Has no effect when
+   * `isReadOnly` — that branch never shows the button either way.
+   */
+  showAddButton?: boolean;
   courseId?: string;
   sectionId?: string;
   className?: string;
@@ -138,7 +146,7 @@ export function BeatList({
         {previewInThisVideo?.beforeBeatId === null && <BeatDropLine />}
       </BeatSortableList>
 
-      <AddBeatButton videoId={video.id} />
+      {showAddButton && <AddBeatButton videoId={video.id} />}
     </div>
   );
 }

--- a/apps/local/app/features/course-view/course-view-components.tsx
+++ b/apps/local/app/features/course-view/course-view-components.tsx
@@ -11,6 +11,8 @@ import { ScriptWriterModal } from "@/features/video-editor/script-writer-modal";
 import { AutofillDescriptionModal } from "@/features/lesson-writer/autofill-description-modal";
 import { computeCourseStats } from "@/features/course-view/course-editor-helpers";
 import { courseViewReducer } from "@/features/course-view/course-view-reducer";
+import { useCourseViewVisibility } from "@/features/course-view/course-view-visibility";
+import { VisibilitySettingsModal } from "@/features/course-view/visibility-settings-modal";
 
 import {
   ChevronsDownUp,
@@ -22,9 +24,10 @@ import {
   Play,
   Rows3,
   Search,
+  SlidersHorizontal,
   X,
 } from "lucide-react";
-import { Suspense } from "react";
+import { Fragment, Suspense, useEffect, type ReactElement } from "react";
 import { useNavigate } from "react-router";
 import { Input } from "@/components/ui/input";
 import type { LoaderData } from "./course-view-types";
@@ -93,11 +96,67 @@ export function FilterBar({
   sectionCount: number;
   dispatch: (action: courseViewReducer.Action) => void;
 }) {
+  const { effective: visibility } = useCourseViewVisibility();
+
+  const showPriorityFilter = visibility.lessonPriorities;
+  const showIconFilter = visibility.lessonTypes;
+  const showTodoFilter = visibility.todoMarkers;
+
+  // The settings modal hides a filter's control the instant its underlying
+  // field is toggled off — but the filter's own selection can outlive that
+  // (it lives in the course-view reducer, not the visibility prefs), leaving
+  // an invisible filter still narrowing the list with no control left to
+  // clear it. Clear it here instead, the moment its control disappears. See
+  // "Filtering out this UI should also apply to the filters" in the course
+  // view visibility design.
+  useEffect(() => {
+    if (!showPriorityFilter) dispatch({ type: "clear-priority-filter" });
+  }, [showPriorityFilter, dispatch]);
+  useEffect(() => {
+    if (!showIconFilter) dispatch({ type: "clear-icon-filter" });
+  }, [showIconFilter, dispatch]);
+  useEffect(() => {
+    if (!showTodoFilter) dispatch({ type: "clear-todo-filter" });
+  }, [showTodoFilter, dispatch]);
+
   const hasActiveFilters =
     priorityFilter.length > 0 ||
     iconFilter.length > 0 ||
     todoFilter ||
     searchQuery.length > 0;
+
+  const filterGroups = [
+    showPriorityFilter && (
+      <PriorityFilterButtons
+        key="priority"
+        priorityFilter={priorityFilter}
+        dispatch={dispatch}
+      />
+    ),
+    showIconFilter && (
+      <IconFilterButtons
+        key="icon"
+        iconFilter={iconFilter}
+        dispatch={dispatch}
+      />
+    ),
+    showTodoFilter && (
+      <button
+        key="todo"
+        className={`text-xs px-2 py-0.5 rounded-sm font-medium transition-colors flex items-center gap-1 ${
+          todoFilter
+            ? "bg-muted text-muted-foreground ring-1 ring-current"
+            : "bg-muted text-muted-foreground hover:bg-muted/80"
+        }`}
+        onClick={() => dispatch({ type: "toggle-todo-filter" })}
+        title="Todo"
+      >
+        <ListChecks className="w-3 h-3" />
+        Todo
+        <span className="opacity-60">{todoCount}</span>
+      </button>
+    ),
+  ].filter((group): group is ReactElement => Boolean(group));
 
   return (
     <div className="space-y-3">
@@ -124,89 +183,21 @@ export function FilterBar({
 
       {/* Filter buttons */}
       <div className="flex items-center gap-2 flex-wrap">
-        <span className="text-xs text-muted-foreground">Filters:</span>
-        {([1, 2, 3] as const).map((priority) => {
-          const isSelected = priorityFilter.includes(priority);
-          const showAsActive = priorityFilter.length === 0 || isSelected;
-          return (
-            <button
-              key={priority}
-              className={`text-xs px-2 py-0.5 rounded-sm font-medium transition-colors ${
-                showAsActive
-                  ? priority === 1
-                    ? "bg-red-500/20 text-red-600"
-                    : priority === 2
-                      ? "bg-yellow-500/20 text-yellow-600"
-                      : "bg-sky-500/20 text-sky-500"
-                  : "bg-muted text-muted-foreground hover:bg-muted/80"
-              } ${isSelected ? "ring-1 ring-current" : ""}`}
-              onClick={() =>
-                dispatch({ type: "toggle-priority-filter", priority })
-              }
-            >
-              P{priority}
-            </button>
-          );
-        })}
-
-        <span className="text-muted-foreground mx-0.5">|</span>
-        {(["code", "discussion", "watch"] as const).map((icon) => {
-          const isSelected = iconFilter.includes(icon);
-          const showAsActive = iconFilter.length === 0 || isSelected;
-          return (
-            <button
-              key={icon}
-              className={`flex items-center justify-center w-6 h-6 rounded-full transition-colors ${
-                icon === "code"
-                  ? showAsActive
-                    ? "bg-yellow-500/20 text-yellow-600"
-                    : "bg-muted text-muted-foreground hover:bg-muted/80"
-                  : icon === "discussion"
-                    ? showAsActive
-                      ? "bg-green-500/20 text-green-600"
-                      : "bg-muted text-muted-foreground hover:bg-muted/80"
-                    : showAsActive
-                      ? "bg-purple-500/20 text-purple-600"
-                      : "bg-muted text-muted-foreground hover:bg-muted/80"
-              } ${isSelected ? "ring-1 ring-current" : ""}`}
-              onClick={() => dispatch({ type: "toggle-icon-filter", icon })}
-              title={
-                icon === "code"
-                  ? "Interactive"
-                  : icon === "discussion"
-                    ? "Discussion"
-                    : "Watch"
-              }
-            >
-              {icon === "code" ? (
-                <Code className="w-3 h-3" />
-              ) : icon === "discussion" ? (
-                <MessageCircle className="w-3 h-3" />
-              ) : (
-                <Play className="w-3 h-3" />
-              )}
-            </button>
-          );
-        })}
-
-        <span className="text-muted-foreground mx-0.5">|</span>
-        <button
-          className={`text-xs px-2 py-0.5 rounded-sm font-medium transition-colors flex items-center gap-1 ${
-            todoFilter
-              ? "bg-muted text-muted-foreground ring-1 ring-current"
-              : "bg-muted text-muted-foreground hover:bg-muted/80"
-          }`}
-          onClick={() => dispatch({ type: "toggle-todo-filter" })}
-          title="Todo"
-        >
-          <ListChecks className="w-3 h-3" />
-          Todo
-          <span className="opacity-60">{todoCount}</span>
-        </button>
+        {filterGroups.length > 0 && (
+          <span className="text-xs text-muted-foreground">Filters:</span>
+        )}
+        {filterGroups.map((group, i) => (
+          <Fragment key={group.key}>
+            {i > 0 && <span className="text-muted-foreground mx-0.5">|</span>}
+            {group}
+          </Fragment>
+        ))}
 
         {hasActiveFilters && (
           <>
-            <span className="text-muted-foreground mx-0.5">|</span>
+            {filterGroups.length > 0 && (
+              <span className="text-muted-foreground mx-0.5">|</span>
+            )}
             <button
               className="text-xs px-2 py-0.5 rounded-sm text-muted-foreground hover:text-foreground transition-colors"
               onClick={() => {
@@ -274,9 +265,109 @@ export function FilterBar({
               <Rows3 className="w-4 h-4" />
             )}
           </button>
+          <button
+            className="flex items-center justify-center w-7 h-7 rounded transition-colors text-muted-foreground hover:text-foreground"
+            onClick={() =>
+              dispatch({
+                type: "set-visibility-settings-modal-open",
+                open: true,
+              })
+            }
+            title="Course view display settings"
+            aria-label="Course view display settings"
+          >
+            <SlidersHorizontal className="w-4 h-4" />
+          </button>
         </div>
       </div>
     </div>
+  );
+}
+
+function PriorityFilterButtons({
+  priorityFilter,
+  dispatch,
+}: {
+  priorityFilter: number[];
+  dispatch: (action: courseViewReducer.Action) => void;
+}) {
+  return (
+    <>
+      {([1, 2, 3] as const).map((priority) => {
+        const isSelected = priorityFilter.includes(priority);
+        const showAsActive = priorityFilter.length === 0 || isSelected;
+        return (
+          <button
+            key={priority}
+            className={`text-xs px-2 py-0.5 rounded-sm font-medium transition-colors ${
+              showAsActive
+                ? priority === 1
+                  ? "bg-red-500/20 text-red-600"
+                  : priority === 2
+                    ? "bg-yellow-500/20 text-yellow-600"
+                    : "bg-sky-500/20 text-sky-500"
+                : "bg-muted text-muted-foreground hover:bg-muted/80"
+            } ${isSelected ? "ring-1 ring-current" : ""}`}
+            onClick={() =>
+              dispatch({ type: "toggle-priority-filter", priority })
+            }
+          >
+            P{priority}
+          </button>
+        );
+      })}
+    </>
+  );
+}
+
+function IconFilterButtons({
+  iconFilter,
+  dispatch,
+}: {
+  iconFilter: string[];
+  dispatch: (action: courseViewReducer.Action) => void;
+}) {
+  return (
+    <>
+      {(["code", "discussion", "watch"] as const).map((icon) => {
+        const isSelected = iconFilter.includes(icon);
+        const showAsActive = iconFilter.length === 0 || isSelected;
+        return (
+          <button
+            key={icon}
+            className={`flex items-center justify-center w-6 h-6 rounded-full transition-colors ${
+              icon === "code"
+                ? showAsActive
+                  ? "bg-yellow-500/20 text-yellow-600"
+                  : "bg-muted text-muted-foreground hover:bg-muted/80"
+                : icon === "discussion"
+                  ? showAsActive
+                    ? "bg-green-500/20 text-green-600"
+                    : "bg-muted text-muted-foreground hover:bg-muted/80"
+                  : showAsActive
+                    ? "bg-purple-500/20 text-purple-600"
+                    : "bg-muted text-muted-foreground hover:bg-muted/80"
+            } ${isSelected ? "ring-1 ring-current" : ""}`}
+            onClick={() => dispatch({ type: "toggle-icon-filter", icon })}
+            title={
+              icon === "code"
+                ? "Interactive"
+                : icon === "discussion"
+                  ? "Discussion"
+                  : "Watch"
+            }
+          >
+            {icon === "code" ? (
+              <Code className="w-3 h-3" />
+            ) : icon === "discussion" ? (
+              <MessageCircle className="w-3 h-3" />
+            ) : (
+              <Play className="w-3 h-3" />
+            )}
+          </button>
+        );
+      })}
+    </>
   );
 }
 
@@ -305,6 +396,7 @@ export function RouteModals({
     isPurgeExportsModalOpen: boolean;
     isCopyTranscriptModalOpen: boolean;
     isDuplicateCourseModalOpen: boolean;
+    isVisibilitySettingsModalOpen: boolean;
     copySectionTranscriptState: {
       sectionTitle: string;
       sectionDescription: string | undefined;
@@ -338,6 +430,13 @@ export function RouteModals({
 }) {
   return (
     <>
+      <VisibilitySettingsModal
+        open={viewState.isVisibilitySettingsModalOpen}
+        onOpenChange={(open) =>
+          dispatch({ type: "set-visibility-settings-modal-open", open })
+        }
+      />
+
       {currentCourse && (
         <RenameCourseModal
           courseId={currentCourse.id}

--- a/apps/local/app/features/course-view/course-view-reducer.test.ts
+++ b/apps/local/app/features/course-view/course-view-reducer.test.ts
@@ -502,4 +502,62 @@ describe("courseViewReducer", () => {
       expect(state.videoPlayerState.isOpen).toBe(true);
     });
   });
+
+  describe("Visibility settings modal", () => {
+    it("55. is closed initially", () => {
+      const state = createTester().getState();
+      expect(state.isVisibilitySettingsModalOpen).toBe(false);
+    });
+
+    it("56. set-visibility-settings-modal-open: opens and closes", () => {
+      const tester = createTester().send({
+        type: "set-visibility-settings-modal-open",
+        open: true,
+      });
+      expect(tester.getState().isVisibilitySettingsModalOpen).toBe(true);
+      const closed = tester
+        .send({ type: "set-visibility-settings-modal-open", open: false })
+        .getState();
+      expect(closed.isVisibilitySettingsModalOpen).toBe(false);
+    });
+  });
+
+  describe("Filters cleared by hidden fields", () => {
+    it("57. clear-priority-filter: empties the priority filter", () => {
+      const state = createTester()
+        .send({ type: "toggle-priority-filter", priority: 1 })
+        .send({ type: "toggle-priority-filter", priority: 2 })
+        .send({ type: "clear-priority-filter" })
+        .getState();
+      expect(state.priorityFilter).toEqual([]);
+    });
+
+    it("58. clear-icon-filter: empties the icon filter", () => {
+      const state = createTester()
+        .send({ type: "toggle-icon-filter", icon: "code" })
+        .send({ type: "clear-icon-filter" })
+        .getState();
+      expect(state.iconFilter).toEqual([]);
+    });
+
+    it("59. clear-todo-filter: resets the todo filter to false", () => {
+      const state = createTester()
+        .send({ type: "toggle-todo-filter" })
+        .send({ type: "clear-todo-filter" })
+        .getState();
+      expect(state.todoFilter).toBe(false);
+    });
+
+    it("60. clearing one filter leaves the others untouched", () => {
+      const state = createTester()
+        .send({ type: "toggle-priority-filter", priority: 1 })
+        .send({ type: "toggle-icon-filter", icon: "code" })
+        .send({ type: "toggle-todo-filter" })
+        .send({ type: "clear-priority-filter" })
+        .getState();
+      expect(state.priorityFilter).toEqual([]);
+      expect(state.iconFilter).toEqual(["code"]);
+      expect(state.todoFilter).toBe(true);
+    });
+  });
 });

--- a/apps/local/app/features/course-view/course-view-reducer.ts
+++ b/apps/local/app/features/course-view/course-view-reducer.ts
@@ -47,6 +47,7 @@ export namespace courseViewReducer {
     isAddStandaloneVideoModalOpen: boolean;
     isCopyTranscriptModalOpen: boolean;
     isDuplicateCourseModalOpen: boolean;
+    isVisibilitySettingsModalOpen: boolean;
     copySectionTranscriptState: {
       sectionTitle: string;
       sectionDescription: string | undefined;
@@ -96,6 +97,7 @@ export namespace courseViewReducer {
     | { type: "set-add-standalone-video-modal-open"; open: boolean }
     | { type: "set-copy-transcript-modal-open"; open: boolean }
     | { type: "set-duplicate-course-modal-open"; open: boolean }
+    | { type: "set-visibility-settings-modal-open"; open: boolean }
     | {
         type: "open-copy-section-transcript";
         sectionTitle: string;
@@ -187,7 +189,12 @@ export namespace courseViewReducer {
     | { type: "toggle-priority-filter"; priority: number }
     | { type: "toggle-icon-filter"; icon: string }
     | { type: "toggle-todo-filter" }
-    | { type: "set-search-query"; query: string };
+    | { type: "set-search-query"; query: string }
+    // Filters cleared because the display-settings modal hid the field they
+    // filter on — see the visibility/filter sync effect in FilterBar.
+    | { type: "clear-priority-filter" }
+    | { type: "clear-icon-filter" }
+    | { type: "clear-todo-filter" };
 
   export type Effect = never;
 }
@@ -202,6 +209,7 @@ export function createInitialCourseViewState(): courseViewReducer.State {
     isAddStandaloneVideoModalOpen: false,
     isCopyTranscriptModalOpen: false,
     isDuplicateCourseModalOpen: false,
+    isVisibilitySettingsModalOpen: false,
     copySectionTranscriptState: null,
     addLessonSectionId: null,
     insertAdjacentLessonId: null,
@@ -258,6 +266,8 @@ export const courseViewReducer: EffectReducer<
       return { ...state, isCopyTranscriptModalOpen: action.open };
     case "set-duplicate-course-modal-open":
       return { ...state, isDuplicateCourseModalOpen: action.open };
+    case "set-visibility-settings-modal-open":
+      return { ...state, isVisibilitySettingsModalOpen: action.open };
     case "open-copy-section-transcript":
       return {
         ...state,
@@ -462,5 +472,17 @@ export const courseViewReducer: EffectReducer<
       return { ...state, todoFilter: !state.todoFilter };
     case "set-search-query":
       return { ...state, searchQuery: action.query };
+    case "clear-priority-filter":
+      return state.priorityFilter.length === 0
+        ? state
+        : { ...state, priorityFilter: [] };
+    case "clear-icon-filter":
+      return state.iconFilter.length === 0
+        ? state
+        : { ...state, iconFilter: [] };
+    case "clear-todo-filter":
+      return state.todoFilter === false
+        ? state
+        : { ...state, todoFilter: false };
   }
 };

--- a/apps/local/app/features/course-view/course-view-visibility.test.ts
+++ b/apps/local/app/features/course-view/course-view-visibility.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_VISIBILITY,
+  resolveEffectiveVisibility,
+  VISIBILITY_TREE,
+  type VisibilityKey,
+} from "./course-view-visibility";
+
+describe("resolveEffectiveVisibility", () => {
+  it("1. is fully visible under the default preferences, except Beat Descriptions", () => {
+    const effective = resolveEffectiveVisibility(DEFAULT_VISIBILITY);
+    for (const node of VISIBILITY_TREE) {
+      if (node.key === "beatDescriptions") continue;
+      expect(effective[node.key]).toBe(true);
+    }
+    expect(effective.beatDescriptions).toBe(false);
+  });
+
+  it("2. hides a child whose own preference is off, without touching siblings", () => {
+    const prefs = { ...DEFAULT_VISIBILITY, lessonPriorities: false };
+    const effective = resolveEffectiveVisibility(prefs);
+    expect(effective.lessonPriorities).toBe(false);
+    expect(effective.lessonTypes).toBe(true);
+    expect(effective.lessons).toBe(true);
+  });
+
+  it("3. cascades a hidden parent down to every descendant", () => {
+    const prefs = { ...DEFAULT_VISIBILITY, lessons: false };
+    const effective = resolveEffectiveVisibility(prefs);
+    expect(effective.lessons).toBe(false);
+    expect(effective.lessonDescriptions).toBe(false);
+    expect(effective.lessonPriorities).toBe(false);
+    expect(effective.lessonTypes).toBe(false);
+    expect(effective.todoMarkers).toBe(false);
+    expect(effective.dependencies).toBe(false);
+    expect(effective.videos).toBe(false);
+    // Two levels down (Beats is a child of Videos, which is a child of
+    // Lessons) — the cascade has to walk the whole ancestor chain, not just
+    // the immediate parent.
+    expect(effective.beats).toBe(false);
+    expect(effective.beatDescriptions).toBe(false);
+    expect(effective.addBeatButton).toBe(false);
+  });
+
+  it("4. leaves an unrelated branch alone when a sibling subtree is hidden", () => {
+    const prefs = { ...DEFAULT_VISIBILITY, lessons: false };
+    const effective = resolveEffectiveVisibility(prefs);
+    expect(effective.learningGoals).toBe(true);
+    expect(effective.learningGoalDescriptions).toBe(true);
+    expect(effective.sectionDescriptions).toBe(true);
+  });
+
+  it("5. keeps a child's own preference intact for when its parent comes back on", () => {
+    // Turning a parent off and back on shouldn't clobber a child's own
+    // stored preference — resolveEffectiveVisibility only reads `prefs`, so
+    // this documents that the parent flag alone decides the cascade.
+    const childOff = {
+      ...DEFAULT_VISIBILITY,
+      videos: false,
+      beats: false,
+    };
+    expect(resolveEffectiveVisibility(childOff).beats).toBe(false);
+
+    const parentBackOn = { ...childOff, videos: true };
+    expect(resolveEffectiveVisibility(parentBackOn).beats).toBe(false);
+    expect(resolveEffectiveVisibility(parentBackOn).videos).toBe(true);
+  });
+
+  it("6. every VISIBILITY_TREE key round-trips through the cascade", () => {
+    const effective = resolveEffectiveVisibility(DEFAULT_VISIBILITY);
+    const keys = VISIBILITY_TREE.map((n) => n.key);
+    const uniqueKeys = new Set<VisibilityKey>(keys);
+    expect(uniqueKeys.size).toBe(keys.length);
+    for (const key of keys) {
+      expect(effective).toHaveProperty(key);
+    }
+  });
+});

--- a/apps/local/app/features/course-view/course-view-visibility.tsx
+++ b/apps/local/app/features/course-view/course-view-visibility.tsx
@@ -1,0 +1,198 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { useLocalStorage } from "@/hooks/use-local-storage";
+
+/**
+ * What can be individually shown or hidden on the course view. Deliberately
+ * does NOT include "sections" — the Section is the one altitude that's
+ * always on screen; every entity below it (Learning Goal, Lesson, Video,
+ * Beat) plus the free-text description fields at each altitude are the
+ * togglable surface. See CONTEXT.md's "Course structure" and "Video
+ * planning" entries for what each of these names.
+ */
+export type VisibilityKey =
+  | "sectionDescriptions"
+  | "learningGoals"
+  | "learningGoalDescriptions"
+  | "lessons"
+  | "lessonDescriptions"
+  | "lessonPriorities"
+  | "lessonTypes"
+  | "todoMarkers"
+  | "dependencies"
+  | "videos"
+  | "beats"
+  | "beatDescriptions"
+  | "addBeatButton";
+
+export type VisibilityNode = {
+  key: VisibilityKey;
+  label: string;
+  /** Effective visibility cascades: a node can only show if its parent does
+   * too — see {@link resolveEffectiveVisibility}. `null` = top-level, gated
+   * only by the always-on Section. */
+  parent: VisibilityKey | null;
+};
+
+/**
+ * The one place the checkbox tree's shape is declared — read by both the
+ * settings modal (to render the list, parent before children) and
+ * {@link resolveEffectiveVisibility} (to cascade). Mirrors the actual
+ * nesting on screen: a Beat lives under a Video, a Video under a Lesson, a
+ * Learning Goal Description under a Learning Goal.
+ */
+export const VISIBILITY_TREE: VisibilityNode[] = [
+  { key: "sectionDescriptions", label: "Section descriptions", parent: null },
+  { key: "learningGoals", label: "Learning goals", parent: null },
+  {
+    key: "learningGoalDescriptions",
+    label: "Learning goal descriptions",
+    parent: "learningGoals",
+  },
+  { key: "lessons", label: "Lessons", parent: null },
+  {
+    key: "lessonDescriptions",
+    label: "Lesson descriptions",
+    parent: "lessons",
+  },
+  { key: "lessonPriorities", label: "Lesson priorities", parent: "lessons" },
+  { key: "lessonTypes", label: "Lesson types", parent: "lessons" },
+  { key: "todoMarkers", label: "To-do markers", parent: "lessons" },
+  { key: "dependencies", label: "Dependencies", parent: "lessons" },
+  { key: "videos", label: "Videos", parent: "lessons" },
+  { key: "beats", label: "Beats", parent: "videos" },
+  { key: "beatDescriptions", label: "Beat descriptions", parent: "beats" },
+  { key: "addBeatButton", label: "Add beat button", parent: "beats" },
+];
+
+/**
+ * Defaults reproduce today's course view exactly, so shipping this feature
+ * changes nothing until someone opens the settings modal. The one exception
+ * is `beatDescriptions: false` — Beat Description is already deliberately
+ * hidden on the course view (see CONTEXT.md's "Beat Description" entry;
+ * previously enforced by `BeatDescriptionsContext` defaulting to `false`
+ * with no provider on this route). Everything else is on today.
+ */
+export const DEFAULT_VISIBILITY: Record<VisibilityKey, boolean> = {
+  sectionDescriptions: true,
+  learningGoals: true,
+  learningGoalDescriptions: true,
+  lessons: true,
+  lessonDescriptions: true,
+  lessonPriorities: true,
+  lessonTypes: true,
+  todoMarkers: true,
+  dependencies: true,
+  videos: true,
+  beats: true,
+  beatDescriptions: false,
+  addBeatButton: true,
+};
+
+const VISIBILITY_STORAGE_KEY = "course-view-visibility";
+
+function parsePrefs(raw: string): Record<VisibilityKey, boolean> {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return DEFAULT_VISIBILITY;
+    const source = parsed as Record<string, unknown>;
+    const next = { ...DEFAULT_VISIBILITY };
+    for (const node of VISIBILITY_TREE) {
+      const value = source[node.key];
+      if (typeof value === "boolean") next[node.key] = value;
+    }
+    return next;
+  } catch {
+    return DEFAULT_VISIBILITY;
+  }
+}
+
+/**
+ * Turns each checkbox's own (stored) preference into what should actually
+ * render, by ANDing it down through its ancestors: a child is only
+ * effectively visible when it — and everything above it — is checked.
+ * Unchecking a parent doesn't clear its children's stored preferences (so
+ * re-checking the parent restores whatever the child was set to), it just
+ * suppresses them until the parent is back on. This is the one function both
+ * the modal (to grey out gated checkboxes) and every rendering call site (to
+ * decide what to show) share, so the two can never disagree.
+ */
+export function resolveEffectiveVisibility(
+  prefs: Record<VisibilityKey, boolean>
+): Record<VisibilityKey, boolean> {
+  const byKey = new Map(VISIBILITY_TREE.map((node) => [node.key, node]));
+  const effective = {} as Record<VisibilityKey, boolean>;
+  const resolve = (key: VisibilityKey): boolean => {
+    if (key in effective) return effective[key]!;
+    const node = byKey.get(key);
+    const own = prefs[key] ?? true;
+    const value = own && (node?.parent ? resolve(node.parent) : true);
+    effective[key] = value;
+    return value;
+  };
+  for (const node of VISIBILITY_TREE) resolve(node.key);
+  return effective;
+}
+
+type VisibilityContextValue = {
+  /** The raw, per-checkbox stored preference (what the modal shows as
+   * checked/unchecked). */
+  prefs: Record<VisibilityKey, boolean>;
+  /** `prefs` cascaded through {@link resolveEffectiveVisibility} — what
+   * every rendering call site should actually gate on. */
+  effective: Record<VisibilityKey, boolean>;
+  setPref: (key: VisibilityKey, value: boolean) => void;
+};
+
+/**
+ * Everything visible, `setPref` a no-op — what any consumer sees with no
+ * {@link CourseViewVisibilityProvider} above it. Mirrors the pattern in
+ * `beat-descriptions-context.tsx`: a surface that never mounts the provider
+ * (the Section Workbench, which already curates its own always-show view)
+ * keeps behaving exactly as it does today.
+ */
+const CourseViewVisibilityContext = createContext<VisibilityContextValue>({
+  prefs: DEFAULT_VISIBILITY,
+  effective: DEFAULT_VISIBILITY,
+  setPref: () => {},
+});
+
+/**
+ * Owns the localStorage-backed visibility preferences for one browser (not
+ * per-course — the whole point is a phase-of-work setting like "just beats
+ * and learning goals", which travels with the person, not the course) and
+ * makes them available to the whole course-view subtree via context, so
+ * deeply-nested renderers (a Beat row, a Learning Goal line) can read it
+ * without threading a prop through every intermediate component.
+ */
+export function CourseViewVisibilityProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [raw, setRaw] = useLocalStorage(
+    VISIBILITY_STORAGE_KEY,
+    JSON.stringify(DEFAULT_VISIBILITY)
+  );
+  const prefs = useMemo(() => parsePrefs(raw), [raw]);
+  const effective = useMemo(() => resolveEffectiveVisibility(prefs), [prefs]);
+
+  const setPref = (key: VisibilityKey, value: boolean) => {
+    setRaw(JSON.stringify({ ...prefs, [key]: value }));
+  };
+
+  const value = useMemo(
+    () => ({ prefs, effective, setPref }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [prefs, effective]
+  );
+
+  return (
+    <CourseViewVisibilityContext.Provider value={value}>
+      {children}
+    </CourseViewVisibilityContext.Provider>
+  );
+}
+
+export function useCourseViewVisibility() {
+  return useContext(CourseViewVisibilityContext);
+}

--- a/apps/local/app/features/course-view/lesson-beat-tree.tsx
+++ b/apps/local/app/features/course-view/lesson-beat-tree.tsx
@@ -5,6 +5,7 @@ import { courseViewReducer } from "@/features/course-view/course-view-reducer";
 import type { CourseEditorEvent } from "@/services/course-editor-service";
 import { BeatList } from "@/features/beats/beat-list";
 import { VideoContextMenuItems } from "./video-context-menu";
+import { useCourseViewVisibility } from "./course-view-visibility";
 import type { LoaderData, Lesson, Section, Video } from "./course-view-types";
 
 /**
@@ -83,6 +84,8 @@ function VideoBeatNode({
   isReadOnly: boolean;
   submitEvent: (event: CourseEditorEvent) => void;
 } & VideoMenuProps) {
+  const { effective: visibility } = useCourseViewVisibility();
+
   const videoRow = (
     <Link
       to={`/videos/${video.id}/edit`}
@@ -102,14 +105,18 @@ function VideoBeatNode({
           {...videoMenuProps}
         />
       </ContextMenu>
-      <BeatList
-        video={{ id: video.id, beats: video.beats ?? [] }}
-        submitEvent={submitEvent}
-        isReadOnly={isReadOnly}
-        courseId={videoMenuProps.courseId}
-        sectionId={videoMenuProps.section.id}
-        className="mt-0.5"
-      />
+      {visibility.beats && (
+        <BeatList
+          video={{ id: video.id, beats: video.beats ?? [] }}
+          submitEvent={submitEvent}
+          isReadOnly={isReadOnly}
+          showDescriptions={visibility.beatDescriptions}
+          showAddButton={visibility.addBeatButton}
+          courseId={videoMenuProps.courseId}
+          sectionId={videoMenuProps.section.id}
+          className="mt-0.5"
+        />
+      )}
     </div>
   );
 }

--- a/apps/local/app/features/course-view/section-card.tsx
+++ b/apps/local/app/features/course-view/section-card.tsx
@@ -10,6 +10,7 @@ import { SortableSectionItem } from "./sortable-section-item";
 import { SectionDescriptionEditor } from "./section-description-editor";
 import { SectionLearningGoals } from "./section-learning-goals";
 import { SectionTitleRow } from "./section-title-row";
+import { useCourseViewVisibility } from "./course-view-visibility";
 import { SectionContextMenuItems } from "./section-context-menu";
 import {
   filterLessons,
@@ -112,6 +113,8 @@ export function SectionCard({
   activeLesson: LessonDragState["activeLesson"];
   bulkDragIds: LessonDragState["bulkDragIds"];
 }) {
+  const { effective: visibility } = useCourseViewVisibility();
+
   const lessons = section.lessons;
 
   const { filteredLessons, hasActiveFilters } = filterLessons(lessons, {
@@ -125,11 +128,19 @@ export function SectionCard({
 
   // Dependency Group runs + spine pairs. Only in compact view, and
   // suppressed under any active filter (the rendered list no longer
-  // reflects true adjacency). See CONTEXT.md / docs/adr/0010.
+  // reflects true adjacency). See CONTEXT.md / docs/adr/0010. Also
+  // suppressed when Dependencies or Lesson Types are hidden by the
+  // course-view display settings — the spine's dashed lines are measured
+  // off the lesson-type icon's `data-dep-icon` anchor (see
+  // sortable-lesson-item.tsx / dep-group-spine.tsx), so it has nothing to
+  // draw between once that icon stops rendering.
   const { runs, spinePairs, revalidateKey } = computeSectionDependencyRuns(
     lessons,
     filteredLessons,
-    viewMode === "compact" && !hasActiveFilters
+    viewMode === "compact" &&
+      !hasActiveFilters &&
+      visibility.dependencies &&
+      visibility.lessonTypes
   );
 
   return (
@@ -198,86 +209,93 @@ export function SectionCard({
                       </div>
                     </div>
                   </div>
-                  {viewMode === "expanded" && (
-                    <SectionDescriptionEditor
-                      sectionId={section.id}
-                      description={section.description ?? ""}
-                      isReadOnly={isReadOnly}
-                      submitEvent={submitEvent}
-                    />
-                  )}
+                  {viewMode === "expanded" &&
+                    visibility.sectionDescriptions && (
+                      <SectionDescriptionEditor
+                        sectionId={section.id}
+                        description={section.description ?? ""}
+                        isReadOnly={isReadOnly}
+                        submitEvent={submitEvent}
+                      />
+                    )}
                 </div>
-                <SectionLearningGoals
-                  learningGoals={section.learningGoals}
-                  defaultOpen={singleColumn && lessons.length === 0}
-                />
-                {(!collapsedSections.has(section.id) || searchQuery) && (
-                  <CompactLessonList
-                    pairs={spinePairs}
-                    revalidateKey={revalidateKey}
-                    className={viewMode === "compact" ? "px-2 py-1" : "p-2"}
-                  >
-                    <SortableContext
-                      items={lessons.map((l) => l.id)}
-                      strategy={verticalListSortingStrategy}
-                    >
-                      {hasActiveFilters && filteredLessons.length === 0 && (
-                        <p className="text-xs text-muted-foreground text-center py-3">
-                          No matching lessons
-                        </p>
-                      )}
-                      {runs.map((run) => (
-                        <div
-                          key={run.lessons[0]!.id}
-                          className={runSpacingClass(run.lessons.length > 1)}
-                        >
-                          {run.lessons.map((lesson, idx) => (
-                            <Fragment key={lesson.id}>
-                              {dropIndicator?.targetSectionId === section.id &&
-                                dropIndicator.beforeLessonId === lesson.id && (
-                                  <DropLine />
-                                )}
-                              <SortableLessonItem
-                                courseId={currentCourse.id}
-                                lesson={lesson}
-                                lessonIndex={run.startIndex + idx}
-                                section={section}
-                                data={data}
-                                navigate={navigate}
-                                allFlatLessons={allFlatLessons}
-                                addVideoToLessonId={addVideoToLessonId}
-                                deleteLessonId={deleteLessonId}
-                                editDescriptionLessonId={
-                                  editDescriptionLessonId
-                                }
-                                dispatch={dispatch}
-                                submitEvent={submitEvent}
-                                startExportUpload={startExportUpload}
-                                revealVideoFetcher={revealVideoFetcher}
-                                deleteVideoFileFetcher={deleteVideoFileFetcher}
-                                submitDeleteVideo={submitDeleteVideo}
-                                allSections={currentCourse.sections}
-                                dependencyMap={dependencyMap}
-                                compact={viewMode === "compact"}
-                                isSelected={
-                                  lessonSelection?.sectionId === section.id &&
-                                  lessonSelection.lessonIds.has(lesson.id)
-                                }
-                                isBulkDragPeer={
-                                  bulkDragIds != null &&
-                                  bulkDragIds.has(lesson.id) &&
-                                  lesson.id !== activeLesson?.id
-                                }
-                              />
-                            </Fragment>
-                          ))}
-                        </div>
-                      ))}
-                      {dropIndicator?.targetSectionId === section.id &&
-                        dropIndicator.beforeLessonId === null && <DropLine />}
-                    </SortableContext>
-                  </CompactLessonList>
+                {visibility.learningGoals && (
+                  <SectionLearningGoals
+                    learningGoals={section.learningGoals}
+                    defaultOpen={singleColumn && lessons.length === 0}
+                    showDescriptions={visibility.learningGoalDescriptions}
+                  />
                 )}
+                {visibility.lessons &&
+                  (!collapsedSections.has(section.id) || searchQuery) && (
+                    <CompactLessonList
+                      pairs={spinePairs}
+                      revalidateKey={revalidateKey}
+                      className={viewMode === "compact" ? "px-2 py-1" : "p-2"}
+                    >
+                      <SortableContext
+                        items={lessons.map((l) => l.id)}
+                        strategy={verticalListSortingStrategy}
+                      >
+                        {hasActiveFilters && filteredLessons.length === 0 && (
+                          <p className="text-xs text-muted-foreground text-center py-3">
+                            No matching lessons
+                          </p>
+                        )}
+                        {runs.map((run) => (
+                          <div
+                            key={run.lessons[0]!.id}
+                            className={runSpacingClass(run.lessons.length > 1)}
+                          >
+                            {run.lessons.map((lesson, idx) => (
+                              <Fragment key={lesson.id}>
+                                {dropIndicator?.targetSectionId ===
+                                  section.id &&
+                                  dropIndicator.beforeLessonId ===
+                                    lesson.id && <DropLine />}
+                                <SortableLessonItem
+                                  courseId={currentCourse.id}
+                                  lesson={lesson}
+                                  lessonIndex={run.startIndex + idx}
+                                  section={section}
+                                  data={data}
+                                  navigate={navigate}
+                                  allFlatLessons={allFlatLessons}
+                                  addVideoToLessonId={addVideoToLessonId}
+                                  deleteLessonId={deleteLessonId}
+                                  editDescriptionLessonId={
+                                    editDescriptionLessonId
+                                  }
+                                  dispatch={dispatch}
+                                  submitEvent={submitEvent}
+                                  startExportUpload={startExportUpload}
+                                  revealVideoFetcher={revealVideoFetcher}
+                                  deleteVideoFileFetcher={
+                                    deleteVideoFileFetcher
+                                  }
+                                  submitDeleteVideo={submitDeleteVideo}
+                                  allSections={currentCourse.sections}
+                                  dependencyMap={dependencyMap}
+                                  compact={viewMode === "compact"}
+                                  isSelected={
+                                    lessonSelection?.sectionId === section.id &&
+                                    lessonSelection.lessonIds.has(lesson.id)
+                                  }
+                                  isBulkDragPeer={
+                                    bulkDragIds != null &&
+                                    bulkDragIds.has(lesson.id) &&
+                                    lesson.id !== activeLesson?.id
+                                  }
+                                />
+                              </Fragment>
+                            ))}
+                          </div>
+                        ))}
+                        {dropIndicator?.targetSectionId === section.id &&
+                          dropIndicator.beforeLessonId === null && <DropLine />}
+                      </SortableContext>
+                    </CompactLessonList>
+                  )}
               </div>
             </ContextMenuTrigger>
             <SectionContextMenuItems

--- a/apps/local/app/features/course-view/section-learning-goals.tsx
+++ b/apps/local/app/features/course-view/section-learning-goals.tsx
@@ -47,9 +47,14 @@ function PriorityBadge({ priority }: { priority: number }) {
 export function SectionLearningGoals({
   learningGoals,
   defaultOpen = false,
+  showDescriptions = true,
 }: {
   learningGoals: Section["learningGoals"];
   defaultOpen?: boolean;
+  /** Course-view display setting for the Learning Goal Description note —
+   * see `course-view-visibility.tsx`. Defaults to shown, matching today's
+   * behaviour for any caller that doesn't pass it. */
+  showDescriptions?: boolean;
 }) {
   if (learningGoals.length === 0) {
     return null;
@@ -76,7 +81,7 @@ export function SectionLearningGoals({
                 <p className="font-medium text-foreground">
                   {goal.title || "(untitled)"}
                 </p>
-                {goal.description && (
+                {showDescriptions && goal.description && (
                   <p className="text-muted-foreground">{goal.description}</p>
                 )}
               </div>

--- a/apps/local/app/features/course-view/sortable-lesson-item.tsx
+++ b/apps/local/app/features/course-view/sortable-lesson-item.tsx
@@ -17,6 +17,7 @@ import {
 } from "./lesson-title-editor";
 import { LessonContextMenuContent } from "./lesson-context-menu";
 import { LessonBeatTree } from "./lesson-beat-tree";
+import { useCourseViewVisibility } from "./course-view-visibility";
 import { courseViewReducer } from "@/features/course-view/course-view-reducer";
 import type { CourseEditorEvent } from "@/services/course-editor-service";
 import { VideoThumbnailGrid } from "./video-thumbnail-grid";
@@ -163,6 +164,7 @@ export function SortableLessonItem({
   };
 
   const isReadOnly = !data.isLatestVersion;
+  const { effective: visibility } = useCourseViewVisibility();
 
   const currentDescription = lesson.description ?? "";
   const [editingDesc, setEditingDesc] = useState(false);
@@ -311,42 +313,44 @@ export function SortableLessonItem({
                     <GripVertical className="w-3.5 h-3.5 text-muted-foreground" />
                   </button>
                 )}
-                <button
-                  data-dep-icon={lesson.id}
-                  className={cn(
-                    "flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center transition-colors",
-                    currentIcon === "code"
-                      ? "bg-yellow-500/20 text-yellow-600"
-                      : currentIcon === "discussion"
-                        ? "bg-green-500/20 text-green-600"
-                        : "bg-purple-500/20 text-purple-600"
-                  )}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (!isReadOnly) handleIconCycle();
-                  }}
-                  title={
-                    currentIcon === "code"
-                      ? isReadOnly
-                        ? "Interactive"
-                        : "Interactive (click to change)"
-                      : currentIcon === "discussion"
+                {visibility.lessonTypes && (
+                  <button
+                    data-dep-icon={lesson.id}
+                    className={cn(
+                      "flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center transition-colors",
+                      currentIcon === "code"
+                        ? "bg-yellow-500/20 text-yellow-600"
+                        : currentIcon === "discussion"
+                          ? "bg-green-500/20 text-green-600"
+                          : "bg-purple-500/20 text-purple-600"
+                    )}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (!isReadOnly) handleIconCycle();
+                    }}
+                    title={
+                      currentIcon === "code"
                         ? isReadOnly
-                          ? "Discussion"
-                          : "Discussion (click to change)"
-                        : isReadOnly
-                          ? "Watch"
-                          : "Watch (click to change)"
-                  }
-                >
-                  {currentIcon === "code" ? (
-                    <Code className="w-3 h-3" />
-                  ) : currentIcon === "discussion" ? (
-                    <MessageCircle className="w-3 h-3" />
-                  ) : (
-                    <Play className="w-3 h-3" />
-                  )}
-                </button>
+                          ? "Interactive"
+                          : "Interactive (click to change)"
+                        : currentIcon === "discussion"
+                          ? isReadOnly
+                            ? "Discussion"
+                            : "Discussion (click to change)"
+                          : isReadOnly
+                            ? "Watch"
+                            : "Watch (click to change)"
+                    }
+                  >
+                    {currentIcon === "code" ? (
+                      <Code className="w-3 h-3" />
+                    ) : currentIcon === "discussion" ? (
+                      <MessageCircle className="w-3 h-3" />
+                    ) : (
+                      <Play className="w-3 h-3" />
+                    )}
+                  </button>
+                )}
                 <LessonTitleEditor
                   lesson={lesson}
                   isReadOnly={isReadOnly}
@@ -363,36 +367,41 @@ export function SortableLessonItem({
                     lessonId: lesson.id,
                   })}
                 />
-                <PrioritySelector
-                  priority={currentPriority}
-                  onSelect={handlePrioritySelect}
-                  readOnly={isReadOnly}
-                />
-                <DependencySelector
-                  lessonId={lesson.id}
-                  dependencies={lessonDeps}
-                  allLessons={allFlatLessons}
-                  onDependenciesChange={handleDependenciesChange}
-                  orderViolations={orderViolations}
-                  priorityViolations={priorityViolations}
-                  lessonPriority={lessonPriority}
-                  dependencyMap={dependencyMap}
-                />
-                {lesson.authoringStatus === "todo" && (
-                  <button
-                    className="text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded bg-foreground text-background hover:opacity-80 transition-opacity shrink-0"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      submitEvent({
-                        type: "set-lesson-authoring-status",
-                        lessonId: lesson.id,
-                        status: "done",
-                      });
-                    }}
-                  >
-                    todo
-                  </button>
+                {visibility.lessonPriorities && (
+                  <PrioritySelector
+                    priority={currentPriority}
+                    onSelect={handlePrioritySelect}
+                    readOnly={isReadOnly}
+                  />
                 )}
+                {visibility.dependencies && (
+                  <DependencySelector
+                    lessonId={lesson.id}
+                    dependencies={lessonDeps}
+                    allLessons={allFlatLessons}
+                    onDependenciesChange={handleDependenciesChange}
+                    orderViolations={orderViolations}
+                    priorityViolations={priorityViolations}
+                    lessonPriority={lessonPriority}
+                    dependencyMap={dependencyMap}
+                  />
+                )}
+                {visibility.todoMarkers &&
+                  lesson.authoringStatus === "todo" && (
+                    <button
+                      className="text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded bg-foreground text-background hover:opacity-80 transition-opacity shrink-0"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        submitEvent({
+                          type: "set-lesson-authoring-status",
+                          lessonId: lesson.id,
+                          status: "done",
+                        });
+                      }}
+                    >
+                      todo
+                    </button>
+                  )}
                 {!isReadOnly &&
                   lesson.lessonWarnings &&
                   lesson.lessonWarnings.length > 0 && (
@@ -410,7 +419,7 @@ export function SortableLessonItem({
                     </TooltipProvider>
                   )}
               </div>
-              {!compact && (
+              {!compact && visibility.lessonDescriptions && (
                 <div className="ml-5">
                   {!isReadOnly && editingDesc ? (
                     <div className="mt-1 max-w-[65ch]">
@@ -491,7 +500,7 @@ export function SortableLessonItem({
             submitEvent={submitEvent}
           />
         </Suspense>
-        {!compact && (
+        {!compact && visibility.videos && (
           <div className="ml-5 mt-3">
             <VideoThumbnailGrid
               courseId={courseId}
@@ -508,7 +517,7 @@ export function SortableLessonItem({
             />
           </div>
         )}
-        {compact && (
+        {compact && visibility.videos && (
           <LessonBeatTree
             courseId={courseId}
             lesson={lesson}

--- a/apps/local/app/features/course-view/visibility-settings-modal.tsx
+++ b/apps/local/app/features/course-view/visibility-settings-modal.tsx
@@ -1,0 +1,107 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import { cn } from "@/lib/utils";
+import {
+  VISIBILITY_TREE,
+  useCourseViewVisibility,
+} from "./course-view-visibility";
+
+/**
+ * The "what's cluttering the course view right now" control: a dependency
+ * checkbox tree (see `course-view-visibility.tsx`) rendered as a flat,
+ * indented list — parents before their children, in the same order they
+ * nest on screen. Unchecking a parent greys out (disables) its children
+ * rather than clearing them, so re-checking it brings back whatever they
+ * were set to. Saved to this browser via `CourseViewVisibilityProvider`, so
+ * it follows Matt's phase of work rather than any one course.
+ */
+export function VisibilitySettingsModal({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { prefs, effective, setPref } = useCourseViewVisibility();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Course view display</DialogTitle>
+          <DialogDescription>
+            Choose what's shown on the course view. Sections are always visible;
+            everything else can be toggled off per phase of work. Applies to
+            filters too — you can't filter on something that's hidden.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-0.5 max-h-[60vh] overflow-y-auto -mx-1 px-1">
+          <VisibilityRow label="Sections" checked disabled alwaysOn />
+          {VISIBILITY_TREE.map((node) => {
+            const parentOn = node.parent ? effective[node.parent] : true;
+            return (
+              <VisibilityRow
+                key={node.key}
+                label={node.label}
+                checked={prefs[node.key]}
+                disabled={!parentOn}
+                indented={node.parent !== null}
+                onCheckedChange={(checked) => setPref(node.key, checked)}
+              />
+            );
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function VisibilityRow({
+  label,
+  checked,
+  disabled,
+  indented,
+  alwaysOn,
+  onCheckedChange,
+}: {
+  label: string;
+  checked: boolean;
+  disabled?: boolean;
+  indented?: boolean;
+  alwaysOn?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+}) {
+  const id = `course-view-visibility-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded px-1 py-1 text-sm",
+        indented && "ml-6"
+      )}
+    >
+      <Checkbox
+        id={id}
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={(value) => onCheckedChange?.(value === true)}
+      />
+      <label
+        htmlFor={id}
+        className={cn(disabled ? "text-muted-foreground/50" : "cursor-pointer")}
+      >
+        {label}
+      </label>
+      {alwaysOn && (
+        <span className="text-xs text-muted-foreground/60">
+          (always visible)
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/local/app/routes/_app.courses.$courseId._index.tsx
+++ b/apps/local/app/routes/_app.courses.$courseId._index.tsx
@@ -35,6 +35,7 @@ import type { Route } from "./+types/_app.courses.$courseId._index";
 import { UploadContext } from "@/features/upload-manager/upload-context";
 import { ActionsDropdown } from "@/features/course-view/actions-menu";
 import { AutofillChaptersProvider } from "@/features/course-view/autofill-chapters-context";
+import { CourseViewVisibilityProvider } from "@/features/course-view/course-view-visibility";
 import { SectionGrid } from "@/features/course-view/section-grid";
 import {
   FilterBar,
@@ -272,225 +273,229 @@ export default function Component(props: Route.ComponentProps) {
   }, [displaySections, dispatch]);
 
   return (
-    <AutofillChaptersProvider>
-      <div className="flex flex-1 min-h-0">
-        <div className="flex flex-1 min-w-0 flex-col bg-background text-foreground">
-          <div className="flex-1 overflow-y-auto">
-            <div className="p-6">
-              {currentCourse ? (
-                <>
-                  {/* Title + version + actions */}
-                  <div className="flex items-center gap-2 mb-2">
-                    <h1 className="text-2xl font-bold flex items-center gap-2">
-                      {currentCourse.name}
-                      {loaderData.selectedVersion &&
-                        loaderData.versions.length > 1 && (
-                          <button
-                            onClick={() =>
-                              dispatch({
-                                type: "set-version-selector-modal-open",
-                                open: true,
-                              })
-                            }
-                            className="text-muted-foreground hover:text-foreground transition-colors text-lg font-normal"
-                          >
-                            [{loaderData.selectedVersion.name || "Draft"}]
-                          </button>
-                        )}
-                    </h1>
-                    <ActionsDropdown
-                      currentCourse={currentCourse}
-                      data={loaderData}
-                      dispatch={dispatch}
-                      archiveCourseFetcher={archiveCourseFetcher}
-                      handleBatchExport={handleBatchExport}
-                    />
-                    {courseWarningCount > 0 && (
-                      <span
-                        title={`${courseWarningCount} video warning${courseWarningCount === 1 ? "" : "s"}`}
-                        className="inline-flex items-center gap-1 rounded-md bg-amber-500/15 px-2 py-1 text-xs font-medium text-amber-600 dark:text-amber-400"
-                      >
-                        <AlertTriangle className="w-3 h-3" />
-                        {courseWarningCount} warning
-                        {courseWarningCount === 1 ? "" : "s"}
-                      </span>
-                    )}
-                  </div>
-
-                  {loaderData.selectedVersion &&
-                    !loaderData.isLatestVersion && <ReadOnlyBanner />}
-
-                  <div className="mb-10">
-                    <StatsBar selectedCourse={currentCourse} />
-                  </div>
-
+    <CourseViewVisibilityProvider>
+      <AutofillChaptersProvider>
+        <div className="flex flex-1 min-h-0">
+          <div className="flex flex-1 min-w-0 flex-col bg-background text-foreground">
+            <div className="flex-1 overflow-y-auto">
+              <div className="p-6">
+                {currentCourse ? (
                   <>
-                    {loaderData.isLatestVersion && (
-                      <div className="mb-14">
-                        <NextTodoCard
-                          courseId={selectedCourseId}
-                          sections={displaySections}
-                          data={loaderData}
-                          navigate={navigate}
-                          addVideoToLessonId={addVideoToLessonId}
-                          deleteLessonId={deleteLessonId}
-                          editDescriptionLessonId={editDescriptionLessonId}
+                    {/* Title + version + actions */}
+                    <div className="flex items-center gap-2 mb-2">
+                      <h1 className="text-2xl font-bold flex items-center gap-2">
+                        {currentCourse.name}
+                        {loaderData.selectedVersion &&
+                          loaderData.versions.length > 1 && (
+                            <button
+                              onClick={() =>
+                                dispatch({
+                                  type: "set-version-selector-modal-open",
+                                  open: true,
+                                })
+                              }
+                              className="text-muted-foreground hover:text-foreground transition-colors text-lg font-normal"
+                            >
+                              [{loaderData.selectedVersion.name || "Draft"}]
+                            </button>
+                          )}
+                      </h1>
+                      <ActionsDropdown
+                        currentCourse={currentCourse}
+                        data={loaderData}
+                        dispatch={dispatch}
+                        archiveCourseFetcher={archiveCourseFetcher}
+                        handleBatchExport={handleBatchExport}
+                      />
+                      {courseWarningCount > 0 && (
+                        <span
+                          title={`${courseWarningCount} video warning${courseWarningCount === 1 ? "" : "s"}`}
+                          className="inline-flex items-center gap-1 rounded-md bg-amber-500/15 px-2 py-1 text-xs font-medium text-amber-600 dark:text-amber-400"
+                        >
+                          <AlertTriangle className="w-3 h-3" />
+                          {courseWarningCount} warning
+                          {courseWarningCount === 1 ? "" : "s"}
+                        </span>
+                      )}
+                    </div>
+
+                    {loaderData.selectedVersion &&
+                      !loaderData.isLatestVersion && <ReadOnlyBanner />}
+
+                    <div className="mb-10">
+                      <StatsBar selectedCourse={currentCourse} />
+                    </div>
+
+                    <>
+                      {loaderData.isLatestVersion && (
+                        <div className="mb-14">
+                          <NextTodoCard
+                            courseId={selectedCourseId}
+                            sections={displaySections}
+                            data={loaderData}
+                            navigate={navigate}
+                            addVideoToLessonId={addVideoToLessonId}
+                            deleteLessonId={deleteLessonId}
+                            editDescriptionLessonId={editDescriptionLessonId}
+                            dispatch={dispatch}
+                            submitEvent={submitEvent}
+                            startExportUpload={startExportUpload}
+                            revealVideoFetcher={revealVideoFetcher}
+                            deleteVideoFileFetcher={deleteVideoFileFetcher}
+                            submitDeleteVideo={submitDeleteVideo}
+                            allFlatLessons={allFlatLessons}
+                            dependencyMap={dependencyMap}
+                            dismissed={nextUpDismissed}
+                            onDismiss={() => setNextUpDismissed(true)}
+                          />
+                        </div>
+                      )}
+
+                      <div className="mb-4">
+                        <h2 className="text-lg font-semibold mb-3">
+                          All Lessons
+                        </h2>
+                        <FilterBar
+                          priorityFilter={priorityFilter}
+                          iconFilter={iconFilter}
+                          todoFilter={todoFilter}
+                          todoCount={todoCount}
+                          searchQuery={searchQuery}
+                          viewMode={viewMode}
+                          onToggleViewMode={() =>
+                            setViewMode(
+                              viewMode === "expanded" ? "compact" : "expanded"
+                            )
+                          }
+                          allSectionsCollapsed={allSectionsCollapsed}
+                          onToggleAllSections={handleToggleAllSections}
+                          sectionCount={sectionIds.length}
                           dispatch={dispatch}
-                          submitEvent={submitEvent}
-                          startExportUpload={startExportUpload}
-                          revealVideoFetcher={revealVideoFetcher}
-                          deleteVideoFileFetcher={deleteVideoFileFetcher}
-                          submitDeleteVideo={submitDeleteVideo}
-                          allFlatLessons={allFlatLessons}
-                          dependencyMap={dependencyMap}
-                          dismissed={nextUpDismissed}
-                          onDismiss={() => setNextUpDismissed(true)}
                         />
                       </div>
-                    )}
 
-                    <div className="mb-4">
-                      <h2 className="text-lg font-semibold mb-3">
-                        All Lessons
-                      </h2>
-                      <FilterBar
+                      <SectionGrid
+                        currentCourse={currentCourse}
+                        data={loaderData}
+                        viewMode={viewMode}
+                        sensors={sensors}
+                        handleSectionDragEnd={handleSectionDragEnd}
                         priorityFilter={priorityFilter}
                         iconFilter={iconFilter}
                         todoFilter={todoFilter}
-                        todoCount={todoCount}
                         searchQuery={searchQuery}
-                        viewMode={viewMode}
-                        onToggleViewMode={() =>
-                          setViewMode(
-                            viewMode === "expanded" ? "compact" : "expanded"
-                          )
-                        }
-                        allSectionsCollapsed={allSectionsCollapsed}
-                        onToggleAllSections={handleToggleAllSections}
-                        sectionCount={sectionIds.length}
+                        addLessonSectionId={addLessonSectionId}
+                        insertAdjacentLessonId={insertAdjacentLessonId}
+                        insertPosition={insertPosition}
+                        editSectionId={editSectionId}
+                        addVideoToLessonId={addVideoToLessonId}
+                        deleteLessonId={deleteLessonId}
+                        editDescriptionLessonId={editDescriptionLessonId}
+                        archiveSectionId={archiveSectionId}
+                        collapsedSections={collapsedSections}
+                        toggleSection={toggleSection}
+                        lessonSelection={lessonSelection}
                         dispatch={dispatch}
+                        submitEvent={submitEvent}
+                        navigate={navigate}
+                        startExportUpload={startExportUpload}
+                        revealVideoFetcher={revealVideoFetcher}
+                        deleteVideoFileFetcher={deleteVideoFileFetcher}
+                        submitDeleteVideo={submitDeleteVideo}
                       />
-                    </div>
 
-                    <SectionGrid
-                      currentCourse={currentCourse}
-                      data={loaderData}
-                      viewMode={viewMode}
-                      sensors={sensors}
-                      handleSectionDragEnd={handleSectionDragEnd}
-                      priorityFilter={priorityFilter}
-                      iconFilter={iconFilter}
-                      todoFilter={todoFilter}
-                      searchQuery={searchQuery}
-                      addLessonSectionId={addLessonSectionId}
-                      insertAdjacentLessonId={insertAdjacentLessonId}
-                      insertPosition={insertPosition}
-                      editSectionId={editSectionId}
-                      addVideoToLessonId={addVideoToLessonId}
-                      deleteLessonId={deleteLessonId}
-                      editDescriptionLessonId={editDescriptionLessonId}
-                      archiveSectionId={archiveSectionId}
-                      collapsedSections={collapsedSections}
-                      toggleSection={toggleSection}
-                      lessonSelection={lessonSelection}
-                      dispatch={dispatch}
-                      submitEvent={submitEvent}
-                      navigate={navigate}
-                      startExportUpload={startExportUpload}
-                      revealVideoFetcher={revealVideoFetcher}
-                      deleteVideoFileFetcher={deleteVideoFileFetcher}
-                      submitDeleteVideo={submitDeleteVideo}
-                    />
+                      {loaderData.selectedVersion &&
+                        loaderData.isLatestVersion && (
+                          <div className="mt-8 flex justify-center">
+                            <Button
+                              variant="outline"
+                              className="border-dashed"
+                              onClick={() =>
+                                dispatch({
+                                  type: "set-create-section-modal-open",
+                                  open: true,
+                                })
+                              }
+                            >
+                              <Plus className="w-4 h-4" />
+                              Add Section
+                            </Button>
+                          </div>
+                        )}
+                    </>
 
                     {loaderData.selectedVersion &&
                       loaderData.isLatestVersion && (
-                        <div className="mt-8 flex justify-center">
-                          <Button
-                            variant="outline"
-                            className="border-dashed"
-                            onClick={() =>
-                              dispatch({
-                                type: "set-create-section-modal-open",
-                                open: true,
-                              })
-                            }
-                          >
-                            <Plus className="w-4 h-4" />
-                            Add Section
-                          </Button>
-                        </div>
+                        <CreateSectionModal
+                          repoVersionId={loaderData.selectedVersion.id}
+                          maxOrder={displaySections.length}
+                          open={isCreateSectionModalOpen}
+                          onOpenChange={(open) =>
+                            dispatch({
+                              type: "set-create-section-modal-open",
+                              open,
+                            })
+                          }
+                          onCreateSection={(title) => {
+                            const maxOrder = displaySections.reduce(
+                              (max, s) => Math.max(max, s.order ?? 0),
+                              0
+                            );
+                            submitEvent({
+                              type: "create-section",
+                              repoVersionId: loaderData.selectedVersion!.id,
+                              title,
+                              maxOrder,
+                              ...(insertAdjacentSectionId
+                                ? {
+                                    adjacentSectionId: insertAdjacentSectionId,
+                                    position:
+                                      insertSectionPosition ?? undefined,
+                                  }
+                                : {}),
+                            });
+                          }}
+                        />
                       )}
                   </>
-
-                  {loaderData.selectedVersion && loaderData.isLatestVersion && (
-                    <CreateSectionModal
-                      repoVersionId={loaderData.selectedVersion.id}
-                      maxOrder={displaySections.length}
-                      open={isCreateSectionModalOpen}
-                      onOpenChange={(open) =>
-                        dispatch({
-                          type: "set-create-section-modal-open",
-                          open,
-                        })
-                      }
-                      onCreateSection={(title) => {
-                        const maxOrder = displaySections.reduce(
-                          (max, s) => Math.max(max, s.order ?? 0),
-                          0
-                        );
-                        submitEvent({
-                          type: "create-section",
-                          repoVersionId: loaderData.selectedVersion!.id,
-                          title,
-                          maxOrder,
-                          ...(insertAdjacentSectionId
-                            ? {
-                                adjacentSectionId: insertAdjacentSectionId,
-                                position: insertSectionPosition ?? undefined,
-                              }
-                            : {}),
-                        });
-                      }}
-                    />
-                  )}
-                </>
-              ) : (
-                <div className="text-center py-12">
-                  <h1 className="text-xl font-semibold mb-2">
-                    Course not found
-                  </h1>
-                  <p className="text-muted-foreground">
-                    This course may have been archived or deleted.
-                  </p>
-                </div>
-              )}
+                ) : (
+                  <div className="text-center py-12">
+                    <h1 className="text-xl font-semibold mb-2">
+                      Course not found
+                    </h1>
+                    <p className="text-muted-foreground">
+                      This course may have been archived or deleted.
+                    </p>
+                  </div>
+                )}
+              </div>
             </div>
+
+            <VideoModal
+              videoId={videoPlayerState.videoId}
+              videoTitle={videoPlayerState.videoTitle}
+              isOpen={videoPlayerState.isOpen}
+              onClose={() => {
+                dispatch({ type: "close-video-player" });
+              }}
+            />
+
+            <RouteModals
+              currentCourse={currentCourse}
+              data={loaderData}
+              selectedCourseId={selectedCourseId}
+              viewState={viewState}
+              dispatch={dispatch}
+              navigate={navigate}
+            />
+
+            <DivergenceReportModal
+              report={divergenceReport}
+              onClose={clearDivergenceReport}
+            />
           </div>
-
-          <VideoModal
-            videoId={videoPlayerState.videoId}
-            videoTitle={videoPlayerState.videoTitle}
-            isOpen={videoPlayerState.isOpen}
-            onClose={() => {
-              dispatch({ type: "close-video-player" });
-            }}
-          />
-
-          <RouteModals
-            currentCourse={currentCourse}
-            data={loaderData}
-            selectedCourseId={selectedCourseId}
-            viewState={viewState}
-            dispatch={dispatch}
-            navigate={navigate}
-          />
-
-          <DivergenceReportModal
-            report={divergenceReport}
-            onClose={clearDivergenceReport}
-          />
         </div>
-      </div>
-    </AutofillChaptersProvider>
+      </AutofillChaptersProvider>
+    </CourseViewVisibilityProvider>
   );
 }


### PR DESCRIPTION
## Summary

The course view always shows everything — beats, learning goals, lesson priorities/types/to-dos/dependencies, videos — even though any given phase of work only needs a slice of it. Adds a **Course view display settings** modal (new toolbar button next to the compact/expanded toggle) with a dependency checkbox tree, persisted per browser via `localStorage`.

```mermaid
graph TD
  Sections["Sections (always visible)"]
  Sections --> SD["Section descriptions"]
  Sections --> LG["Learning goals"]
  LG --> LGD["Learning goal descriptions"]
  Sections --> L["Lessons"]
  L --> LD["Lesson descriptions"]
  L --> LP["Lesson priorities"]
  L --> LT["Lesson types"]
  L --> TM["To-do markers"]
  L --> DEP["Dependencies"]
  L --> V["Videos"]
  V --> B["Beats"]
  B --> BD["Beat descriptions"]
  B --> AB["Add beat button"]
```

- Unchecking a parent (e.g. **Lessons**, or a Video's **Beats**) greys out and suppresses its children in the modal — without discarding their own stored preference, so re-checking the parent restores whatever they were set to.
- The filter bar reads the same preferences: a filter control (priority, lesson type, to-do) only renders — and only applies — while its underlying field is visible. Turning a field off clears any active filter on it, so there's never a hidden filter silently narrowing the list.
- **Defaults reproduce today's course view exactly** (Beat Descriptions stay off by default, matching the existing `BeatDescriptionsContext` behaviour) — shipping this changes nothing on screen until someone opens the modal.
- The Section Workbench is untouched — it doesn't mount `CourseViewVisibilityProvider`, so it keeps showing everything, same as today.

## Where it lives

```
apps/local/app/features/course-view/
├── course-view-visibility.tsx        (new) tree + cascade + context/provider
├── course-view-visibility.test.ts    (new) cascade unit tests
├── visibility-settings-modal.tsx     (new) the checkbox-tree Dialog
├── course-view-reducer.ts            + isVisibilitySettingsModalOpen, clear-*-filter actions
├── course-view-components.tsx        FilterBar gates + clears filters, new toolbar button; RouteModals renders the modal
├── section-card.tsx                  gates section/learning-goal descriptions, learning goals, lessons, dep spine
├── section-learning-goals.tsx        + showDescriptions prop
├── sortable-lesson-item.tsx          gates type icon, priority, dependency, todo pill, description, videos
└── lesson-beat-tree.tsx              gates BeatList, passes showDescriptions/showAddButton
apps/local/app/features/beats/beat-list.tsx  + showAddButton prop
apps/local/app/routes/_app.courses.$courseId._index.tsx  wraps the page in CourseViewVisibilityProvider
CONTEXT.md                            + Course View Display Settings glossary entry, updated Beat Description entry
```

One coupling worth flagging in review: the Dependency Group spine (the dashed lines in compact view) measures off the lesson-type icon's `data-dep-icon` anchor, so it's suppressed whenever either **Dependencies** or **Lesson types** is hidden — see the comment in `section-card.tsx`.

## Test plan

- [x] `pnpm --filter @cvm/local run typecheck`
- [x] `pnpm --filter @cvm/local run lint:boundaries`
- [x] `pnpm --filter @cvm/local test -- app/features/course-view app/features/beats` (382 tests)
- [x] pre-commit hooks (prettier, typecheck, boundaries) passed on commit
- [ ] Manual: open the modal, hide Learning goals + everything under Lessons except Videos, confirm compact and expanded views both react and filters disappear/clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)