### PR TITLE
Make cvm RPC call mappings and forwarding type-safe

### DIFF
--- a/apps/local/app/cli/cli-error-round-trip.test.ts
+++ b/apps/local/app/cli/cli-error-round-trip.test.ts
@@ -1,14 +1,16 @@
 import { Effect } from "effect";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { BeatOperationsService } from "@/services/db-beat-operations.server";
-import { ClipOperationsService } from "@/services/db-clip-operations.server";
-import { CourseOperationsService } from "@/services/db-course-operations.server";
-import { DeliverableOperationsService } from "@/services/db-deliverable-operations.server";
-import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
-import { PitchOperationsService } from "@/services/db-pitch-operations.server";
-import { SearchOperationsService } from "@/services/db-search-operations.server";
-import { VersionOperationsService } from "@/services/db-version-operations.server";
-import { VideoOperationsService } from "@/services/db-video-operations.server";
+import {
+  BeatOperationsService,
+  ClipOperationsService,
+  CourseOperationsService,
+  DeliverableOperationsService,
+  LessonSectionOperationsService,
+  PitchOperationsService,
+  SearchOperationsService,
+  VersionOperationsService,
+  VideoOperationsService,
+} from "./rpc-services";
 import {
   ClipNotZoomableError,
   NotFoundError,

--- a/apps/local/app/cli/cli-layer.test.ts
+++ b/apps/local/app/cli/cli-layer.test.ts
@@ -110,11 +110,27 @@ const GROUPS = [
     body: ["version_1"],
   },
   {
+    group: "section archive",
+    tag: LessonSectionOperationsService,
+    method: "archiveSection",
+    args: ["section_1"],
+    path: "/rpc/section/archiveSection",
+    body: ["section_1"],
+  },
+  {
     group: "lesson",
     tag: LessonSectionOperationsService,
     method: "getLessonById",
     args: ["lesson_1"],
     path: "/rpc/lesson/getLessonById",
+    body: ["lesson_1"],
+  },
+  {
+    group: "lesson delete",
+    tag: LessonSectionOperationsService,
+    method: "deleteLesson",
+    args: ["lesson_1"],
+    path: "/rpc/lesson/deleteLesson",
     body: ["lesson_1"],
   },
   {

--- a/apps/local/app/cli/cli-layer.test.ts
+++ b/apps/local/app/cli/cli-layer.test.ts
@@ -142,12 +142,36 @@ const GROUPS = [
     body: [["clip_1", "clip_2"]],
   },
   {
+    group: "clip archive",
+    tag: ClipOperationsService,
+    method: "archiveClip",
+    args: ["clip_1"],
+    path: "/rpc/clip/archiveClip",
+    body: ["clip_1"],
+  },
+  {
+    group: "chapter archive",
+    tag: ClipOperationsService,
+    method: "archiveChapter",
+    args: ["chapter_1"],
+    path: "/rpc/chapter/archiveChapter",
+    body: ["chapter_1"],
+  },
+  {
     group: "overlay",
     tag: OverlayOperationsService,
     method: "listOverlaysByVideoId",
     args: ["video_1", null],
     path: "/rpc/overlay/listOverlaysByVideoId",
     body: ["video_1", null],
+  },
+  {
+    group: "overlay delete",
+    tag: OverlayOperationsService,
+    method: "deleteOverlay",
+    args: ["overlay_1"],
+    path: "/rpc/overlay/deleteOverlay",
+    body: ["overlay_1"],
   },
   {
     group: "beat",
@@ -166,6 +190,14 @@ const GROUPS = [
     body: [{ sectionId: "section_1" }],
   },
   {
+    group: "beat delete",
+    tag: BeatOperationsService,
+    method: "deleteBeat",
+    args: ["beat_1"],
+    path: "/rpc/beat/deleteBeat",
+    body: ["beat_1"],
+  },
+  {
     group: "pitch",
     tag: PitchOperationsService,
     method: "listPitches",
@@ -180,6 +212,14 @@ const GROUPS = [
     args: [],
     path: "/rpc/deliverable/listDeliverables",
     body: [],
+  },
+  {
+    group: "deliverable archive",
+    tag: DeliverableOperationsService,
+    method: "archiveDeliverable",
+    args: ["deliverable_1"],
+    path: "/rpc/deliverable/archiveDeliverable",
+    body: ["deliverable_1"],
   },
 ] as const;
 

--- a/apps/local/app/cli/cli-layer.test.ts
+++ b/apps/local/app/cli/cli-layer.test.ts
@@ -4,17 +4,19 @@ import {
 } from "@cvm/core/rpc/schema-version";
 import { Effect } from "effect";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { BeatOperationsService } from "@/services/db-beat-operations.server";
-import { ClipOperationsService } from "@/services/db-clip-operations.server";
-import { CourseOperationsService } from "@/services/db-course-operations.server";
-import { CourseWriteService } from "@/services/course-write-service";
-import { DeliverableOperationsService } from "@/services/db-deliverable-operations.server";
-import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
-import { OverlayOperationsService } from "@/services/db-overlay-operations.server";
-import { PitchOperationsService } from "@/services/db-pitch-operations.server";
-import { SearchOperationsService } from "@/services/db-search-operations.server";
-import { VersionOperationsService } from "@/services/db-version-operations.server";
-import { VideoOperationsService } from "@/services/db-video-operations.server";
+import {
+  BeatOperationsService,
+  ClipOperationsService,
+  CourseOperationsService,
+  CourseWriteService,
+  DeliverableOperationsService,
+  LessonSectionOperationsService,
+  OverlayOperationsService,
+  PitchOperationsService,
+  SearchOperationsService,
+  VersionOperationsService,
+  VideoOperationsService,
+} from "./rpc-services";
 import { cliLayer } from "./layer";
 
 // ===========================================================================

--- a/apps/local/app/cli/commands/beat.ts
+++ b/apps/local/app/cli/commands/beat.ts
@@ -1,8 +1,10 @@
 import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
-import { BeatOperationsService } from "@/services/db-beat-operations.server";
-import { PitchOperationsService } from "@/services/db-pitch-operations.server";
-import { LearningGoalOperationsService } from "@/services/db-learning-goal-operations.server";
+import {
+  BeatOperationsService,
+  LearningGoalOperationsService,
+  PitchOperationsService,
+} from "@/cli/rpc-services";
 import { BEAT_KINDS, DEFAULT_BEAT_KIND } from "@/features/beats/beat-kinds";
 import {
   detail,

--- a/apps/local/app/cli/commands/chapter.ts
+++ b/apps/local/app/cli/commands/chapter.ts
@@ -1,7 +1,9 @@
 import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
-import { ClipOperationsService } from "@/services/db-clip-operations.server";
-import { VideoOperationsService } from "@/services/db-video-operations.server";
+import {
+  ClipOperationsService,
+  VideoOperationsService,
+} from "@/cli/rpc-services";
 import {
   detail,
   emitNdjson,

--- a/apps/local/app/cli/commands/clip.ts
+++ b/apps/local/app/cli/commands/clip.ts
@@ -1,7 +1,9 @@
 import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
-import { ClipOperationsService } from "@/services/db-clip-operations.server";
-import { VideoOperationsService } from "@/services/db-video-operations.server";
+import {
+  ClipOperationsService,
+  VideoOperationsService,
+} from "@/cli/rpc-services";
 import {
   detail,
   emitNdjson,

--- a/apps/local/app/cli/commands/course-readiness.ts
+++ b/apps/local/app/cli/commands/course-readiness.ts
@@ -1,10 +1,13 @@
 import { Args, Command, Options } from "@effect/cli";
 import { ConfigProvider, Effect } from "effect";
 import { NodeContext } from "@effect/platform-node";
-import { CourseOperationsService } from "@/services/db-course-operations.server";
+import {
+  CourseOperationsService,
+  VersionOperationsService,
+} from "@/cli/rpc-services";
 import {
   PUBLISH_BLOCKING_LISTS,
-  validatePublishability,
+  validatePublishabilityWith,
 } from "@/services/course-publish-readiness";
 import { loadRepoEnv } from "@/cli/env";
 import {
@@ -164,7 +167,11 @@ export const readinessCmd = Command.make(
       }
 
       const versionId = yield* resolveVersionId({ courseId, version });
-      const readiness = yield* validatePublishability(versionId);
+      const versionOps = yield* VersionOperationsService;
+      const readiness = yield* validatePublishabilityWith(
+        versionId,
+        versionOps.getVersionWithSections
+      );
       const position = includeTodoLessons
         ? readiness.withTodo
         : readiness.withoutTodo;

--- a/apps/local/app/cli/commands/course.ts
+++ b/apps/local/app/cli/commands/course.ts
@@ -3,8 +3,10 @@ import { Effect } from "effect";
 import { courseSearchCmd } from "./search";
 import { publishCmd } from "./course-publish";
 import { readinessCmd } from "./course-readiness";
-import { CourseOperationsService } from "@/services/db-course-operations.server";
-import { VersionOperationsService } from "@/services/db-version-operations.server";
+import {
+  CourseOperationsService,
+  VersionOperationsService,
+} from "@/cli/rpc-services";
 import {
   detail,
   emitGet,

--- a/apps/local/app/cli/commands/deliverable.ts
+++ b/apps/local/app/cli/commands/deliverable.ts
@@ -1,8 +1,10 @@
 import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
-import { DeliverableOperationsService } from "@/services/db-deliverable-operations.server";
-import { CourseOperationsService } from "@/services/db-course-operations.server";
-import { PitchOperationsService } from "@/services/db-pitch-operations.server";
+import {
+  CourseOperationsService,
+  DeliverableOperationsService,
+  PitchOperationsService,
+} from "@/cli/rpc-services";
 import {
   detail,
   emitGet,

--- a/apps/local/app/cli/commands/file.ts
+++ b/apps/local/app/cli/commands/file.ts
@@ -2,7 +2,7 @@ import { Args, Command, Options } from "@effect/cli";
 import { FileSystem } from "@effect/platform";
 import { Effect, Option } from "effect";
 import path from "node:path";
-import { VideoOperationsService } from "@/services/db-video-operations.server";
+import { VideoOperationsService } from "@/cli/rpc-services";
 import {
   deleteVideoFile,
   InvalidVideoFilePathError,

--- a/apps/local/app/cli/commands/learning-goal.ts
+++ b/apps/local/app/cli/commands/learning-goal.ts
@@ -1,9 +1,7 @@
 import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
-import {
-  LearningGoalOperationsService,
-  type LearningGoalFields,
-} from "@/services/db-learning-goal-operations.server";
+import { LearningGoalOperationsService } from "@/cli/rpc-services";
+import type { LearningGoalFields } from "@/services/db-learning-goal-operations.server";
 import {
   detail,
   emitGet,

--- a/apps/local/app/cli/commands/lesson.ts
+++ b/apps/local/app/cli/commands/lesson.ts
@@ -1,11 +1,13 @@
 import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
 import { lessonSearchCmd } from "./search";
-import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
+import {
+  CourseWriteService,
+  LessonSectionOperationsService,
+  VersionOperationsService,
+  VideoOperationsService,
+} from "@/cli/rpc-services";
 import { AUTHORING_STATUSES } from "@/services/lesson-authoring-status";
-import { VersionOperationsService } from "@/services/db-version-operations.server";
-import { VideoOperationsService } from "@/services/db-video-operations.server";
-import { CourseWriteService } from "@/services/course-write-service";
 import {
   detail,
   emitGet,

--- a/apps/local/app/cli/commands/overlay.clip-zoom-guard.ts
+++ b/apps/local/app/cli/commands/overlay.clip-zoom-guard.ts
@@ -10,7 +10,7 @@
 
 import { Effect } from "effect";
 import { notFound, parseError } from "@/cli/helpers";
-import { VideoOperationsService } from "@/services/db-video-operations.server";
+import { VideoOperationsService } from "@/cli/rpc-services";
 import type { OverlayKind } from "@/features/videos/overlay-kind";
 import { overlayTransform } from "@/features/videos/overlay-transform";
 import {

--- a/apps/local/app/cli/commands/overlay.ts
+++ b/apps/local/app/cli/commands/overlay.ts
@@ -1,8 +1,10 @@
 import { Command } from "@effect/cli";
 import { Effect, Option } from "effect";
-import { ClipOperationsService } from "@/services/db-clip-operations.server";
-import { OverlayOperationsService } from "@/services/db-overlay-operations.server";
-import { VideoOperationsService } from "@/services/db-video-operations.server";
+import {
+  ClipOperationsService,
+  OverlayOperationsService,
+  VideoOperationsService,
+} from "@/cli/rpc-services";
 import {
   detail,
   emitNdjson,

--- a/apps/local/app/cli/commands/pitch.ts
+++ b/apps/local/app/cli/commands/pitch.ts
@@ -1,9 +1,9 @@
 import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
-import {
-  PitchOperationsService,
-  type PitchState,
-  type PitchFields,
+import { PitchOperationsService } from "@/cli/rpc-services";
+import type {
+  PitchState,
+  PitchFields,
 } from "@/services/db-pitch-operations.server";
 import {
   detail,

--- a/apps/local/app/cli/commands/search.ts
+++ b/apps/local/app/cli/commands/search.ts
@@ -1,9 +1,9 @@
 import { Args, Command, Options } from "@effect/cli";
 import { Effect } from "effect";
-import {
-  SearchOperationsService,
-  type SearchKind,
-  type SearchRoot,
+import { SearchOperationsService } from "@/cli/rpc-services";
+import type {
+  SearchKind,
+  SearchRoot,
 } from "@/services/db-search-operations.server";
 import { detail, emitNdjson, notFound, parseError } from "@/cli/helpers";
 

--- a/apps/local/app/cli/commands/section.ts
+++ b/apps/local/app/cli/commands/section.ts
@@ -1,9 +1,11 @@
 import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
 import { sectionSearchCmd } from "./search";
-import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
-import { VersionOperationsService } from "@/services/db-version-operations.server";
-import { CourseWriteService } from "@/services/course-write-service";
+import {
+  CourseWriteService,
+  LessonSectionOperationsService,
+  VersionOperationsService,
+} from "@/cli/rpc-services";
 import {
   detail,
   emitGet,

--- a/apps/local/app/cli/commands/timeline-position.ts
+++ b/apps/local/app/cli/commands/timeline-position.ts
@@ -1,5 +1,5 @@
 import { Effect, Option } from "effect";
-import { ClipOperationsService } from "@/services/db-clip-operations.server";
+import { ClipOperationsService } from "@/cli/rpc-services";
 import { notFound, rejectBothFlags } from "@/cli/helpers";
 
 /**

--- a/apps/local/app/cli/commands/version.ts
+++ b/apps/local/app/cli/commands/version.ts
@@ -1,6 +1,6 @@
 import { Args, Command, Options } from "@effect/cli";
 import { Effect } from "effect";
-import { VersionOperationsService } from "@/services/db-version-operations.server";
+import { VersionOperationsService } from "@/cli/rpc-services";
 import {
   detail,
   emitGet,

--- a/apps/local/app/cli/commands/video.ts
+++ b/apps/local/app/cli/commands/video.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "node:fs";
 import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option } from "effect";
-import { VideoOperationsService } from "@/services/db-video-operations.server";
-import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
-import { PitchOperationsService } from "@/services/db-pitch-operations.server";
+import {
+  LessonSectionOperationsService,
+  PitchOperationsService,
+  VideoOperationsService,
+} from "@/cli/rpc-services";
 import {
   detail,
   emitGet,

--- a/apps/local/app/cli/helpers.ts
+++ b/apps/local/app/cli/helpers.ts
@@ -1,7 +1,6 @@
 import { HelpDoc } from "@effect/cli";
 import { Effect, Option } from "effect";
-import { VersionOperationsService } from "@/services/db-version-operations.server";
-import type { UnknownDBServiceError } from "@/services/db-service-errors";
+import { VersionOperationsService } from "@/cli/rpc-services";
 import { CliOutput } from "./output";
 import {
   NotFoundError,
@@ -214,11 +213,7 @@ export const emitGet = <A, E, R>(params: {
 export const resolveVersionId = (opts: {
   readonly courseId: string;
   readonly version?: Option.Option<string> | string | undefined;
-}): Effect.Effect<
-  string,
-  NotFoundError | UnknownDBServiceError,
-  VersionOperationsService
-> =>
+}) =>
   Effect.gen(function* () {
     const versionOps = yield* VersionOperationsService;
     const pinned =

--- a/apps/local/app/cli/layer.ts
+++ b/apps/local/app/cli/layer.ts
@@ -13,8 +13,9 @@ import { makeRemoteLayer } from "./rpc-layer";
  * token. That is deliberate: a second in-process path for local use would be
  * the path least exercised, on the machine least watched.
  *
- * The services keep the same TAGS and the same SIGNATURES they had when they
- * ran in-process, so no command handler knows the work happens elsewhere.
+ * Command handlers use CLI-specific RPC tags. Each tag exposes only the
+ * mapped methods, with their domain arguments and results plus wire failures;
+ * database-service tags remain reserved for the local publish graph.
  *
  * WRITES. The CLI is read-mostly, but a handful of write verbs exist (lesson
  * create/update/move, video create/move/update, clip update/move/delete,
@@ -50,7 +51,7 @@ export const cliLayer = Layer.suspend(() => {
  */
 export const cliRuntime = ManagedRuntime.make(cliLayer);
 
-/** The full context the runtime provides (every domain service `cvm` uses). */
+/** The full context of CLI RPC service tags the runtime provides. */
 export type CliServices = ManagedRuntime.ManagedRuntime.Context<
   typeof cliRuntime
 >;

--- a/apps/local/app/cli/rpc-client.ts
+++ b/apps/local/app/cli/rpc-client.ts
@@ -81,10 +81,10 @@ export const makeRpcClient = (config: RpcClientConfig): RpcClient => {
  * A domain service's method, as it behaves once it is a network call away.
  *
  * Same arguments, same success value, same domain failures — plus the three the
- * wire adds. Building each RPC-backed method against this (`satisfies
- * RemoteService<T>` in ./rpc-layer.ts) is what makes a service signature
- * changing in `@cvm/core` a COMPILE ERROR in the CLI's client, rather than an
- * argument silently arriving as `undefined` on a box nobody is watching.
+ * wire adds. `CvmRemoteAdapter` contextualizes each mapped method with this
+ * type in ./rpc-layer.ts, so a service signature changing in `@cvm/core` is a
+ * COMPILE ERROR in the CLI's client rather than an argument silently arriving
+ * as `undefined` on a box nobody is watching.
  */
 type RemoteMethod<F> = F extends (
   ...args: infer A
@@ -97,12 +97,10 @@ type WireError =
   AuthenticationError | SchemaVersionMismatchError | TransportError;
 
 /**
- * The RPC-backed shape of the selected domain methods `cvm` exposes.
+ * The RPC-backed shape a `cvm` adapter selects its domain methods from.
  *
- * Callers pass a `Pick` containing precisely the service methods that have an
- * endpoint. This mapped type deliberately preserves required properties: an
- * adapter can omit unrelated domain methods, but it cannot omit a selected
- * `cvm` call.
+ * `CvmRemoteAdapter` makes this shape partial during contextual type checking,
+ * then its inferred adapter value retains only the methods it actually maps.
  */
 export type RemoteService<S> = {
   readonly [K in keyof S]: RemoteMethod<S[K]>;
@@ -115,14 +113,17 @@ export type RemoteService<S> = {
  * They are forwarded variadically rather than listed, so there is no place for
  * a client to reorder or drop an argument on its way to the wire — the only
  * thing a call site states is which endpoint it is. `F` comes from the
- * contextual type (`satisfies RemoteService<T>` at the call site), so the
- * method's signature is still the service's own.
+ * contextual `CvmRemoteAdapter` type, so the method's signature is still the
+ * service's own. `NonNullable` prevents that adapter's optional mapping key
+ * from making an implemented method possibly undefined in its inferred type.
  */
 export const rpcMethod = <F>(
   send: (
     json: ReadonlyArray<unknown>
   ) => Promise<ClientResponse<unknown, number, "json">>
-): F => ((...args: ReadonlyArray<unknown>) => callRpc(send, ...args)) as F;
+): NonNullable<F> =>
+  ((...args: ReadonlyArray<unknown>) =>
+    callRpc(send, ...args)) as NonNullable<F>;
 
 /**
  * Trailing `undefined` arguments are DROPPED rather than serialised.

--- a/apps/local/app/cli/rpc-client.ts
+++ b/apps/local/app/cli/rpc-client.ts
@@ -97,12 +97,15 @@ type WireError =
   AuthenticationError | SchemaVersionMismatchError | TransportError;
 
 /**
- * The RPC-backed shape of a domain service. PARTIAL on purpose: the API
- * exposes what `cvm` asks for and nothing more, so a service's methods that no
- * command calls have no endpoint and belong in no client.
+ * The RPC-backed shape of the selected domain methods `cvm` exposes.
+ *
+ * Callers pass a `Pick` containing precisely the service methods that have an
+ * endpoint. This mapped type deliberately preserves required properties: an
+ * adapter can omit unrelated domain methods, but it cannot omit a selected
+ * `cvm` call.
  */
 export type RemoteService<S> = {
-  readonly [K in keyof S]?: RemoteMethod<S[K]>;
+  readonly [K in keyof S]: RemoteMethod<S[K]>;
 };
 
 /**

--- a/apps/local/app/cli/rpc-forwarding.test.ts
+++ b/apps/local/app/cli/rpc-forwarding.test.ts
@@ -1,0 +1,72 @@
+import { forward } from "@cvm/remote/rpc";
+import { BeatOperationsService } from "@/services/db-beat-operations.server";
+import { Effect, Layer, ManagedRuntime } from "effect";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { RemoteRuntime } from "@cvm/remote/runtime";
+
+const makeRuntime = (service: unknown): RemoteRuntime =>
+  ManagedRuntime.make(
+    Layer.succeed(BeatOperationsService, service as never)
+  ) as never;
+
+describe("forward", () => {
+  it("passes the selected call its typed argument tuple in order", async () => {
+    const moveBeat = vi.fn(
+      (beatId: string, targetVideoId: string, beforeBeatId: string | null) =>
+        Effect.succeed({ beatId, targetVideoId, beforeBeatId })
+    );
+    const app = new Hono().post(
+      "/moveBeat",
+      forward(makeRuntime({ moveBeat }), BeatOperationsService, "moveBeat")
+    );
+
+    const response = await app.request("http://cvm-api.test/moveBeat", {
+      method: "POST",
+      body: JSON.stringify(["beat_1", "video_2", null]),
+      headers: { "content-type": "application/json" },
+    });
+
+    expect(moveBeat).toHaveBeenCalledExactlyOnceWith("beat_1", "video_2", null);
+    expect(await response.json()).toEqual({
+      ok: true,
+      value: { beatId: "beat_1", targetVideoId: "video_2", beforeBeatId: null },
+    });
+  });
+
+  it("returns the existing transport failure for a non-array body", async () => {
+    const app = new Hono().post(
+      "/moveBeat",
+      forward(
+        makeRuntime({
+          moveBeat: (
+            beatId: string,
+            targetVideoId: string,
+            beforeBeatId: string | null
+          ) => Effect.succeed({ beatId, targetVideoId, beforeBeatId }),
+        }),
+        BeatOperationsService,
+        "moveBeat"
+      )
+    );
+
+    const response = await app.request("http://cvm-api.test/moveBeat", {
+      method: "POST",
+      body: JSON.stringify({
+        beatId: "beat_1",
+        targetVideoId: "video_2",
+        beforeBeatId: null,
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      ok: false,
+      error: {
+        _tag: "TransportError",
+        message: "moveBeat expects a JSON array of arguments",
+      },
+    });
+  });
+});

--- a/apps/local/app/cli/rpc-layer.ts
+++ b/apps/local/app/cli/rpc-layer.ts
@@ -1,16 +1,16 @@
 import { Context, Layer } from "effect";
-import { BeatOperationsService } from "@/services/db-beat-operations.server";
-import { ClipOperationsService } from "@/services/db-clip-operations.server";
-import { CourseOperationsService } from "@/services/db-course-operations.server";
-import { CourseWriteService } from "@/services/course-write-service";
-import { DeliverableOperationsService } from "@/services/db-deliverable-operations.server";
-import { LearningGoalOperationsService } from "@/services/db-learning-goal-operations.server";
-import { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
-import { OverlayOperationsService } from "@/services/db-overlay-operations.server";
-import { PitchOperationsService } from "@/services/db-pitch-operations.server";
-import { SearchOperationsService } from "@/services/db-search-operations.server";
-import { VersionOperationsService } from "@/services/db-version-operations.server";
-import { VideoOperationsService } from "@/services/db-video-operations.server";
+import type { BeatOperationsService } from "@/services/db-beat-operations.server";
+import type { ClipOperationsService } from "@/services/db-clip-operations.server";
+import type { CourseOperationsService } from "@/services/db-course-operations.server";
+import type { CourseWriteService } from "@/services/course-write-service";
+import type { DeliverableOperationsService } from "@/services/db-deliverable-operations.server";
+import type { LearningGoalOperationsService } from "@/services/db-learning-goal-operations.server";
+import type { LessonSectionOperationsService } from "@/services/db-lesson-section-operations.server";
+import type { OverlayOperationsService } from "@/services/db-overlay-operations.server";
+import type { PitchOperationsService } from "@/services/db-pitch-operations.server";
+import type { SearchOperationsService } from "@/services/db-search-operations.server";
+import type { VersionOperationsService } from "@/services/db-version-operations.server";
+import type { VideoOperationsService } from "@/services/db-video-operations.server";
 import {
   callRpc,
   makeRpcClient,
@@ -24,10 +24,9 @@ import {
  * The CLI's transport layer: the domain services, backed by HTTP instead of a
  * Postgres connection.
  *
- * The services keep their existing TAGS and their existing SIGNATURES, so no
- * command handler knows or cares that the work now happens on another machine —
- * swapping the layer is the whole change, and every `cli-*` test asserts on
- * exactly what it asserted on before.
+ * Each adapter has a CLI-specific TAG whose service type is inferred from its
+ * mapped methods. Commands can ask only for methods with HTTP endpoints, so a
+ * new command cannot compile against an unmapped domain method.
  *
  * THERE IS ONE TRANSPORT. The author's own `cvm` goes through here too. A
  * second in-process path for local use would be the path least exercised, on
@@ -40,41 +39,24 @@ import {
  *   the ENDPOINT   `hc<RemoteApp>` is built from the deployed app's route
  *                  table, so a renamed or missing route is a compile error
  *                  rather than a 404 on a box nobody is watching;
- *   the SIGNATURE  the required `CvmRemoteAdapter` method set checks each
- *                  method against the service's own declaration in
- *                  `@cvm/core`, and rejects an omitted `cvm` call;
+ *   the SIGNATURE  `CvmRemoteAdapter` checks every mapped method against the
+ *                  service's own declaration in `@cvm/core`;
  *   the ARGUMENTS  `rpcMethod` forwards them variadically, so there is nowhere
  *                  for a hand-written call to reorder or drop one.
  *
- * THE ONE CAST, and it is literally one — see `remoteLayer` at the bottom of
- * this file. It narrows the existing domain tag to its checked adapter shape;
- * it never turns the adapter into the full domain service. That is necessary
- * because over HTTP every selected method's failure channel also carries
- * AuthenticationError and TransportError, and Effect's error channel does not
- * widen on assignment. Each adapter's required mapping still rejects an
- * omitted `cvm` call. The CLI renderer dispatches on `_tag` and handles an
- * unknown tag defensively, so the mismatch is contained to that one line
- * rather than rippling through every command signature.
+ * The CLI tags are deliberately distinct from the database service tags.
+ * Their methods include the wire failures an HTTP call can add, while the
+ * database services remain available to the local-only publish graph.
  */
 
 /**
- * The required methods one domain service exposes through `cvm`.
+ * The mapped methods one domain service exposes through `cvm`.
  *
- * A service's other domain methods need no remote route. `_tag` remains part
- * of the value handed to Effect's existing service tag.
+ * `Partial` makes a route optional, while `RemoteService` contextualizes each
+ * mapped key with its domain method signature. The inferred object type keeps
+ * only the keys this adapter actually implements.
  */
-type CvmRemoteAdapter<Service, Methods extends keyof Service> = RemoteService<
-  Pick<Service, Methods | Extract<"_tag", keyof Service>>
->;
-
-type CourseRemoteAdapter = CvmRemoteAdapter<
-  CourseOperationsService,
-  | "getCourses"
-  | "getArchivedCourses"
-  | "getCourseById"
-  | "getCourseWithSlimClipsById"
-  | "getVideoTranscripts"
->;
+type CvmRemoteAdapter<Service> = Partial<RemoteService<Service>>;
 
 const courseService = (client: RpcClient) =>
   ({
@@ -94,15 +76,7 @@ const courseService = (client: RpcClient) =>
     getVideoTranscripts: rpcMethod((json) =>
       client.rpc.course.getVideoTranscripts.$post({ json })
     ),
-  }) satisfies CourseRemoteAdapter;
-
-type VersionRemoteAdapter = CvmRemoteAdapter<
-  VersionOperationsService,
-  | "getCourseVersions"
-  | "getCourseVersionById"
-  | "getLatestCourseVersion"
-  | "getVersionWithSections"
->;
+  }) satisfies CvmRemoteAdapter<CourseOperationsService>;
 
 const versionService = (client: RpcClient) =>
   ({
@@ -119,29 +93,12 @@ const versionService = (client: RpcClient) =>
     getVersionWithSections: rpcMethod((json) =>
       client.rpc.version.getVersionWithSections.$post({ json })
     ),
-  }) satisfies VersionRemoteAdapter;
+  }) satisfies CvmRemoteAdapter<VersionOperationsService>;
 
 /**
  * Sections and Lessons are two nouns to an agent but one service here, so this
  * object spans the `/rpc/section` and `/rpc/lesson` groups.
  */
-type LessonSectionRemoteAdapter = CvmRemoteAdapter<
-  LessonSectionOperationsService,
-  | "getSectionsByRepoVersionId"
-  | "getSectionWithHierarchyById"
-  | "createSections"
-  | "updateSectionTitle"
-  | "archiveSection"
-  | "batchUpdateSectionOrders"
-  | "getLessonsBySectionId"
-  | "getLessonById"
-  | "getLessonWithHierarchyById"
-  | "createLesson"
-  | "updateLesson"
-  | "batchUpdateLessonOrders"
-  | "deleteLesson"
->;
-
 const lessonSectionService = (client: RpcClient) =>
   ({
     _tag: "LessonSectionOperationsService",
@@ -184,17 +141,12 @@ const lessonSectionService = (client: RpcClient) =>
     deleteLesson: rpcMethod((json) =>
       client.rpc.lesson.deleteLesson.$post({ json })
     ),
-  }) satisfies LessonSectionRemoteAdapter;
+  }) satisfies CvmRemoteAdapter<LessonSectionOperationsService>;
 
 /**
  * `cvm lesson move` and `cvm section move` — structural writes, in their
  * respective route groups with the rest of that noun's verbs.
  */
-type CourseWriteRemoteAdapter = CvmRemoteAdapter<
-  CourseWriteService,
-  "reorderLessons" | "moveToSection" | "reorderSections"
->;
-
 const courseWriteService = (client: RpcClient) =>
   ({
     _tag: "CourseWriteService",
@@ -207,25 +159,7 @@ const courseWriteService = (client: RpcClient) =>
     reorderSections: rpcMethod((json) =>
       client.rpc.section.reorderSections.$post({ json })
     ),
-  }) satisfies CourseWriteRemoteAdapter;
-
-type VideoRemoteAdapter = CvmRemoteAdapter<
-  VideoOperationsService,
-  | "getAllStandaloneVideos"
-  | "getArchivedStandaloneVideos"
-  | "getVideoRowById"
-  | "getVideoWithClipsById"
-  | "getVideoDeepById"
-  | "createVideo"
-  | "createStandaloneVideo"
-  | "linkVideoToPitch"
-  | "moveVideoToLesson"
-  | "updateVideoTitle"
-  | "updateVideoBody"
-  | "updateVideoDescription"
-  | "updateVideoScript"
-  | "updateVideoFormat"
->;
+  }) satisfies CvmRemoteAdapter<CourseWriteService>;
 
 const videoService = (client: RpcClient) =>
   ({
@@ -272,27 +206,7 @@ const videoService = (client: RpcClient) =>
     updateVideoFormat: rpcMethod((json) =>
       client.rpc.video.updateVideoFormat.$post({ json })
     ),
-  }) satisfies VideoRemoteAdapter;
-
-type ClipRemoteAdapter = CvmRemoteAdapter<
-  ClipOperationsService,
-  | "getClipsByIds"
-  | "listTimelineOrder"
-  | "createClip"
-  | "updateClip"
-  | "retimeClip"
-  | "setClipZoom"
-  | "moveClipToPosition"
-  | "archiveClip"
-  | "listTranscriptWords"
-  | "replaceTranscriptWords"
-  | "getChaptersByIds"
-  | "listChaptersByVideoId"
-  | "createChapterAtItem"
-  | "updateChapter"
-  | "moveChapterToPosition"
-  | "archiveChapter"
->;
+  }) satisfies CvmRemoteAdapter<VideoOperationsService>;
 
 const clipService = (client: RpcClient) =>
   ({
@@ -342,16 +256,7 @@ const clipService = (client: RpcClient) =>
     archiveChapter: rpcMethod((json) =>
       client.rpc.chapter.archiveChapter.$post({ json })
     ),
-  }) satisfies ClipRemoteAdapter;
-
-type OverlayRemoteAdapter = CvmRemoteAdapter<
-  OverlayOperationsService,
-  | "listOverlaysByVideoId"
-  | "getOverlaysByIds"
-  | "createOverlay"
-  | "updateOverlay"
-  | "deleteOverlay"
->;
+  }) satisfies CvmRemoteAdapter<ClipOperationsService>;
 
 const overlayService = (client: RpcClient) =>
   ({
@@ -371,21 +276,7 @@ const overlayService = (client: RpcClient) =>
     deleteOverlay: rpcMethod((json) =>
       client.rpc.overlay.deleteOverlay.$post({ json })
     ),
-  }) satisfies OverlayRemoteAdapter;
-
-type BeatRemoteAdapter = CvmRemoteAdapter<
-  BeatOperationsService,
-  | "listBeatsByVideoId"
-  | "listBeatsByScope"
-  | "getBeatById"
-  | "createBeat"
-  | "renameBeat"
-  | "setBeatDescription"
-  | "setBeatKind"
-  | "setBeatLearningGoals"
-  | "moveBeat"
-  | "deleteBeat"
->;
+  }) satisfies CvmRemoteAdapter<OverlayOperationsService>;
 
 const beatService = (client: RpcClient) =>
   ({
@@ -412,18 +303,7 @@ const beatService = (client: RpcClient) =>
     ),
     moveBeat: rpcMethod((json) => client.rpc.beat.moveBeat.$post({ json })),
     deleteBeat: rpcMethod((json) => client.rpc.beat.deleteBeat.$post({ json })),
-  }) satisfies BeatRemoteAdapter;
-
-type LearningGoalRemoteAdapter = CvmRemoteAdapter<
-  LearningGoalOperationsService,
-  | "listLearningGoalsBySectionId"
-  | "getLearningGoalById"
-  | "createLearningGoal"
-  | "updateLearningGoal"
-  | "moveLearningGoal"
-  | "unlinkBeat"
-  | "deleteLearningGoal"
->;
+  }) satisfies CvmRemoteAdapter<BeatOperationsService>;
 
 const learningGoalService = (client: RpcClient) =>
   ({
@@ -449,17 +329,7 @@ const learningGoalService = (client: RpcClient) =>
     deleteLearningGoal: rpcMethod((json) =>
       client.rpc["learning-goal"].deleteLearningGoal.$post({ json })
     ),
-  }) satisfies LearningGoalRemoteAdapter;
-
-type PitchRemoteAdapter = CvmRemoteAdapter<
-  PitchOperationsService,
-  | "listPitches"
-  | "getPitch"
-  | "getPitchWithVideos"
-  | "createPitch"
-  | "updatePitch"
-  | "createVideoFromPitch"
->;
+  }) satisfies CvmRemoteAdapter<LearningGoalOperationsService>;
 
 const pitchService = (client: RpcClient) =>
   ({
@@ -480,16 +350,7 @@ const pitchService = (client: RpcClient) =>
     createVideoFromPitch: rpcMethod((json) =>
       client.rpc.pitch.createVideoFromPitch.$post({ json })
     ),
-  }) satisfies PitchRemoteAdapter;
-
-type DeliverableRemoteAdapter = CvmRemoteAdapter<
-  DeliverableOperationsService,
-  | "listDeliverables"
-  | "getDeliverableById"
-  | "createDeliverable"
-  | "updateDeliverable"
-  | "archiveDeliverable"
->;
+  }) satisfies CvmRemoteAdapter<PitchOperationsService>;
 
 const deliverableService = (client: RpcClient) =>
   ({
@@ -509,9 +370,7 @@ const deliverableService = (client: RpcClient) =>
     archiveDeliverable: rpcMethod((json) =>
       client.rpc.deliverable.archiveDeliverable.$post({ json })
     ),
-  }) satisfies DeliverableRemoteAdapter;
-
-type SearchRemoteAdapter = CvmRemoteAdapter<SearchOperationsService, "search">;
+  }) satisfies CvmRemoteAdapter<DeliverableOperationsService>;
 
 const searchService = (client: RpcClient) =>
   ({
@@ -525,45 +384,80 @@ const searchService = (client: RpcClient) =>
         query: params.query,
         types: [...params.types],
       }),
