### PR TITLE
Add bulk section and lesson Beat lists

### DIFF
--- a/apps/local/app/cli/cli-integration.test.ts
+++ b/apps/local/app/cli/cli-integration.test.ts
@@ -304,6 +304,70 @@ describe("archived filtering", () => {
     expect(rows.every((r) => r.archived === false)).toBe(true);
   });
 
+  it("beat list --section returns its active beats as the existing NDJSON rows", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "beat",
+      "list",
+      "--section",
+      s.draftSectionId,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(ndjson(stdout)).toMatchObject([
+      { videoId: s.lessonVideoId, title: "Active beat", archived: false },
+    ]);
+  });
+
+  it("beat list --lesson returns its active beats as the existing NDJSON rows", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "beat",
+      "list",
+      "--lesson",
+      s.lessonId,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(ndjson(stdout)).toMatchObject([
+      { videoId: s.lessonVideoId, title: "Active beat", archived: false },
+    ]);
+  });
+
+  it("beat list rejects archived section and lesson scopes as not found", async () => {
+    const archivedSection = await run([
+      "beat",
+      "list",
+      "--section",
+      s.archivedSectionId,
+    ]);
+    const archivedLesson = await run([
+      "beat",
+      "list",
+      "--lesson",
+      s.archivedLessonId,
+    ]);
+
+    expect(archivedSection.exitCode).toBe(2);
+    expect(JSON.parse(archivedSection.stderr)).toMatchObject({
+      _tag: "NotFoundError",
+      entity: "section",
+    });
+    expect(archivedLesson.exitCode).toBe(2);
+    expect(JSON.parse(archivedLesson.stderr)).toMatchObject({
+      _tag: "NotFoundError",
+      entity: "lesson",
+    });
+  });
+
+  it("beat list requires exactly one hierarchy scope", async () => {
+    const { stdout, stderr, exitCode } = await run(["beat", "list"]);
+
+    expect(exitCode).toBe(3);
+    expect(stdout).toBe("");
+    expect(JSON.parse(stderr)).toMatchObject({ _tag: "ParseError" });
+  });
+
   it("clip get on an archived clip id => NotFoundError, exit 2", async () => {
     const { stdout, stderr, exitCode } = await run([
       "clip",

--- a/apps/local/app/cli/cli-layer.test.ts
+++ b/apps/local/app/cli/cli-layer.test.ts
@@ -158,6 +158,14 @@ const GROUPS = [
     body: ["video_1"],
   },
   {
+    group: "beat bulk list",
+    tag: BeatOperationsService,
+    method: "listBeatsByScope",
+    args: [{ sectionId: "section_1" }],
+    path: "/rpc/beat/listBeatsByScope",
+    body: [{ sectionId: "section_1" }],
+  },
+  {
     group: "pitch",
     tag: PitchOperationsService,
     method: "listPitches",

--- a/apps/local/app/cli/commands/beat.help.ts
+++ b/apps/local/app/cli/commands/beat.help.ts
@@ -40,7 +40,7 @@ Output fields: id, videoId, kind, title, description (never published), order
 archived, createdAt.
 
 Verbs (flags come BEFORE the positional <id> — a flag after it exits 3):
-  list   --video <id>              A Video's full ordered plan (active only)
+  list   --video|--lesson|--section <id>  An active hierarchy scope's ordered plan
   add    --video|--pitch <id> [flags]  Create a Beat in a Video's plan
                                    (--pitch targets a pitch's video)
   update [flags] <id>              Patch title/description/kind/learning goals
@@ -51,27 +51,35 @@ Every write echoes the affected row as one pretty JSON object.
 
 Examples:
   cvm beat list --video vid_123
+  cvm beat list --lesson les_123
+  cvm beat list --section sec_123
   cvm beat add --video vid_123 --kind quest --title "Try it"
   cvm beat update --title "Setup" --kind walkthrough seg_456
   cvm beat move --video vid_123 --after seg_789 seg_456
   cvm beat delete seg_456`;
 
-export const LIST_HELP = `List a Video's full, ordered Beat plan as NDJSON (one compact JSON object
-per line; empty plan prints nothing). Requires --video <videoId>.
+export const LIST_HELP = `List an active Video, Lesson, or Section's full, ordered Beat plan as NDJSON
+(one compact JSON object per line; empty plan prints nothing). Requires EXACTLY
+ONE of --video <videoId>, --lesson <lessonId>, or --section <sectionId>.
 
-The list is the COMPLETE active plan, already sorted by 'order' ascending (plan
-order). Archived (deleted) Beats are always excluded — there is no flag to
-include them.
+The list is the COMPLETE active plan. A Video's Beats sort by 'order' ascending
+(plan order). A Lesson's Videos sort by title, then their Beats by plan order.
+A Section's Lessons sort by order, then each Lesson's Videos by title, then
+their Beats by plan order. Archived (deleted) Beats and archived hierarchy
+records are always excluded — there is no flag to include them.
 
 Each line carries: id, videoId, kind (definition|walkthrough|playthrough|quest|
 reaction), title, description (in-app planning note; never published), order
 (fractional sort key), learningGoalIds (Learning Goals this Beat serves),
 archived (always false), createdAt.
 
-Find a video id with 'cvm video list' or 'cvm video tree <id>'.
+Find ids with 'cvm video list', 'cvm lesson list --section <id>', or
+'cvm section list --course <id>'.
 
 Examples:
   cvm beat list --video vid_123
+  cvm beat list --lesson les_123
+  cvm beat list --section sec_123
   cvm beat list --video vid_123 | jq -r '.title'
   cvm beat list --video vid_123 | jq -r 'select(.kind=="walkthrough") | .id'`;
 

--- a/apps/local/app/cli/commands/beat.ts
+++ b/apps/local/app/cli/commands/beat.ts
@@ -26,9 +26,22 @@ import {
 // ---------------------------------------------------------------------------
 
 const videoListOption = Options.text("video").pipe(
+  Options.withDescription("The parent Video id whose Beat plan to list."),
+  Options.optional
+);
+
+const lessonListOption = Options.text("lesson").pipe(
   Options.withDescription(
-    "The parent Video id whose Beat plan to list (required)."
-  )
+    "The parent Lesson id whose Videos' Beat plans to list."
+  ),
+  Options.optional
+);
+
+const sectionListOption = Options.text("section").pipe(
+  Options.withDescription(
+    "The parent Section id whose Lessons' Beat plans to list."
+  ),
+  Options.optional
 );
 
 const videoTargetOption = Options.text("video").pipe(
@@ -228,12 +241,48 @@ const resolveLearningGoalIds = (learningGoalIds: readonly string[]) =>
 // Verbs
 // ---------------------------------------------------------------------------
 
-const listCmd = Command.make("list", { video: videoListOption }, ({ video }) =>
-  Effect.gen(function* () {
-    const svc = yield* BeatOperationsService;
-    const rows = yield* svc.listBeatsByVideoId(video);
-    yield* emitNdjson(rows);
-  })
+const listCmd = Command.make(
+  "list",
+  {
+    video: videoListOption,
+    lesson: lessonListOption,
+    section: sectionListOption,
+  },
+  ({ video, lesson, section }) =>
+    Effect.gen(function* () {
+      const svc = yield* BeatOperationsService;
+      const videoId = Option.getOrUndefined(video);
+      const lessonId = Option.getOrUndefined(lesson);
+      const sectionId = Option.getOrUndefined(section);
+      const scopeCount = [videoId, lessonId, sectionId].filter(
+        (id) => id !== undefined
+      ).length;
+      if (scopeCount !== 1) {
+        return yield* parseError(
+          "beat list needs exactly one of --video / --lesson / --section",
+          "beat"
+        );
+      }
+      const rows =
+        videoId !== undefined
+          ? yield* svc.listBeatsByVideoId(videoId)
+          : lessonId !== undefined
+            ? yield* svc
+                .listBeatsByScope({ lessonId })
+                .pipe(
+                  Effect.catchTag("NotFoundError", () =>
+                    notFound("lesson", lessonId)
+                  )
+                )
+            : yield* svc
+                .listBeatsByScope({ sectionId: sectionId! })
+                .pipe(
+                  Effect.catchTag("NotFoundError", () =>
+                    notFound("section", sectionId!)
+                  )
+                );
+      yield* emitNdjson(rows);
+    })
 ).pipe(Command.withDescription(detail(LIST_HELP)));
 
 const addCmd = Command.make(

--- a/apps/local/app/cli/rpc-layer.ts
+++ b/apps/local/app/cli/rpc-layer.ts
@@ -282,6 +282,9 @@ const beatService = (client: RpcClient) =>
     listBeatsByVideoId: rpcMethod((json) =>
       client.rpc.beat.listBeatsByVideoId.$post({ json })
     ),
+    listBeatsByScope: rpcMethod((json) =>
+      client.rpc.beat.listBeatsByScope.$post({ json })
+    ),
     getBeatById: rpcMethod((json) =>
       client.rpc.beat.getBeatById.$post({ json })
     ),

--- a/apps/remote/routes/beat.ts
+++ b/apps/remote/routes/beat.ts
@@ -17,6 +17,10 @@ export const beatRoutes = (runtime: RemoteRuntime) =>
       forward(runtime, BeatOperationsService, "listBeatsByVideoId")
     )
     .post(
+      "/listBeatsByScope",
+      forward(runtime, BeatOperationsService, "listBeatsByScope")
+    )
+    .post(
       "/getBeatById",
       forward(runtime, BeatOperationsService, "getBeatById")
     )

--- a/packages/core/services/db-beat-operations.list.test.ts
+++ b/packages/core/services/db-beat-operations.list.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "@effect/vitest";
+import { beforeAll, beforeEach } from "vitest";
+import { Effect, Layer } from "effect";
+import { BeatOperationsService } from "./db-beat-operations.server.js";
+import { DrizzleService } from "./drizzle-service.server.js";
+import {
+  beats,
+  courses,
+  courseVersions,
+  lessons,
+  sections,
+  videos,
+} from "../db/schema.js";
+import {
+  createTestDb,
+  truncateAllTables,
+  type TestDb,
+} from "../test-utils/pglite.js";
+
+let testDb: TestDb;
+let testLayer: Layer.Layer<BeatOperationsService>;
+
+beforeAll(async () => {
+  const result = await createTestDb();
+  testDb = result.testDb;
+  testLayer = BeatOperationsService.Default.pipe(
+    Layer.provide(Layer.succeed(DrizzleService, testDb as any))
+  );
+});
+
+beforeEach(async () => {
+  await truncateAllTables(testDb);
+});
+
+describe("listBeatsByScope", () => {
+  it.effect(
+    "lists a section's active beats in lesson, video title, then beat order",
+    () =>
+      Effect.gen(function* () {
+        const [course] = yield* Effect.promise(() =>
+          testDb.insert(courses).values({ name: "course" }).returning()
+        );
+        const [version] = yield* Effect.promise(() =>
+          testDb
+            .insert(courseVersions)
+            .values({ repoId: course!.id, name: "v1" })
+            .returning()
+        );
+        yield* Effect.promise(() =>
+          testDb.insert(sections).values([
+            { id: "section-early", repoVersionId: version!.id, order: 1 },
+            { id: "section-late", repoVersionId: version!.id, order: 2 },
+          ])
+        );
+        yield* Effect.promise(() =>
+          testDb.insert(lessons).values([
+            { id: "lesson-early", sectionId: "section-early", order: 1 },
+            { id: "lesson-late", sectionId: "section-early", order: 2 },
+            { id: "lesson-other", sectionId: "section-late", order: 1 },
+          ])
+        );
+        yield* Effect.promise(() =>
+          testDb.insert(videos).values([
+            {
+              id: "video-z",
+              lessonId: "lesson-early",
+              title: "z.mp4",
+              originalFootagePath: "/z",
+            },
+            {
+              id: "video-a",
+              lessonId: "lesson-early",
+              title: "a.mp4",
+              originalFootagePath: "/a",
+            },
+            {
+              id: "video-late",
+              lessonId: "lesson-late",
+              title: "late.mp4",
+              originalFootagePath: "/late",
+            },
+            {
+              id: "video-archived",
+              lessonId: "lesson-late",
+              title: "archived.mp4",
+              originalFootagePath: "/archived",
+              archived: true,
+            },
+            {
+              id: "video-other",
+              lessonId: "lesson-other",
+              title: "other.mp4",
+              originalFootagePath: "/other",
+            },
+          ])
+        );
+        yield* Effect.promise(() =>
+          testDb.insert(beats).values([
+            { id: "beat-z", videoId: "video-z", order: "0001" },
+            { id: "beat-a-second", videoId: "video-a", order: "0002" },
+            { id: "beat-a-first", videoId: "video-a", order: "0001" },
+            { id: "beat-late", videoId: "video-late", order: "0001" },
+            {
+              id: "beat-archived-video",
+              videoId: "video-archived",
+              order: "0001",
+            },
+            {
+              id: "beat-archived",
+              videoId: "video-late",
+              order: "0002",
+              archived: true,
+            },
+            { id: "beat-other", videoId: "video-other", order: "0001" },
+          ])
+        );
+        const svc = yield* BeatOperationsService;
+
+        const listed = yield* svc.listBeatsByScope({
+          sectionId: "section-early",
+        });
+
+        expect(listed.map((beat) => beat.id)).toEqual([
+          "beat-a-first",
+          "beat-a-second",
+          "beat-z",
+          "beat-late",
+        ]);
+      }).pipe(Effect.provide(testLayer))
+  );
+});

--- a/packages/core/services/db-beat-operations.server.ts
+++ b/packages/core/services/db-beat-operations.server.ts
@@ -1,11 +1,17 @@
 import { DrizzleService, type Database } from "./drizzle-service.server.js";
-import { beatLearningGoals, beats } from "../db/schema.js";
+import {
+  beatLearningGoals,
+  beats,
+  lessons,
+  sections,
+  videos,
+} from "../db/schema.js";
 import { NotFoundError, UnknownDBServiceError } from "./db-service-errors.js";
 import {
   DEFAULT_BEAT_KIND,
   type BeatKind,
 } from "../features/beats/beat-kinds.js";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, isNull } from "drizzle-orm";
 import { generateNKeysBetween } from "fractional-indexing";
 import { Effect } from "effect";
 
@@ -43,6 +49,9 @@ const withLearningGoalIds = <
   };
 };
 
+export type BeatListScope =
+  { readonly lessonId: string } | { readonly sectionId: string };
+
 export const createBeatOperations = (db: Database) => {
   /** Non-archived beats of a video, sorted by their fractional `order` key. */
   const listBeatsByVideoId = (videoId: string) =>
@@ -58,6 +67,77 @@ export const createBeatOperations = (db: Database) => {
         },
       })
     ).pipe(Effect.map((rows) => rows.map(withLearningGoalIds)));
+
+  const listBeatsByScope = Effect.fn("listBeatsByScope")(function* (
+    scope: BeatListScope
+  ) {
+    const beatQuery = {
+      where: eq(beats.archived, false),
+      orderBy: asc(beats.order),
+      with: {
+        beatLearningGoals: {
+          columns: { learningGoalId: true },
+          with: { learningGoal: { columns: { archived: true } } },
+        },
+      },
+    } as const;
+
+    if ("sectionId" in scope) {
+      const section = yield* makeDbCall(() =>
+        db.query.sections.findFirst({
+          where: and(
+            eq(sections.id, scope.sectionId),
+            isNull(sections.archivedAt)
+          ),
+          with: {
+            lessons: {
+              where: eq(lessons.archived, false),
+              orderBy: asc(lessons.order),
+              with: {
+                videos: {
+                  where: eq(videos.archived, false),
+                  orderBy: asc(videos.title),
+                  with: { beats: beatQuery },
+                },
+              },
+            },
+          },
+        })
+      );
+      if (!section) {
+        return yield* new NotFoundError({
+          type: "section",
+          params: { id: scope.sectionId },
+        });
+      }
+      return section.lessons.flatMap((lesson) =>
+        lesson.videos.flatMap((video) => video.beats.map(withLearningGoalIds))
+      );
+    }
+
+    const lesson = yield* makeDbCall(() =>
+      db.query.lessons.findFirst({
+        where: and(eq(lessons.id, scope.lessonId), eq(lessons.archived, false)),
+        with: {
+          section: { columns: { archivedAt: true } },
+          videos: {
+            where: eq(videos.archived, false),
+            orderBy: asc(videos.title),
+            with: { beats: beatQuery },
+          },
+        },
+      })
+    );
+    if (!lesson || lesson.section.archivedAt !== null) {
+      return yield* new NotFoundError({
+        type: "lesson",
+        params: { id: scope.lessonId },
+      });
+    }
+    return lesson.videos.flatMap((video) =>
+      video.beats.map(withLearningGoalIds)
+    );
+  });
 
   /**
    * Create a Beat in the Video's plan, with the given `title` (default
@@ -271,6 +351,7 @@ export const createBeatOperations = (db: Database) => {
 
   return {
     listBeatsByVideoId,
+    listBeatsByScope,
     getBeatById: requireBeat,
     createBeat,
     renameBeat,

--- a/packages/core/services/db-beat-operations.server.ts
+++ b/packages/core/services/db-beat-operations.server.ts
@@ -52,6 +52,11 @@ const withLearningGoalIds = <
 export type BeatListScope =
   { readonly lessonId: string } | { readonly sectionId: string };
 
+const beatLearningGoalsQuery = {
+  columns: { learningGoalId: true },
+  with: { learningGoal: { columns: { archived: true } } },
+} as const;
+
 export const createBeatOperations = (db: Database) => {
   /** Non-archived beats of a video, sorted by their fractional `order` key. */
   const listBeatsByVideoId = (videoId: string) =>
@@ -60,10 +65,7 @@ export const createBeatOperations = (db: Database) => {
         where: and(eq(beats.videoId, videoId), eq(beats.archived, false)),
         orderBy: asc(beats.order),
         with: {
-          beatLearningGoals: {
-            columns: { learningGoalId: true },
-            with: { learningGoal: { columns: { archived: true } } },
-          },
+          beatLearningGoals: beatLearningGoalsQuery,
         },
       })
     ).pipe(Effect.map((rows) => rows.map(withLearningGoalIds)));
@@ -75,10 +77,7 @@ export const createBeatOperations = (db: Database) => {
       where: eq(beats.archived, false),
       orderBy: asc(beats.order),
       with: {
-        beatLearningGoals: {
-          columns: { learningGoalId: true },
-          with: { learningGoal: { columns: { archived: true } } },
-        },
+        beatLearningGoals: beatLearningGoalsQuery,
       },
     } as const;
 


### PR DESCRIPTION
Closes #1612

```mermaid
flowchart LR
  S[--section] --> L[Lessons: fractional order]
  L --> V[Videos: title]
  V --> B[Beats: fractional order]
  Q[--lesson] --> V
  P[--video] --> B
  B --> N[Existing NDJSON Beat rows]
```

```diff
 cvm beat list
   --video <id>
+  --lesson <id>   # Videos by title, then Beats by order
+  --section <id>  # Lessons by order, Videos by title, Beats by order
```

- Preserves the current compact, one-Beat-per-line NDJSON contract.
- Excludes archived Beats, Videos, Lessons, and Sections.
- An explicitly archived Lesson or Section returns the normal not-found result.
- Wires the scope query through core, the remote RPC route, and the CLI transport.