-  }) satisfies SearchRemoteAdapter;
+  }) satisfies CvmRemoteAdapter<SearchOperationsService>;
 
-/** Every domain service the `cvm` CLI reaches over HTTP. */
+/** The CLI's RPC-only service tags, each exposing its mapped adapter shape. */
+export const CvmSearchOperationsService = Context.GenericTag<
+  "CvmSearchOperationsService",
+  ReturnType<typeof searchService>
+>("CvmSearchOperationsService");
+export const CvmCourseOperationsService = Context.GenericTag<
+  "CvmCourseOperationsService",
+  ReturnType<typeof courseService>
+>("CvmCourseOperationsService");
+export const CvmVersionOperationsService = Context.GenericTag<
+  "CvmVersionOperationsService",
+  ReturnType<typeof versionService>
+>("CvmVersionOperationsService");
+export const CvmLessonSectionOperationsService = Context.GenericTag<
+  "CvmLessonSectionOperationsService",
+  ReturnType<typeof lessonSectionService>
+>("CvmLessonSectionOperationsService");
+export const CvmLearningGoalOperationsService = Context.GenericTag<
+  "CvmLearningGoalOperationsService",
+  ReturnType<typeof learningGoalService>
+>("CvmLearningGoalOperationsService");
+export const CvmVideoOperationsService = Context.GenericTag<
+  "CvmVideoOperationsService",
+  ReturnType<typeof videoService>
+>("CvmVideoOperationsService");
+export const CvmClipOperationsService = Context.GenericTag<
+  "CvmClipOperationsService",
+  ReturnType<typeof clipService>
+>("CvmClipOperationsService");
+export const CvmOverlayOperationsService = Context.GenericTag<
+  "CvmOverlayOperationsService",
+  ReturnType<typeof overlayService>
+>("CvmOverlayOperationsService");
+export const CvmBeatOperationsService = Context.GenericTag<
+  "CvmBeatOperationsService",
+  ReturnType<typeof beatService>
+>("CvmBeatOperationsService");
+export const CvmPitchOperationsService = Context.GenericTag<
+  "CvmPitchOperationsService",
+  ReturnType<typeof pitchService>
+>("CvmPitchOperationsService");
+export const CvmDeliverableOperationsService = Context.GenericTag<
+  "CvmDeliverableOperationsService",
+  ReturnType<typeof deliverableService>
+>("CvmDeliverableOperationsService");
+export const CvmCourseWriteService = Context.GenericTag<
+  "CvmCourseWriteService",
+  ReturnType<typeof courseWriteService>
+>("CvmCourseWriteService");
+
+/** Every CLI RPC service environment the transport layer provides. */
 export type RemoteServices =
-  | SearchOperationsService
-  | CourseOperationsService
-  | VersionOperationsService
-  | LessonSectionOperationsService
-  | LearningGoalOperationsService
-  | VideoOperationsService
-  | ClipOperationsService
-  | OverlayOperationsService
-  | BeatOperationsService
-  | PitchOperationsService
-  | DeliverableOperationsService
-  | CourseWriteService;
+  | Context.Tag.Identifier<typeof CvmSearchOperationsService>
+  | Context.Tag.Identifier<typeof CvmCourseOperationsService>
+  | Context.Tag.Identifier<typeof CvmVersionOperationsService>
+  | Context.Tag.Identifier<typeof CvmLessonSectionOperationsService>
+  | Context.Tag.Identifier<typeof CvmLearningGoalOperationsService>
+  | Context.Tag.Identifier<typeof CvmVideoOperationsService>
+  | Context.Tag.Identifier<typeof CvmClipOperationsService>
+  | Context.Tag.Identifier<typeof CvmOverlayOperationsService>
+  | Context.Tag.Identifier<typeof CvmBeatOperationsService>
+  | Context.Tag.Identifier<typeof CvmPitchOperationsService>
+  | Context.Tag.Identifier<typeof CvmDeliverableOperationsService>
+  | Context.Tag.Identifier<typeof CvmCourseWriteService>;
 
 /**
- * One RPC-backed service, as the layer that hands it out under the tag the
- * command handlers already ask for.
- *
- * The adapter is required to cover a selected set of the tagged service's
- * methods. Its service tag is narrowed locally rather than casting the adapter
- * to the complete domain service: a mapping can therefore never manufacture an
- * unimplemented domain method merely to satisfy `Layer.succeed`.
+ * One RPC-backed service under its dedicated CLI tag.
  */
-const remoteAdapterTag = <I, S, Methods extends keyof S>(
-  tag: Context.Tag<I, S>
-): Context.Tag<I, CvmRemoteAdapter<S, Methods>> =>
-  // Tags are invariant in their service value. This relates the existing tag
-  // to the adapter only; unlike the former cast, it cannot add adapter methods.
-  tag as unknown as Context.Tag<I, CvmRemoteAdapter<S, Methods>>;
-
-const remoteLayer = <I, S, Methods extends keyof S>(
-  tag: Context.Tag<I, S>,
-  build: (client: RpcClient) => CvmRemoteAdapter<S, Methods>,
-  client: RpcClient
-): Layer.Layer<I> =>
-  Layer.succeed(remoteAdapterTag<I, S, Methods>(tag), build(client));
+const remoteLayer = <I, Service>(
+  tag: Context.Tag<I, Service>,
+  service: Service
+): Layer.Layer<I> => Layer.succeed(tag, service);
 
 export const makeRemoteLayer = (
   config: RpcClientConfig
@@ -571,17 +465,20 @@ export const makeRemoteLayer = (
   const client = makeRpcClient(config);
 
   return Layer.mergeAll(
-    remoteLayer(SearchOperationsService, searchService, client),
-    remoteLayer(CourseOperationsService, courseService, client),
-    remoteLayer(VersionOperationsService, versionService, client),
-    remoteLayer(LessonSectionOperationsService, lessonSectionService, client),
-    remoteLayer(LearningGoalOperationsService, learningGoalService, client),
-    remoteLayer(VideoOperationsService, videoService, client),
-    remoteLayer(ClipOperationsService, clipService, client),
-    remoteLayer(OverlayOperationsService, overlayService, client),
-    remoteLayer(BeatOperationsService, beatService, client),
-    remoteLayer(PitchOperationsService, pitchService, client),
-    remoteLayer(DeliverableOperationsService, deliverableService, client),
-    remoteLayer(CourseWriteService, courseWriteService, client)
+    remoteLayer(CvmSearchOperationsService, searchService(client)),
+    remoteLayer(CvmCourseOperationsService, courseService(client)),
+    remoteLayer(CvmVersionOperationsService, versionService(client)),
+    remoteLayer(
+      CvmLessonSectionOperationsService,
+      lessonSectionService(client)
+    ),
+    remoteLayer(CvmLearningGoalOperationsService, learningGoalService(client)),
+    remoteLayer(CvmVideoOperationsService, videoService(client)),
+    remoteLayer(CvmClipOperationsService, clipService(client)),
+    remoteLayer(CvmOverlayOperationsService, overlayService(client)),
+    remoteLayer(CvmBeatOperationsService, beatService(client)),
+    remoteLayer(CvmPitchOperationsService, pitchService(client)),
+    remoteLayer(CvmDeliverableOperationsService, deliverableService(client)),
+    remoteLayer(CvmCourseWriteService, courseWriteService(client))
   );
 };

--- a/apps/local/app/cli/rpc-layer.ts
+++ b/apps/local/app/cli/rpc-layer.ts
@@ -40,21 +40,41 @@ import {
  *   the ENDPOINT   `hc<RemoteApp>` is built from the deployed app's route
  *                  table, so a renamed or missing route is a compile error
  *                  rather than a 404 on a box nobody is watching;
- *   the SIGNATURE  `satisfies RemoteService<T>` checks each method against the
- *                  service's own declaration in `@cvm/core`;
+ *   the SIGNATURE  the required `CvmRemoteAdapter` method set checks each
+ *                  method against the service's own declaration in
+ *                  `@cvm/core`, and rejects an omitted `cvm` call;
  *   the ARGUMENTS  `rpcMethod` forwards them variadically, so there is nowhere
  *                  for a hand-written call to reorder or drop one.
  *
  * THE ONE CAST, and it is literally one — see `remoteLayer` at the bottom of
- * this file. An RPC-backed service reaches `Layer.succeed` through a cast,
- * because over HTTP every method's failure channel also carries
- * AuthenticationError and TransportError, and Effect's error channel does not
- * widen on assignment. The CLI renderer dispatches on `_tag` and handles an
- * unknown tag defensively, so the mismatch is contained to that one line
- * rather than rippling through every command signature. That is the price of
- * the services keeping their tags across the move to HTTP, and it is worth
- * paying: no command handler changed.
+ * this file. The complete, required adapter mapping reaches `Layer.succeed`
+ * through a cast only because over HTTP every selected method's failure
+ * channel also carries AuthenticationError and TransportError, and Effect's
+ * error channel does not widen on assignment. It cannot hide a missing `cvm`
+ * call: each adapter's checked mapping requires every exposed method. The CLI
+ * renderer dispatches on `_tag` and handles an unknown tag defensively, so the
+ * mismatch is contained to that one line rather than rippling through every
+ * command signature.
  */
+
+/**
+ * The required methods one domain service exposes through `cvm`.
+ *
+ * A service's other domain methods need no remote route. `_tag` remains part
+ * of the value handed to Effect's existing service tag.
+ */
+type CvmRemoteAdapter<Service, Methods extends keyof Service> = RemoteService<
+  Pick<Service, Methods | Extract<"_tag", keyof Service>>
+>;
+
+type CourseRemoteAdapter = CvmRemoteAdapter<
+  CourseOperationsService,
+  | "getCourses"
+  | "getArchivedCourses"
+  | "getCourseById"
+  | "getCourseWithSlimClipsById"
+  | "getVideoTranscripts"
+>;
 
 const courseService = (client: RpcClient) =>
   ({
@@ -74,7 +94,15 @@ const courseService = (client: RpcClient) =>
     getVideoTranscripts: rpcMethod((json) =>
       client.rpc.course.getVideoTranscripts.$post({ json })
     ),
-  }) satisfies RemoteService<CourseOperationsService>;
+  }) satisfies CourseRemoteAdapter;
+
+type VersionRemoteAdapter = CvmRemoteAdapter<
+  VersionOperationsService,
+  | "getCourseVersions"
+  | "getCourseVersionById"
+  | "getLatestCourseVersion"
+  | "getVersionWithSections"
+>;
 
 const versionService = (client: RpcClient) =>
   ({
@@ -91,12 +119,29 @@ const versionService = (client: RpcClient) =>
     getVersionWithSections: rpcMethod((json) =>
       client.rpc.version.getVersionWithSections.$post({ json })
     ),
-  }) satisfies RemoteService<VersionOperationsService>;
+  }) satisfies VersionRemoteAdapter;
 
 /**
  * Sections and Lessons are two nouns to an agent but one service here, so this
  * object spans the `/rpc/section` and `/rpc/lesson` groups.
  */
+type LessonSectionRemoteAdapter = CvmRemoteAdapter<
+  LessonSectionOperationsService,
+  | "getSectionsByRepoVersionId"
+  | "getSectionWithHierarchyById"
+  | "createSections"
+  | "updateSectionTitle"
+  | "archiveSection"
+  | "batchUpdateSectionOrders"
+  | "getLessonsBySectionId"
+  | "getLessonById"
+  | "getLessonWithHierarchyById"
+  | "createLesson"
+  | "updateLesson"
+  | "batchUpdateLessonOrders"
+  | "deleteLesson"
+>;
+
 const lessonSectionService = (client: RpcClient) =>
   ({
     _tag: "LessonSectionOperationsService",
@@ -139,12 +184,17 @@ const lessonSectionService = (client: RpcClient) =>
     deleteLesson: rpcMethod((json) =>
       client.rpc.lesson.deleteLesson.$post({ json })
     ),
-  }) satisfies RemoteService<LessonSectionOperationsService>;
+  }) satisfies LessonSectionRemoteAdapter;
 
 /**
  * `cvm lesson move` and `cvm section move` — structural writes, in their
  * respective route groups with the rest of that noun's verbs.
  */
+type CourseWriteRemoteAdapter = CvmRemoteAdapter<
+  CourseWriteService,
+  "reorderLessons" | "moveToSection" | "reorderSections"
+>;
+
 const courseWriteService = (client: RpcClient) =>
   ({
     _tag: "CourseWriteService",
@@ -157,7 +207,25 @@ const courseWriteService = (client: RpcClient) =>
     reorderSections: rpcMethod((json) =>
       client.rpc.section.reorderSections.$post({ json })
     ),
-  }) satisfies RemoteService<CourseWriteService>;
+  }) satisfies CourseWriteRemoteAdapter;
+
+type VideoRemoteAdapter = CvmRemoteAdapter<
+  VideoOperationsService,
+  | "getAllStandaloneVideos"
+  | "getArchivedStandaloneVideos"
+  | "getVideoRowById"
+  | "getVideoWithClipsById"
+  | "getVideoDeepById"
+  | "createVideo"
+  | "createStandaloneVideo"
+  | "linkVideoToPitch"
+  | "moveVideoToLesson"
+  | "updateVideoTitle"
+  | "updateVideoBody"
+  | "updateVideoDescription"
+  | "updateVideoScript"
+  | "updateVideoFormat"
+>;
 
 const videoService = (client: RpcClient) =>
   ({
@@ -204,7 +272,27 @@ const videoService = (client: RpcClient) =>
     updateVideoFormat: rpcMethod((json) =>
       client.rpc.video.updateVideoFormat.$post({ json })
     ),
-  }) satisfies RemoteService<VideoOperationsService>;
+  }) satisfies VideoRemoteAdapter;
+
+type ClipRemoteAdapter = CvmRemoteAdapter<
+  ClipOperationsService,
+  | "getClipsByIds"
+  | "listTimelineOrder"
+  | "createClip"
+  | "updateClip"
+  | "retimeClip"
+  | "setClipZoom"
+  | "moveClipToPosition"
+  | "archiveClip"
+  | "listTranscriptWords"
+  | "replaceTranscriptWords"
+  | "getChaptersByIds"
+  | "listChaptersByVideoId"
+  | "createChapterAtItem"
+  | "updateChapter"
+  | "moveChapterToPosition"
+  | "archiveChapter"
+>;
 
 const clipService = (client: RpcClient) =>
   ({
@@ -254,7 +342,16 @@ const clipService = (client: RpcClient) =>
     archiveChapter: rpcMethod((json) =>
       client.rpc.chapter.archiveChapter.$post({ json })
     ),
-  }) satisfies RemoteService<ClipOperationsService>;
+  }) satisfies ClipRemoteAdapter;
+
+type OverlayRemoteAdapter = CvmRemoteAdapter<
+  OverlayOperationsService,
+  | "listOverlaysByVideoId"
+  | "getOverlaysByIds"
+  | "createOverlay"
+  | "updateOverlay"
+  | "deleteOverlay"
+>;
 
 const overlayService = (client: RpcClient) =>
   ({
@@ -274,7 +371,21 @@ const overlayService = (client: RpcClient) =>
     deleteOverlay: rpcMethod((json) =>
       client.rpc.overlay.deleteOverlay.$post({ json })
     ),
-  }) satisfies RemoteService<OverlayOperationsService>;
+  }) satisfies OverlayRemoteAdapter;
+
+type BeatRemoteAdapter = CvmRemoteAdapter<
+  BeatOperationsService,
+  | "listBeatsByVideoId"
+  | "listBeatsByScope"
+  | "getBeatById"
+  | "createBeat"
+  | "renameBeat"
+  | "setBeatDescription"
+  | "setBeatKind"
+  | "setBeatLearningGoals"
+  | "moveBeat"
+  | "deleteBeat"
+>;
 
 const beatService = (client: RpcClient) =>
   ({
@@ -301,7 +412,18 @@ const beatService = (client: RpcClient) =>
     ),
     moveBeat: rpcMethod((json) => client.rpc.beat.moveBeat.$post({ json })),
     deleteBeat: rpcMethod((json) => client.rpc.beat.deleteBeat.$post({ json })),
-  }) satisfies RemoteService<BeatOperationsService>;
+  }) satisfies BeatRemoteAdapter;
+
+type LearningGoalRemoteAdapter = CvmRemoteAdapter<
+  LearningGoalOperationsService,
+  | "listLearningGoalsBySectionId"
+  | "getLearningGoalById"
+  | "createLearningGoal"
+  | "updateLearningGoal"
+  | "moveLearningGoal"
+  | "unlinkBeat"
+  | "deleteLearningGoal"
+>;
 
 const learningGoalService = (client: RpcClient) =>
   ({
@@ -327,7 +449,17 @@ const learningGoalService = (client: RpcClient) =>
     deleteLearningGoal: rpcMethod((json) =>
       client.rpc["learning-goal"].deleteLearningGoal.$post({ json })
     ),
-  }) satisfies RemoteService<LearningGoalOperationsService>;
+  }) satisfies LearningGoalRemoteAdapter;
+
+type PitchRemoteAdapter = CvmRemoteAdapter<
+  PitchOperationsService,
+  | "listPitches"
+  | "getPitch"
+  | "getPitchWithVideos"
+  | "createPitch"
+  | "updatePitch"
+  | "createVideoFromPitch"
+>;
 
 const pitchService = (client: RpcClient) =>
   ({
@@ -348,7 +480,16 @@ const pitchService = (client: RpcClient) =>
     createVideoFromPitch: rpcMethod((json) =>
       client.rpc.pitch.createVideoFromPitch.$post({ json })
     ),
-  }) satisfies RemoteService<PitchOperationsService>;
+  }) satisfies PitchRemoteAdapter;
+
+type DeliverableRemoteAdapter = CvmRemoteAdapter<
+  DeliverableOperationsService,
+  | "listDeliverables"
+  | "getDeliverableById"
+  | "createDeliverable"
+  | "updateDeliverable"
+  | "archiveDeliverable"
+>;
 
 const deliverableService = (client: RpcClient) =>
   ({
@@ -368,7 +509,9 @@ const deliverableService = (client: RpcClient) =>
     archiveDeliverable: rpcMethod((json) =>
       client.rpc.deliverable.archiveDeliverable.$post({ json })
     ),
-  }) satisfies RemoteService<DeliverableOperationsService>;
+  }) satisfies DeliverableRemoteAdapter;
+
+type SearchRemoteAdapter = CvmRemoteAdapter<SearchOperationsService, "search">;
 
 const searchService = (client: RpcClient) =>
   ({
@@ -382,7 +525,7 @@ const searchService = (client: RpcClient) =>
         query: params.query,
         types: [...params.types],
       }),
-  }) satisfies RemoteService<SearchOperationsService>;
+  }) satisfies SearchRemoteAdapter;
 
 /** Every domain service the `cvm` CLI reaches over HTTP. */
 export type RemoteServices =
@@ -405,15 +548,15 @@ export type RemoteServices =
  *
  * This is where the cast the doc block above describes lives, and it is the
  * only one in the file: `satisfies RemoteService<T>` on each service object has
- * already checked every method against the service's own declaration, so all
- * that is left here is widening a failure channel Effect will not widen by
- * itself. Written once, it cannot drift between the ten call sites — and a
+ * already checked every exposed method against the service's own declaration,
+ * so all that is left here is widening a failure channel Effect will not widen
+ * by itself. Written once, it cannot drift between the ten call sites — and a
  * service object handed to the wrong tag is still a compile error, because
  * `build` is typed by the tag it is given.
  */
-const remoteLayer = <I, S>(
+const remoteLayer = <I, S, Adapter extends Partial<S>>(
   tag: Context.Tag<I, S>,
-  build: (client: RpcClient) => RemoteService<S>,
+  build: (client: RpcClient) => RemoteService<Adapter>,
   client: RpcClient
 ): Layer.Layer<I> => Layer.succeed(tag, build(client) as S);
 

--- a/apps/local/app/cli/rpc-layer.ts
+++ b/apps/local/app/cli/rpc-layer.ts
@@ -47,14 +47,14 @@ import {
  *                  for a hand-written call to reorder or drop one.
  *
  * THE ONE CAST, and it is literally one — see `remoteLayer` at the bottom of
- * this file. The complete, required adapter mapping reaches `Layer.succeed`
- * through a cast only because over HTTP every selected method's failure
- * channel also carries AuthenticationError and TransportError, and Effect's
- * error channel does not widen on assignment. It cannot hide a missing `cvm`
- * call: each adapter's checked mapping requires every exposed method. The CLI
- * renderer dispatches on `_tag` and handles an unknown tag defensively, so the
- * mismatch is contained to that one line rather than rippling through every
- * command signature.
+ * this file. It narrows the existing domain tag to its checked adapter shape;
+ * it never turns the adapter into the full domain service. That is necessary
+ * because over HTTP every selected method's failure channel also carries
+ * AuthenticationError and TransportError, and Effect's error channel does not
+ * widen on assignment. Each adapter's required mapping still rejects an
+ * omitted `cvm` call. The CLI renderer dispatches on `_tag` and handles an
+ * unknown tag defensively, so the mismatch is contained to that one line
+ * rather than rippling through every command signature.
  */
 
 /**
@@ -546,19 +546,24 @@ export type RemoteServices =
  * One RPC-backed service, as the layer that hands it out under the tag the
  * command handlers already ask for.
  *
- * This is where the cast the doc block above describes lives, and it is the
- * only one in the file: `satisfies RemoteService<T>` on each service object has
- * already checked every exposed method against the service's own declaration,
- * so all that is left here is widening a failure channel Effect will not widen
- * by itself. Written once, it cannot drift between the ten call sites — and a
- * service object handed to the wrong tag is still a compile error, because
- * `build` is typed by the tag it is given.
+ * The adapter is required to cover a selected set of the tagged service's
+ * methods. Its service tag is narrowed locally rather than casting the adapter
+ * to the complete domain service: a mapping can therefore never manufacture an
+ * unimplemented domain method merely to satisfy `Layer.succeed`.
  */
-const remoteLayer = <I, S, Adapter extends Partial<S>>(
+const remoteAdapterTag = <I, S, Methods extends keyof S>(
+  tag: Context.Tag<I, S>
+): Context.Tag<I, CvmRemoteAdapter<S, Methods>> =>
+  // Tags are invariant in their service value. This relates the existing tag
+  // to the adapter only; unlike the former cast, it cannot add adapter methods.
+  tag as unknown as Context.Tag<I, CvmRemoteAdapter<S, Methods>>;
+
+const remoteLayer = <I, S, Methods extends keyof S>(
   tag: Context.Tag<I, S>,
-  build: (client: RpcClient) => RemoteService<Adapter>,
+  build: (client: RpcClient) => CvmRemoteAdapter<S, Methods>,
   client: RpcClient
-): Layer.Layer<I> => Layer.succeed(tag, build(client) as S);
+): Layer.Layer<I> =>
+  Layer.succeed(remoteAdapterTag<I, S, Methods>(tag), build(client));
 
 export const makeRemoteLayer = (
   config: RpcClientConfig

--- a/apps/local/app/cli/rpc-services.ts
+++ b/apps/local/app/cli/rpc-services.ts
@@ -1,0 +1,21 @@
+/**
+ * The service tags command handlers may request.
+ *
+ * These tags expose only the RPC mappings in ./rpc-layer.ts. Importing a
+ * database service tag here would let a command compile against a method with
+ * no HTTP endpoint.
+ */
+export {
+  CvmBeatOperationsService as BeatOperationsService,
+  CvmClipOperationsService as ClipOperationsService,
+  CvmCourseOperationsService as CourseOperationsService,
+  CvmCourseWriteService as CourseWriteService,
+  CvmDeliverableOperationsService as DeliverableOperationsService,
+  CvmLearningGoalOperationsService as LearningGoalOperationsService,
+  CvmLessonSectionOperationsService as LessonSectionOperationsService,
+  CvmOverlayOperationsService as OverlayOperationsService,
+  CvmPitchOperationsService as PitchOperationsService,
+  CvmSearchOperationsService as SearchOperationsService,
+  CvmVersionOperationsService as VersionOperationsService,
+  CvmVideoOperationsService as VideoOperationsService,
+} from "./rpc-layer";

--- a/apps/local/app/services/course-publish-readiness.ts
+++ b/apps/local/app/services/course-publish-readiness.ts
@@ -59,22 +59,36 @@ export type UnexportedVideo = {
   readonly title: string;
 };
 
+type VersionWithSections = Effect.Effect.Success<
+  ReturnType<VersionOperationsService["getVersionWithSections"]>
+>;
+
+type GetVersionWithSections<E, R> = (
+  versionId: string
+) => Effect.Effect<VersionWithSections, E, R>;
+
 /**
  * Validation gates on the effective output — the set of Lessons a publish
  * actually ships. Because the to-do toggle can flip on the publish page with no
  * round-trip, both positions are computed in a single pass: the expensive
  * per-Video existence checks run once, then the pure counters run against the
  * effective Sections for each toggle state.
+ *
+ * The caller supplies the one read this calculation needs. The local publish
+ * graph passes its database service; `cvm course readiness` passes its
+ * RPC-backed service without widening the CLI's dependency to the full tag.
  */
-export const validatePublishability = Effect.fn("validatePublishability")(
-  function* (versionId: string) {
-    const versionOps = yield* VersionOperationsService;
+export const validatePublishabilityWith = <E, R>(
+  versionId: string,
+  getVersionWithSections: GetVersionWithSections<E, R>
+) =>
+  Effect.gen(function* () {
     const effectFs = yield* FileSystem.FileSystem;
     const finishedVideosDirectory = yield* Config.string(
       "FINISHED_VIDEOS_DIRECTORY"
     );
 
-    const version = yield* versionOps.getVersionWithSections(versionId);
+    const version = yield* getVersionWithSections(versionId);
     const courseId = version.repo.id;
 
     // Title lookup for the unexported set, built on the same walk as the
@@ -187,6 +201,16 @@ export const validatePublishability = Effect.fn("validatePublishability")(
       withTodo: evaluate(true),
       withoutTodo: evaluate(false),
     };
+  });
+
+/** Database-backed entry point used by the local publish service. */
+export const validatePublishability = Effect.fn("validatePublishability")(
+  function* (versionId: string) {
+    const versionOps = yield* VersionOperationsService;
+    return yield* validatePublishabilityWith(
+      versionId,
+      versionOps.getVersionWithSections
+    );
   }
 );
 

--- a/apps/remote/rpc.ts
+++ b/apps/remote/rpc.ts
@@ -38,6 +38,11 @@ type MethodsOf<S> = {
   [K in keyof S]: S[K] extends ServiceMethod ? K : never;
 }[keyof S];
 
+/** The selected domain call, retaining its own parameter tuple. */
+type MethodOf<S, K extends MethodsOf<S>> = Extract<S[K], ServiceMethod>;
+
+type MethodArguments<S, K extends MethodsOf<S>> = Parameters<MethodOf<S, K>>;
+
 /**
  * One endpoint: name a service and one of its methods, and the request body's
  * ARGUMENT ARRAY is spread into it.
@@ -79,13 +84,11 @@ export const forward =
 
     const body: RpcResponse<unknown> = await runRpc(
       runtime,
-      Effect.flatMap(tag, (service) =>
-        (
-          service[method] as (
-            ...a: ReadonlyArray<unknown>
-          ) => Effect.Effect<unknown, unknown, never>
-        )(...args)
-      )
+      Effect.flatMap(tag, (service) => {
+        const domainCall = service[method] as MethodOf<S, K>;
+        const domainArgs = args as MethodArguments<S, K>;
+        return domainCall(...domainArgs);
+      })
     );
     return c.json(body);
   };


### PR DESCRIPTION
Closes #1619
Closes #1620
Closes #1621

## Summary

- Make every cvm remote adapter call required and type-safe.
- Preserve selected domain call argument tuples through RPC forwarding.
- Cover forwarding and representative archive/delete transport behavior.